### PR TITLE
Update eval and expect semantics

### DIFF
--- a/fault/python_simulator_target.py
+++ b/fault/python_simulator_target.py
@@ -76,6 +76,6 @@ class PythonSimulatorTarget(Target):
             (inputs, steps, outputs) = self.__parse_tv(tv)
             self.__process_inputs(inputs)
             evaluate = self.__process_clock(steps)
+            self.__process_outputs(outputs)
             if evaluate:
                 self._simulator.evaluate()
-            self.__process_outputs(outputs)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -31,14 +31,17 @@ class Tester:
         # Initialize first test vector to all Nones
         initial_vector = []
         for port in self.ports.values():
-            if isinstance(port, m._BitType):
-                val = BitVector(None, 1)
-            elif isinstance(port, m.ArrayType):
-                val = self.get_array_val(port)
-            else:
-                raise NotImplementedError(port)
+            val = self.get_initial_value(port)
             initial_vector.append(val)
         self.test_vectors.append(initial_vector)
+
+    def get_initial_value(self, port):
+        if isinstance(port, m._BitType):
+            return BitVector(None, 1)
+        elif isinstance(port, m.ArrayType):
+            return self.get_array_val(port)
+        else:
+            raise NotImplementedError(port)
 
     def get_array_val(self, arr):
         if isinstance(arr.T, m._BitKind):
@@ -80,7 +83,17 @@ class Tester:
         self.add_test_vector(port, value)
 
     def eval(self):
+        """
+        Finalize the current test vector by making a copy
+        For the new test vector,
+            (1) Set all inputs to retain their previous value
+            (2) Set all expected outputs to None (X) for the new test vector
+        """
         self.test_vectors.append(copy.deepcopy(self.test_vectors[-1]))
+        for port in self.ports.values():
+            if port.isinput():
+                self.test_vectors[-1][self.get_index(port)] = \
+                    self.get_initial_value(port)
 
     def step(self):
         if self.clock_index is None:

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -139,8 +139,8 @@ int main(int argc, char **argv, char **env) {{
 
     source += f'''\
         std::cout << std::endl;
-        top->eval();
 {output_str}
+        top->eval();
 '''
     source += '''\
     }

--- a/tests/test_python_simulator_target.py
+++ b/tests/test_python_simulator_target.py
@@ -1,8 +1,8 @@
 import random
-import magma as m
 import common
-from fault.python_simulator_target import *
+from fault.python_simulator_target import PythonSimulatorTarget
 from bit_vector import BitVector
+import fault
 
 
 def test_python_simulator_target_basic():
@@ -21,9 +21,11 @@ def test_python_simulator_target_basic():
 def test_python_simulator_target_nested_arrays():
     circ = common.TestNestedArraysCircuit
     tester = fault.Tester(circ)
-    for i in range(3):
-        val = random.randint(0, (1 << 4) - 1)
+    expected = [random.randint(0, (1 << 4) - 1) for i in range(3)]
+    for i, val in enumerate(expected):
         tester.poke(circ.I[i], val)
+    tester.eval()
+    for i, val in enumerate(expected):
         tester.expect(circ.O[i], val)
 
     target = PythonSimulatorTarget(circ, tester.test_vectors, None)

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -25,9 +25,11 @@ def test_verilator_target_basic():
 def test_tester_nested_arrays():
     circ = common.TestNestedArraysCircuit
     tester = fault.Tester(circ)
-    for i in range(3):
-        val = random.randint(0, (1 << 4) - 1)
+    expected = [random.randint(0, (1 << 4) - 1) for i in range(3)]
+    for i, val in enumerate(expected):
         tester.poke(circ.I[i], val)
+    tester.eval()
+    for i, val in enumerate(expected):
         tester.expect(circ.O[i], val)
 
     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
This now matches verilator's semantics, where expect is equivalent to
asserting a peek. So, the user must now call `eval` before `expect` if
the expected value reflects newly poked inputs. Compare this to before,
where `expect` meant " this is the expected value when the next eval is
called".