### PR TITLE
Move target specific logic into own class

### DIFF
--- a/fault/target.py
+++ b/fault/target.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class Target(ABC):
+    def __init__(self, circuit, test_vectors):
+        self._circuit = circuit
+        self._test_vectors = test_vectors
+
+    @abstractmethod
+    def run(self):
+        pass

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -1,7 +1,7 @@
 from bit_vector import BitVector
 import magma as m
 import functools
-import magma.testing.verilator
+from .verilator_target import VerilatorTarget
 
 
 def convert_value(fn):
@@ -58,13 +58,10 @@ class Tester:
         self.eval()
         self.test_vectors[-1][self.clock_index] ^= BitVector(1, 1)
 
-    def compile_and_run(self, directory="build", target="verilator", flags=[]):
+    def compile_and_run(self, target="verilator", **kwargs):
         if target == "verilator":
-            magma.testing.verilator.compile(
-                f"{directory}/test_{self.circuit.name}.cpp", self.circuit,
-                self.test_vectors)
-            magma.testing.verilator.run_verilator_test(
-                self.circuit.name, f"test_{self.circuit.name}",
-                self.circuit.name, flags, build_dir=directory)
+            target = VerilogTarget(self.circuit, self.test_vectors, **kwargs)
         else:
             raise NotImplementedError(target)
+
+        target.run()

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -1,0 +1,17 @@
+from .target import Target
+import magma.testing.verilator
+
+
+class VerilatorTarget(Target):
+    def __init__(self, circuit, test_vectors, directory="build/", flags=[]):
+        super().__init__(circuit, test_vectors)
+        self._directory = directory
+        self._flags = flags
+
+    def run(self):
+        magma.testing.verilator.compile(
+            f"{self._directory}/test_{self._circuit.name}.cpp", self._circuit,
+            self._test_vectors)
+        magma.testing.verilator.run_verilator_test(
+            self._circuit.name, f"test_{self._circuit.name}",
+            self._circuit.name, self._flags, build_dir=self._directory)

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -1,9 +1,13 @@
+import tempfile
 import magma as m
 import fault
 from bit_vector import BitVector
 
 
 def test_verilator_target():
+    """
+    Test basic verilator workflow with a simple circuit.
+    """
 
     class Foo(m.Circuit):
         IO = ["I", m.In(m.Bit), "O", m.Out(m.Bit)]
@@ -12,11 +16,12 @@ def test_verilator_target():
         def definition(io):
             m.wire(io.I, io.O)
 
-    # Compile to verilog.
-    # TODO(rsetaluri): Make this part of the target itself.
-    m.compile("build/Foo", Foo, output="verilog")
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Compile to verilog.
+        # TODO(rsetaluri): Make this part of the target itself.
+        m.compile(f"{tempdir}/Foo", Foo, output="verilog")
 
-    test_vectors = [[BitVector(0, 1), BitVector(0, 1)]]
-    target = fault.verilator_target.VerilatorTarget(
-        Foo, test_vectors, directory="build/")
-    target.run()
+        test_vectors = [[BitVector(0, 1), BitVector(0, 1)]]
+        target = fault.verilator_target.VerilatorTarget(
+            Foo, test_vectors, directory=f"{tempdir}/")
+        target.run()

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -1,0 +1,22 @@
+import magma as m
+import fault
+from bit_vector import BitVector
+
+
+def test_verilator_target():
+
+    class Foo(m.Circuit):
+        IO = ["I", m.In(m.Bit), "O", m.Out(m.Bit)]
+
+        @classmethod
+        def definition(io):
+            m.wire(io.I, io.O)
+
+    # Compile to verilog.
+    # TODO(rsetaluri): Make this part of the target itself.
+    m.compile("build/Foo", Foo, output="verilog")
+
+    test_vectors = [[BitVector(0,1), BitVector(0, 1)]]
+    target = fault.verilator_target.VerilatorTarget(
+        Foo, test_vectors, directory="build/")
+    target.run()

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -16,7 +16,7 @@ def test_verilator_target():
     # TODO(rsetaluri): Make this part of the target itself.
     m.compile("build/Foo", Foo, output="verilog")
 
-    test_vectors = [[BitVector(0,1), BitVector(0, 1)]]
+    test_vectors = [[BitVector(0, 1), BitVector(0, 1)]]
     target = fault.verilator_target.VerilatorTarget(
         Foo, test_vectors, directory="build/")
     target.run()


### PR DESCRIPTION
For issue #3

Added the following:
  -- target.Target is the base class for all targets. It contains a very
     simple interface (__init__(), run()).
  -- verilator_target.Target is an implementation of target.Target for
     verilator.

The verilator specific logic in tester.compile_and_run() should now go
in a separate file for each target.

Also added relevant tests.