### PR TITLE
Add initial support for print

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -52,7 +52,6 @@ class Peek(Action):
         return cls(new_port, self.format_str)
 
 
-
 class Expect(PortAction):
     def __init__(self, port, value):
         if port.isoutput():

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -34,6 +34,25 @@ class Poke(PortAction):
         super().__init__(port, value)
 
 
+class Peek(Action):
+    def __init__(self, port, format_str="%x"):
+        if port.isoutput():
+            raise ValueError(f"Can only peek outputs: {port.debug_name} "
+                             f"{type(port)}")
+        super().__init__()
+        self.port = port
+        self.format_str = format_str
+
+    def __str__(self):
+        return f"Peek({self.port.debug_name}, \"{self.format_str}\")"
+
+    def retarget(self, new_circuit, clock):
+        cls = type(self)
+        new_port = new_circuit.interface.ports[str(self.port.name)]
+        return cls(new_port, self.format_str)
+
+
+
 class Expect(PortAction):
     def __init__(self, port, value):
         if port.isoutput():

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -34,7 +34,7 @@ class Poke(PortAction):
         super().__init__(port, value)
 
 
-class Peek(Action):
+class Print(Action):
     def __init__(self, port, format_str="%x"):
         if port.isoutput():
             raise ValueError(f"Can only peek outputs: {port.debug_name} "
@@ -44,7 +44,7 @@ class Peek(Action):
         self.format_str = format_str
 
     def __str__(self):
-        return f"Peek({self.port.debug_name}, \"{self.format_str}\")"
+        return f"Print({self.port.debug_name}, \"{self.format_str}\")"
 
     def retarget(self, new_circuit, clock):
         cls = type(self)

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -32,7 +32,7 @@ class MagmaSimulatorTarget(Target):
                         isinstance(value, BitVector):
                     value = value.as_uint()
                 simulator.set_value(action.port, value)
-            elif isinstance(action, actions.Peek):
+            elif isinstance(action, actions.Print):
                 got = BitVector(simulator.get_value(action.port))
                 print(f'{action.port.debug_name} = {action.format_str}' %
                       got.as_uint())

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -32,6 +32,10 @@ class MagmaSimulatorTarget(Target):
                         isinstance(value, BitVector):
                     value = value.as_uint()
                 simulator.set_value(action.port, value)
+            elif isinstance(action, actions.Peek):
+                got = BitVector(simulator.get_value(action.port))
+                print(f'{action.port.debug_name} = {action.format_str}' %
+                      got.as_uint())
             elif isinstance(action, actions.Expect):
                 got = BitVector(simulator.get_value(action.port))
                 expected = action.value

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -5,7 +5,7 @@ from fault.logging import warning
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
-from fault.actions import Poke, Expect, Step, Peek
+from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
 import copy
 
@@ -40,7 +40,7 @@ class Tester:
     def peek(self, port, format_str=None):
         if format_str is None:
             format_str = self.default_peek_format_str
-        self.actions.append(actions.Peek(port, format_str))
+        self.actions.append(actions.Print(port, format_str))
 
     def expect(self, port, value):
         value = make_value(port, value)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -5,18 +5,19 @@ from fault.logging import warning
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
-from fault.actions import Poke, Expect, Step
+from fault.actions import Poke, Expect, Step, Peek
 from fault.circuit_utils import check_interface_is_subset
 import copy
 
 
 class Tester:
-    def __init__(self, circuit, clock=None):
+    def __init__(self, circuit, clock=None, default_peek_format_str="%x"):
         self.circuit = circuit
         self.actions = []
         if clock is not None and not isinstance(clock, magma.ClockType):
             raise TypeError(f"Expected clock port: {clock, type(clock)}")
         self.clock = clock
+        self.default_peek_format_str = default_peek_format_str
 
     def make_target(self, target, **kwargs):
         if target == "verilator":
@@ -35,6 +36,11 @@ class Tester:
     def poke(self, port, value):
         value = make_value(port, value)
         self.actions.append(actions.Poke(port, value))
+
+    def peek(self, port, format_str=None):
+        if format_str is None:
+            format_str = self.default_peek_format_str
+        self.actions.append(actions.Peek(port, format_str))
 
     def expect(self, port, value):
         value = make_value(port, value)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -75,7 +75,7 @@ class Tester:
         # Check that the interface of self.circuit is a subset of new_circuit
         check_interface_is_subset(self.circuit, new_circuit)
 
-        new_tester = Tester(new_circuit, clock)
+        new_tester = Tester(new_circuit, clock, self.default_peek_format_str)
         new_tester.actions = [action.retarget(new_circuit, clock) for action in
                               self.actions]
         return new_tester

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -11,13 +11,13 @@ import copy
 
 
 class Tester:
-    def __init__(self, circuit, clock=None, default_peek_format_str="%x"):
+    def __init__(self, circuit, clock=None, default_print_format_str="%x"):
         self.circuit = circuit
         self.actions = []
         if clock is not None and not isinstance(clock, magma.ClockType):
             raise TypeError(f"Expected clock port: {clock, type(clock)}")
         self.clock = clock
-        self.default_peek_format_str = default_peek_format_str
+        self.default_print_format_str = default_print_format_str
 
     def make_target(self, target, **kwargs):
         if target == "verilator":
@@ -37,9 +37,9 @@ class Tester:
         value = make_value(port, value)
         self.actions.append(actions.Poke(port, value))
 
-    def peek(self, port, format_str=None):
+    def print(self, port, format_str=None):
         if format_str is None:
-            format_str = self.default_peek_format_str
+            format_str = self.default_print_format_str
         self.actions.append(actions.Print(port, format_str))
 
     def expect(self, port, value):
@@ -75,7 +75,7 @@ class Tester:
         # Check that the interface of self.circuit is a subset of new_circuit
         check_interface_is_subset(self.circuit, new_circuit)
 
-        new_tester = Tester(new_circuit, clock, self.default_peek_format_str)
+        new_tester = Tester(new_circuit, clock, self.default_print_format_str)
         new_tester.actions = [action.retarget(new_circuit, clock) for action in
                               self.actions]
         return new_tester

--- a/fault/vector_builder.py
+++ b/fault/vector_builder.py
@@ -57,5 +57,8 @@ class VectorBuilder:
                 val ^= BitVector(1, 1)
                 self.__eval()
                 self.__set(indices, val)
+        elif isinstance(action, actions.Peek):
+            # Skip Peek actions for test vectors
+            return
         else:
             raise NotImplementedError(action)

--- a/fault/vector_builder.py
+++ b/fault/vector_builder.py
@@ -57,8 +57,8 @@ class VectorBuilder:
                 val ^= BitVector(1, 1)
                 self.__eval()
                 self.__set(indices, val)
-        elif isinstance(action, actions.Peek):
-            # Skip Peek actions for test vectors
+        elif isinstance(action, actions.Print):
+            # Skip Print actions for test vectors
             return
         else:
             raise NotImplementedError(action)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -49,7 +49,7 @@ class VerilatorTarget(Target):
         if isinstance(action, actions.Poke):
             name = verilator_utils.verilator_name(action.port.name)
             return [f"top->{name} = {action.value};"]
-        if isinstance(action, actions.Peek):
+        if isinstance(action, actions.Print):
             name = verilator_utils.verilator_name(action.port.name)
             return [f'printf("{action.port.debug_name} = '
                     f'{action.format_str}\\n", top->{name});']

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -49,6 +49,9 @@ class VerilatorTarget(Target):
         if isinstance(action, actions.Poke):
             name = verilator_utils.verilator_name(action.port.name)
             return [f"top->{name} = {action.value};"]
+        if isinstance(action, actions.Peek):
+            name = verilator_utils.verilator_name(action.port.name)
+            return [f'printf("{action.port.debug_name} = {action.format_str}\\n", top->{name});']
         if isinstance(action, actions.Expect):
             # For verilator, if an expect is "AnyValue" we don't need to perform
             # the expect.

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -51,7 +51,8 @@ class VerilatorTarget(Target):
             return [f"top->{name} = {action.value};"]
         if isinstance(action, actions.Peek):
             name = verilator_utils.verilator_name(action.port.name)
-            return [f'printf("{action.port.debug_name} = {action.format_str}\\n", top->{name});']
+            return [f'printf("{action.port.debug_name} = '
+                    f'{action.format_str}\\n", top->{name});']
         if isinstance(action, actions.Expect):
             # For verilator, if an expect is "AnyValue" we don't need to perform
             # the expect.

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,4 @@
-from fault.actions import Poke, Expect, Eval, Step
+from fault.actions import Poke, Expect, Eval, Step, Peek
 import common
 
 
@@ -8,3 +8,4 @@ def test_action_strs():
     assert str(Expect(circ.O, 1)) == 'Expect(BasicClkCircuit.O, 1)'
     assert str(Eval()) == 'Eval()'
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
+    assert str(Peek(circ.O, "%08x")) == 'Peek(BasicClkCircuit.O, "%08x")'

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,4 @@
-from fault.actions import Poke, Expect, Eval, Step, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print
 import common
 
 
@@ -8,4 +8,4 @@ def test_action_strs():
     assert str(Expect(circ.O, 1)) == 'Expect(BasicClkCircuit.O, 1)'
     assert str(Eval()) == 'Eval()'
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
-    assert str(Peek(circ.O, "%08x")) == 'Peek(BasicClkCircuit.O, "%08x")'
+    assert str(Print(circ.O, "%08x")) == 'Print(BasicClkCircuit.O, "%08x")'

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -1,6 +1,6 @@
 from bit_vector import BitVector
 import common
-from fault.actions import Poke, Expect, Eval, Step, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.random import random_bv
 
@@ -61,9 +61,9 @@ def test_magma_simulator_target_clock(backend, capfd):
         Step(circ.CLK, 1),
         Poke(circ.I, BitVector(1, 1)),
         Eval(),
-        Peek(circ.O),
+        Print(circ.O),
     ]
     run(circ, actions, circ.CLK, backend)
     out, err = capfd.readouterr()
     assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
