### PR TITLE
Modify pep8 setup file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ pep8ignore =
     tests/_test_cgra.py ALL
     tests/_test_mantle.py ALL
     tests/_test_verilator.py ALL
+pep8maxlinelength = 80


### PR DESCRIPTION
Set pytest pep8 check line length to 80 (instead of 79).