### PR TITLE
Convert BitVector(1) to bool for python simulator m.Bit

### DIFF
--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -1,4 +1,5 @@
 from bit_vector import BitVector
+import magma as m
 from magma.simulator.python_simulator import PythonSimulator
 from magma.simulator.coreir_simulator import CoreIRSimulator
 import fault.actions as actions
@@ -24,7 +25,12 @@ class MagmaSimulatorTarget(Target):
         simulator = self.backend_cls(self.circuit, self.clock)
         for action in self.actions:
             if isinstance(action, actions.Poke):
-                simulator.set_value(action.port, action.value)
+                value = action.value
+                # Python simulator does not support setting Bit with
+                # BitVector(1), so do conversion here
+                if isinstance(action.port, m.BitType) and isinstance(value, BitVector):
+                    value = value.as_uint()
+                simulator.set_value(action.port, value)
             elif isinstance(action, actions.Expect):
                 got = BitVector(simulator.get_value(action.port))
                 expected = action.value


### PR DESCRIPTION
This is required for simulating single bit inputs in the python simulator. The issue is that `make_value` (https://github.com/leonardt/fault/blob/c0fc82e591cad08f6bd60eefc36241693173a685/fault/value_utils.py#L7) converts `Bit` values to `BitVector(1)`. This is fine for the verilator target, which we're mainly using, but the PythonSimulator got updated to only support passing `bool` for `Bit`, so we do an unpacking here. Not sure if there's a better solution for this, perhaps this is fine as a temporary workaround until we introduce the `Bit` type in the `bit_vector` package.