-        "Peek output incorrect"
+        "Print output incorrect"

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -1,6 +1,6 @@
 from bit_vector import BitVector
 import common
-from fault.actions import Poke, Expect, Eval, Step
+from fault.actions import Poke, Expect, Eval, Step, Peek
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.random import random_bv
 
@@ -50,7 +50,7 @@ def test_magma_simulator_target_nested_arrays(backend):
     run(circ, actions, None, backend)
 
 
-def test_magma_simulator_target_clock(backend):
+def test_magma_simulator_target_clock(backend, capfd):
     circ = common.TestBasicClkCircuit
     actions = [
         Poke(circ.I, BitVector(0, 1)),
@@ -59,5 +59,10 @@ def test_magma_simulator_target_clock(backend):
         # coreir simulator. Currently it does not allow this.
         # Poke(circ.CLK, BitVector(0, 1)),
         Step(circ.CLK, 1),
+        Poke(circ.I, BitVector(1, 1)),
+        Eval(),
+        Peek(circ.O),
     ]
     run(circ, actions, circ.CLK, backend)
+    out, err = capfd.readouterr()
+    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", "Peek output incorrect"

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -65,4 +65,5 @@ def test_magma_simulator_target_clock(backend, capfd):
     ]
     run(circ, actions, circ.CLK, backend)
     out, err = capfd.readouterr()
