### PR TITLE
Add support for copying a tester for a circuit with the same interface

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -17,23 +17,28 @@ class PortAction(Action):
         self.value = value
 
     def __str__(self):
-        return f"{type(self).__name__}({self.port.debug_name}, {self.value})"
+        type_name = type(self).__name__
+        return f"{type_name}({self.port.debug_name}, {self.value})"
 
     def retarget(self, new_circuit, clock):
-        return type(self)(getattr(new_circuit, str(self.port.name)), self.value)
+        cls = type(self)
+        new_port = new_circuit.interface.ports[str(self.port.name)]
+        return cls(new_port, self.value)
 
 
 class Poke(PortAction):
     def __init__(self, port, value):
         if port.isinput():
-            raise ValueError(f"Can only poke inputs: {port} {type(port)}")
+            raise ValueError(f"Can only poke inputs: {port.debug_name} "
+                             f"{type(port)}")
         super().__init__(port, value)
 
 
 class Expect(PortAction):
     def __init__(self, port, value):
         if port.isoutput():
-            raise ValueError(f"Can only expect on outputs: {port} {type(port)}")
+            raise ValueError(f"Can only expect on outputs: {port.debug_name} "
+                             f"{type(port)}")
         super().__init__(port, value)
 
 
@@ -42,7 +47,7 @@ class Eval(Action):
         super().__init__()
 
     def __str__(self):
-        return f"Eval()"
+        return "Eval()"
 
     def retarget(self, new_circuit, clock):
         return Eval()
@@ -51,6 +56,7 @@ class Eval(Action):
 class Step(Action):
     def __init__(self, clock, steps):
         super().__init__()
+        # TODO(rsetaluri): Check if `clock` is a clock type?
         self.clock = clock
         self.steps = steps
 

--- a/fault/circuit_utils.py
+++ b/fault/circuit_utils.py
@@ -1,0 +1,18 @@
+def check_interface_is_subset(circuit1, circuit2):
+    """
+    Checks that the interface of circuit1 is a subset of circuit2
+
+    Subset is defined as circuit2 contains all the ports of circuit1. Ports are
+    matched by name comparison, then the types are checked to see if one could
+    be converted to another.
+    """
+    circuit1_port_names = circuit1.interface.ports.keys()
+    for name in circuit1_port_names:
+        if name not in circuit2.interface.ports:
+            raise ValueError(f"{circuit2} (circuit2) does not have port {name}")
+        circuit1_kind = type(type(getattr(circuit1, name)))
+        circuit2_kind = type(type(getattr(circuit2, name)))
+        # Check that the type of one could be converted to the other
+        if not (issubclass(circuit2_kind, circuit1_kind) or
+                issubclass(circuit1_kind, circuit2_kind)):
+            raise ValueError("Types don't match")

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -5,6 +5,8 @@ from fault.logging import warning
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
+from fault.actions import Poke, Expect, Step
+import copy
 
 
 class Tester:
@@ -20,11 +22,13 @@ class Tester:
             return VerilatorTarget(self.circuit, self.actions, **kwargs)
         if target == "coreir":
             return MagmaSimulatorTarget(self.circuit, self.actions,
-                                        backend='coreir', **kwargs)
+                                        clock=self.clock, backend='coreir',
+                                        **kwargs)
         if target == "python":
             warning("Python simulator is not actively supported")
             return MagmaSimulatorTarget(self.circuit, self.actions,
-                                        backend='python', **kwargs)
+                                        clock=self.clock, backend='python',
+                                        **kwargs)
         raise NotImplementedError(target)
 
     def poke(self, port, value):
@@ -53,3 +57,30 @@ class Tester:
     def compile_and_run(self, target="verilator", **kwargs):
         target_inst = self.make_target(target, **kwargs)
         target_inst.run()
+
+    def __check_interfaces_match(self, old_circuit, new_circuit):
+        old_port_names = old_circuit.interface.ports.keys()
+        for name in old_port_names:
+            if not hasattr(new_circuit, name):
+                raise ValueError(f"New circuit does not have port {name}")
+            old_kind = type(type(getattr(old_circuit, name)))
+            new_kind = type(type(getattr(new_circuit, name)))
+            if not (issubclass(new_kind, old_kind) or \
+                issubclass(old_kind, new_kind)):
+                raise ValueError("Types don't match")
+
+    def copy(self, new_circuit, clock=None):
+        """
+        Generates a copy of the tester for new_circuit
+        Checks that new_circut has exactly the same interface as self.circuit
+        """
+        self.__check_interfaces_match(self.circuit, new_circuit)
+        new_tester = Tester(new_circuit, clock)
+        for old_action in self.actions:
+            new_action = copy.copy(old_action)
+            if isinstance(new_action, (Poke, Expect)):
+                new_action.port = getattr(new_circuit, str(old_action.port.name))
+            elif isinstance(new_action, Step):
+                new_action.clock = clock
+            new_tester.actions.append(new_action)
+        return new_tester

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -6,6 +6,7 @@ from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
 from fault.actions import Poke, Expect, Step
+from fault.circuit_utils import check_interface_is_subset
 import copy
 
 
@@ -58,30 +59,17 @@ class Tester:
         target_inst = self.make_target(target, **kwargs)
         target_inst.run()
 
