### PR TITLE
[verilator-target] Add interface to add include directories

### DIFF
--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -37,12 +37,14 @@ int main(int argc, char **argv) {{
 
 class VerilatorTarget(Target):
     def __init__(self, circuit, actions, directory="build/",
-                 flags=[], skip_compile=False, include_verilog_files=[]):
+                 flags=[], skip_compile=False, include_verilog_libraries=[],
+                 include_directories=[]):
         super().__init__(circuit, actions)
         self.directory = Path(directory)
         self.flags = flags
         self.skip_compile = skip_compile
-        self.include_verilog_files = include_verilog_files
+        self.include_verilog_libraries = include_verilog_libraries
+        self.include_directories = include_directories
 
     @staticmethod
     def generate_action_code(i, action):
@@ -115,8 +117,8 @@ class VerilatorTarget(Target):
         # the Makefile output by verilator, and finally run the executable
         # created by verilator.
         verilator_cmd = verilator_utils.verilator_cmd(
-            top, verilog_file.name, self.include_verilog_files,
-            driver_file.name, self.flags)
+            top, verilog_file.name, self.include_verilog_libraries,
+            self.include_directories, driver_file.name, self.flags)
         assert not self.run_from_directory(verilator_cmd)
         verilator_make_cmd = verilator_utils.verilator_make_cmd(top)
         assert not self.run_from_directory(verilator_make_cmd)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {{
 
 class VerilatorTarget(Target):
     def __init__(self, circuit, actions, directory="build/",
-                 flags=[], skip_compile=False, include_verilog_files=[],
+                 flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output="verilog"):
         super().__init__(circuit, actions)
         self.directory = Path(directory)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -39,6 +39,16 @@ class VerilatorTarget(Target):
     def __init__(self, circuit, actions, directory="build/",
                  flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output="verilog"):
+        """
+        Params:
+            `include_verilog_libraries`: a list of verilog libraries to include
+            with the -v flag.  From the verilator docs:
+                -v <filename>              Verilog library
+
+            `include_directories`: a list of directories to include using the
+            -I flag. From the the verilator docs:
+                -I<dir>                    Directory to search for includes
+        """
         super().__init__(circuit, actions)
         self.directory = Path(directory)
         self.flags = flags

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -2,8 +2,8 @@ import magma
 import fault.actions as actions
 
 
-def verilator_cmd(top, verilog_filename, include_verilog_files, driver_filename,
-                  verilator_flags):
+def verilator_cmd(top, verilog_filename, include_verilog_libraries,
+                  include_directories, driver_filename, verilator_flags):
     DEFAULT_FLAGS = [
         "-Wall",
         "-Wno-INCABSPATH",
@@ -12,7 +12,8 @@ def verilator_cmd(top, verilog_filename, include_verilog_files, driver_filename,
     flags = DEFAULT_FLAGS
     flags.extend(verilator_flags)
     flag_str = " ".join(flags)
-    include_str = ' '.join(f'-v {file_}' for file_ in include_verilog_files)
+    include_str = ' '.join(f'-v {file_}' for file_ in include_verilog_libraries)
+    include_str += " -I" + " -I".join(dir_ for dir_ in include_directories)
     return (f"verilator {flag_str} "
             f"--cc {verilog_filename} "
             f"{include_str} "

--- a/tests/SB_DFF.v
+++ b/tests/SB_DFF.v
@@ -1,0 +1,1 @@
+sb_dff_sim.v

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -2,6 +2,7 @@ import pathlib
 import tempfile
 import fault
 import magma as m
+import os
 
 
 def test_include_verilog():
@@ -24,3 +25,10 @@ def test_include_verilog():
     with tempfile.TemporaryDirectory() as tmp_dir:
         tester.compile_and_run(target="verilator", directory=tmp_dir,
                                include_verilog_libraries=[sb_dff_filename])
+
+    # Should work by including the tests/ directory which contains the verilog
+    # file SB_DFF.v
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tester.compile_and_run(target="verilator", directory=tmp_dir,
+                               include_directories=[dir_path])

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -23,4 +23,4 @@ def test_include_verilog():
     sb_dff_filename = pathlib.Path("tests/sb_dff_sim.v").resolve()
     with tempfile.TemporaryDirectory() as tmp_dir:
         tester.compile_and_run(target="verilator", directory=tmp_dir,
-                               include_verilog_files=[sb_dff_filename])
+                               include_verilog_libraries=[sb_dff_filename])


### PR DESCRIPTION
Adds a parameter `include_directories` which is a list of directories to
include in the verilator command using the `-I` flag.

Also, renames the include_verilog_files parameter/field to be
`include_verilog_libraries` to more explicitly match the verilator
terminology (`-v` is use for library files.)