-    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", "Peek output incorrect"
+    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
+        "Peek output incorrect"

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,7 +1,7 @@
 import random
 from bit_vector import BitVector
 import fault
-from fault.actions import Poke, Expect, Eval, Step, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print
 import common
 
 
@@ -18,7 +18,7 @@ def test_tester_basic():
     tester.peek(circ.O, "%08x")
     check(tester.actions[0], Poke(circ.I, 0))
     check(tester.actions[1], Expect(circ.O, 0))
-    check(tester.actions[2], Peek(circ.O, "%08x"))
+    check(tester.actions[2], Print(circ.O, "%08x"))
     tester.eval()
     check(tester.actions[3], Eval())
 
@@ -58,7 +58,7 @@ def test_retarget_tester():
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
         Step(circ.CLK, 1),
-        Peek(circ.O, "%08x")
+        Print(circ.O, "%08x")
     ]
     tester = fault.Tester(circ, circ.CLK, default_peek_format_str="%08x")
     tester.poke(circ.I, 0)
@@ -79,7 +79,7 @@ def test_retarget_tester():
         Expect(circ_copy.O, 0),
         Poke(circ_copy.CLK, 0),
         Step(circ_copy.CLK, 1),
-        Peek(circ_copy.O, "%08x")
+        Print(circ_copy.O, "%08x")
     ]
     for i, exp in enumerate(copy_expected):
         check(copy.actions[i], exp)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -15,7 +15,7 @@ def test_tester_basic():
     tester = fault.Tester(circ)
     tester.poke(circ.I, 0)
     tester.expect(circ.O, 0)
