### PR TITLE
Add __str__ methods for actions

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -13,6 +13,9 @@ class Poke(Action):
         self.port = port
         self.value = value
 
+    def __str__(self):
+        return f"Poke({self.port.debug_name}, {self.value})"
+
 
 class Expect(Action):
     def __init__(self, port, value):
@@ -22,10 +25,16 @@ class Expect(Action):
         self.port = port
         self.value = value
 
+    def __str__(self):
+        return f"Expect({self.port.debug_name}, {self.value})"
+
 
 class Eval(Action):
     def __init__(self):
         super().__init__()
+
+    def __str__(self):
+        return f"Eval()"
 
 
 class Step(Action):
@@ -33,3 +42,6 @@ class Step(Action):
         super().__init__()
         self.steps = steps
         self.clock = clock
+
+    def __str__(self):
+        return f"Step({self.steps}, {self.clock.debug_name})"

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -38,10 +38,10 @@ class Eval(Action):
 
 
 class Step(Action):
-    def __init__(self, steps, clock):
+    def __init__(self, clock, steps):
         super().__init__()
-        self.steps = steps
         self.clock = clock
+        self.steps = steps
 
     def __str__(self):
-        return f"Step({self.steps}, {self.clock.debug_name})"
+        return f"Step({self.clock.debug_name}, steps={self.steps})"

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -1,4 +1,4 @@
-import magma
+iclockmport magma
 import fault.actions as actions
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.logging import warning
@@ -42,7 +42,7 @@ class Tester:
         if self.clock is None:
             raise RuntimeError("Stepping tester without a clock (did you "
                                "specify a clock during initialization?)")
-        self.actions.append(actions.Step(steps, self.clock))
+        self.actions.append(actions.Step(self.clock, steps))
 
     def serialize(self):
         builder = VectorBuilder(self.circuit)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -1,3 +1,4 @@
+import magma
 import fault.actions as actions
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.logging import warning

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -1,4 +1,3 @@
-iclockmport magma
 import fault.actions as actions
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.logging import warning

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,10 @@
+from fault.actions import Poke, Expect, Eval, Step
+import common
+
+
+def test_action_strs():
+    circ = common.TestBasicClkCircuit
+    assert str(Poke(circ.I, 1)) == 'Poke(BasicClkCircuit.I, 1)'
+    assert str(Expect(circ.O, 1)) == 'Expect(BasicClkCircuit.O, 1)'
+    assert str(Eval()) == 'Eval()'
+    assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -58,6 +58,6 @@ def test_magma_simulator_target_clock(backend):
         # TODO(rsetaluri): Figure out how to set clock value directly with the
         # coreir simulator. Currently it does not allow this.
         # Poke(circ.CLK, BitVector(0, 1)),
-        Step(1, circ.CLK),
+        Step(circ.CLK, 1),
     ]
     run(circ, actions, circ.CLK, backend)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -31,7 +31,7 @@ def test_tester_clock():
     tester.poke(circ.CLK, 0)
     check(tester.actions[2], Poke(circ.CLK, 0))
     tester.step()
-    check(tester.actions[3], Step(1, circ.CLK))
+    check(tester.actions[3], Step(circ.CLK, 1))
 
 
 def test_tester_nested_arrays():

--- a/tests/test_vector_builder.py
+++ b/tests/test_vector_builder.py
@@ -30,7 +30,7 @@ def test_tester_clock():
     assert builder.vectors == [
         [BitVector(0, 1), BitVector(0, 1), BitVector(0, 1)]
     ]
-    builder.process(Step(1, circ.CLK))
+    builder.process(Step(circ.CLK, 1))
     assert builder.vectors == [
         [BitVector(0, 1), BitVector(0, 1), BitVector(0, 1)],
         [BitVector(0, 1), fault.AnyValue, BitVector(1, 1)]

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -43,6 +43,6 @@ def test_verilator_target_clock():
         Poke(circ.I, 0),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
-        Step(1, circ.CLK),
+        Step(circ.CLK, 1),
     ]
     run(circ, actions, flags=["-Wno-lint"])


### PR DESCRIPTION
Convenience methods for debugging.

For example, with this change
```diff
diff --git a/fault/magma_simulator_target.py b/fault/magma_simulator_target.py
index 8bfc66b..2b09d84 100644
--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -24,6 +24,7 @@ class MagmaSimulatorTarget(Target):
     def run(self):
         simulator = self.backend_cls(self.circuit, self.clock)
         for action in self.actions:
+            print(action)
             if isinstance(action, actions.Poke):
                 value = action.value
                 # Python simulator does not support setting Bit with
```

You get a nice printout, such as
```
Poke(PISO10.PI, 956)
Poke(PISO10.SI, 0)
Poke(PISO10.LOAD, 1)
Step(2, PISO10.CLK)
Poke(PISO10.PI, 255)
Poke(PISO10.SI, 0)
Poke(PISO10.LOAD, 0)
Step(2, PISO10.CLK)
Expect(PISO10.O, 1)
```