-    def __check_interfaces_match(self, old_circuit, new_circuit):
-        old_port_names = old_circuit.interface.ports.keys()
-        for name in old_port_names:
-            if not hasattr(new_circuit, name):
-                raise ValueError(f"New circuit does not have port {name}")
-            old_kind = type(type(getattr(old_circuit, name)))
-            new_kind = type(type(getattr(new_circuit, name)))
-            if not (issubclass(new_kind, old_kind) or
-                    issubclass(old_kind, new_kind)):
-                raise ValueError("Types don't match")
+    def retarget(self, new_circuit, clock=None):
+        """
+        Generates a new instance of the Tester object that targets
+        `new_circuit`. This allows you to copy a set of actions for a new
+        circuit with the same interface (or an interface that is a super set of
+        self.circuit)
+        """
+        # Check that the interface of self.circuit is a subset of new_circuit
+        check_interface_is_subset(self.circuit, new_circuit)
 
-    def copy(self, new_circuit, clock=None):
-        """
-        Generates a copy of the tester for new_circuit
-        Checks that new_circut has exactly the same interface as self.circuit
-        """
-        self.__check_interfaces_match(self.circuit, new_circuit)
         new_tester = Tester(new_circuit, clock)
-        for old_action in self.actions:
-            new_action = copy.copy(old_action)
-            if isinstance(new_action, (Poke, Expect)):
-                new_action.port = getattr(new_circuit,
-                                          str(old_action.port.name))
-            elif isinstance(new_action, Step):
-                new_action.clock = clock
-            new_tester.actions.append(new_action)
+        new_tester.actions = [action.retarget(new_circuit, clock) for action in
+                              self.actions]
         return new_tester

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -65,8 +65,8 @@ class Tester:
                 raise ValueError(f"New circuit does not have port {name}")
             old_kind = type(type(getattr(old_circuit, name)))
             new_kind = type(type(getattr(new_circuit, name)))
-            if not (issubclass(new_kind, old_kind) or \
-                issubclass(old_kind, new_kind)):
+            if not (issubclass(new_kind, old_kind) or
+                    issubclass(old_kind, new_kind)):
                 raise ValueError("Types don't match")
 
     def copy(self, new_circuit, clock=None):
@@ -79,7 +79,8 @@ class Tester:
         for old_action in self.actions:
             new_action = copy.copy(old_action)
             if isinstance(new_action, (Poke, Expect)):
-                new_action.port = getattr(new_circuit, str(old_action.port.name))
+                new_action.port = getattr(new_circuit,
+                                          str(old_action.port.name))
             elif isinstance(new_action, Step):
                 new_action.clock = clock
             new_tester.actions.append(new_action)

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,3 +22,4 @@ TestSIntCircuit = define_simple_circuit(m.SInt(3), "SIntCircuit")
 TestNestedArraysCircuit = define_simple_circuit(m.Array(3, m.Bits(4)),
                                                 "NestedArraysCircuit")
 TestBasicClkCircuit = define_simple_circuit(m.Bit, "BasicClkCircuit", True)
+TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy", True)

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,4 +22,5 @@ TestSIntCircuit = define_simple_circuit(m.SInt(3), "SIntCircuit")
 TestNestedArraysCircuit = define_simple_circuit(m.Array(3, m.Bits(4)),
                                                 "NestedArraysCircuit")
 TestBasicClkCircuit = define_simple_circuit(m.Bit, "BasicClkCircuit", True)
-TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy", True)
+TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy",
+                                                True)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -64,7 +64,6 @@ def test_copy_tester():
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
 
-
     circ_copy = common.TestBasicClkCircuitCopy
     copy = tester.copy(circ_copy, circ_copy.CLK)
     copy_expected = [

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -54,23 +54,24 @@ def test_copy_tester():
         Poke(circ.I, 0),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
-        Step(1, circ.CLK)
+        Step(circ.CLK, 1)
     ]
     tester = fault.Tester(circ, circ.CLK)
     tester.poke(circ.I, 0)
     tester.expect(circ.O, 0)
     tester.poke(circ.CLK, 0)
     tester.step()
+    print(tester.actions)
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
 
     circ_copy = common.TestBasicClkCircuitCopy
-    copy = tester.copy(circ_copy, circ_copy.CLK)
+    copy = tester.retarget(circ_copy, circ_copy.CLK)
     copy_expected = [
         Poke(circ_copy.I, 0),
         Expect(circ_copy.O, 0),
         Poke(circ_copy.CLK, 0),
-        Step(1, circ_copy.CLK)
+        Step(circ_copy.CLK, 1)
     ]
     for i, exp in enumerate(copy_expected):
         check(copy.actions[i], exp)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -46,3 +46,32 @@ def test_tester_nested_arrays():
         expected.append(Expect(circ.O[i], val))
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
+
+
+def test_copy_tester():
+    circ = common.TestBasicClkCircuit
+    expected = [
+        Poke(circ.I, 0),
+        Expect(circ.O, 0),
+        Poke(circ.CLK, 0),
+        Step(1, circ.CLK)
+    ]
+    tester = fault.Tester(circ, circ.CLK)
+    tester.poke(circ.I, 0)
+    tester.expect(circ.O, 0)
+    tester.poke(circ.CLK, 0)
+    tester.step()
+    for i, exp in enumerate(expected):
+        check(tester.actions[i], exp)
+
+
+    circ_copy = common.TestBasicClkCircuitCopy
+    copy = tester.copy(circ_copy, circ_copy.CLK)
+    copy_expected = [
+        Poke(circ_copy.I, 0),
+        Expect(circ_copy.O, 0),
+        Poke(circ_copy.CLK, 0),
+        Step(1, circ_copy.CLK)
+    ]
+    for i, exp in enumerate(copy_expected):
+        check(copy.actions[i], exp)


### PR DESCRIPTION
Closes https://github.com/leonardt/fault/issues/16

Basically, we can't just copy test vectors any more because the actions save the associated port. My proposed solution is to add a `copy` method to a tester object, which you can call with a new circuit and clock. It copies all the actions and updates the port/clock references. It also checks that the interfaces are the same.