-    tester.peek(circ.O, "%08x")
+    tester.print(circ.O, "%08x")
     check(tester.actions[0], Poke(circ.I, 0))
     check(tester.actions[1], Expect(circ.O, 0))
     check(tester.actions[2], Print(circ.O, "%08x"))
@@ -60,19 +60,19 @@ def test_retarget_tester():
         Step(circ.CLK, 1),
         Print(circ.O, "%08x")
     ]
-    tester = fault.Tester(circ, circ.CLK, default_peek_format_str="%08x")
+    tester = fault.Tester(circ, circ.CLK, default_print_format_str="%08x")
     tester.poke(circ.I, 0)
     tester.eval()
     tester.expect(circ.O, 0)
     tester.poke(circ.CLK, 0)
     tester.step()
-    tester.peek(circ.O)
+    tester.print(circ.O)
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
 
     circ_copy = common.TestBasicClkCircuitCopy
     copy = tester.retarget(circ_copy, circ_copy.CLK)
-    assert copy.default_peek_format_str == "%08x"
+    assert copy.default_print_format_str == "%08x"
     copy_expected = [
         Poke(circ_copy.I, 0),
         Eval(),

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -50,29 +50,36 @@ def test_tester_nested_arrays():
         check(tester.actions[i], exp)
 
 
-def test_copy_tester():
+def test_retarget_tester():
     circ = common.TestBasicClkCircuit
     expected = [
         Poke(circ.I, 0),
+        Eval(),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
-        Step(circ.CLK, 1)
+        Step(circ.CLK, 1),
+        Peek(circ.O, "%08x")
     ]
-    tester = fault.Tester(circ, circ.CLK)
+    tester = fault.Tester(circ, circ.CLK, default_peek_format_str="%08x")
     tester.poke(circ.I, 0)
+    tester.eval()
     tester.expect(circ.O, 0)
     tester.poke(circ.CLK, 0)
     tester.step()
+    tester.peek(circ.O)
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
 
     circ_copy = common.TestBasicClkCircuitCopy
     copy = tester.retarget(circ_copy, circ_copy.CLK)
+    assert copy.default_peek_format_str == "%08x"
     copy_expected = [
         Poke(circ_copy.I, 0),
+        Eval(),
         Expect(circ_copy.O, 0),
         Poke(circ_copy.CLK, 0),
-        Step(circ_copy.CLK, 1)
+        Step(circ_copy.CLK, 1),
+        Peek(circ_copy.O, "%08x")
     ]
     for i, exp in enumerate(copy_expected):
         check(copy.actions[i], exp)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,7 +1,7 @@
 import random
 from bit_vector import BitVector
 import fault
-from fault.actions import Poke, Expect, Eval, Step
+from fault.actions import Poke, Expect, Eval, Step, Peek
 import common
 
 
@@ -15,10 +15,12 @@ def test_tester_basic():
     tester = fault.Tester(circ)
     tester.poke(circ.I, 0)
     tester.expect(circ.O, 0)
+    tester.peek(circ.O, "%08x")
     check(tester.actions[0], Poke(circ.I, 0))
     check(tester.actions[1], Expect(circ.O, 0))
+    check(tester.actions[2], Peek(circ.O, "%08x"))
     tester.eval()
-    check(tester.actions[2], Eval())
+    check(tester.actions[3], Eval())
 
 
 def test_tester_clock():
@@ -61,7 +63,6 @@ def test_copy_tester():
     tester.expect(circ.O, 0)
     tester.poke(circ.CLK, 0)
     tester.step()
-    print(tester.actions)
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
 

--- a/tests/test_vector_builder.py
+++ b/tests/test_vector_builder.py
@@ -2,7 +2,7 @@ import random
 from bit_vector import BitVector
 import fault
 import common
-from fault.actions import Poke, Expect, Eval, Step
+from fault.actions import Poke, Expect, Eval, Step, Peek
 from fault.array import Array
 from fault.vector_builder import VectorBuilder
 
@@ -22,6 +22,7 @@ def test_tester_clock():
     circ = common.TestBasicClkCircuit
     builder = VectorBuilder(circ)
     builder.process(Poke(circ.I, BitVector(0, 1)))
+    builder.process(Peek(circ.O))
     builder.process(Expect(circ.O, BitVector(0, 1)))
     assert builder.vectors == [
         [BitVector(0, 1), BitVector(0, 1), fault.AnyValue]

--- a/tests/test_vector_builder.py
+++ b/tests/test_vector_builder.py
@@ -2,7 +2,7 @@ import random
 from bit_vector import BitVector
 import fault
 import common
-from fault.actions import Poke, Expect, Eval, Step, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print
 from fault.array import Array
 from fault.vector_builder import VectorBuilder
 
@@ -22,7 +22,7 @@ def test_tester_clock():
     circ = common.TestBasicClkCircuit
     builder = VectorBuilder(circ)
     builder.process(Poke(circ.I, BitVector(0, 1)))
-    builder.process(Peek(circ.O))
+    builder.process(Print(circ.O))
     builder.process(Expect(circ.O, BitVector(0, 1)))
     assert builder.vectors == [
         [BitVector(0, 1), BitVector(0, 1), fault.AnyValue]

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -4,7 +4,7 @@ import fault
 from bit_vector import BitVector
 import common
 import random
-from fault.actions import Poke, Expect, Eval, Step, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print
 
 
 def run(circ, actions, flags=[]):
@@ -43,13 +43,13 @@ def test_verilator_target_clock(capfd):
         Poke(circ.I, 0),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
-        Peek(circ.O),
+        Print(circ.O),
         Step(circ.CLK, 1),
         Poke(circ.I, BitVector(1, 1)),
         Eval(),
-        Peek(circ.O),
+        Print(circ.O),
     ]
     run(circ, actions, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
     assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
-        "Peek output incorrect"
+        "Print output incorrect"

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -51,4 +51,5 @@ def test_verilator_target_clock(capfd):
     ]
     run(circ, actions, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
-    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", "Peek output incorrect"
+    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
+        "Peek output incorrect"


### PR DESCRIPTION
Only works on top level ports

Supports an optional argument `format_str` which allows you to customize how the value is printed (by default it is `%x`).

Example usage:
```python
    tester.print(circ.O, "%08x")
```

Adds tests for Actions, Tester, and the magma/verilator targets.