### PR TITLE
Allow printing input values

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -36,9 +36,6 @@ class Poke(PortAction):
 
 class Print(Action):
     def __init__(self, port, format_str="%x"):
-        if port.isoutput():
-            raise ValueError(f"Can only peek outputs: {port.debug_name} "
-                             f"{type(port)}")
         super().__init__()
         self.port = port
         self.format_str = format_str

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -54,6 +54,7 @@ def test_magma_simulator_target_clock(backend, capfd):
     circ = common.TestBasicClkCircuit
     actions = [
         Poke(circ.I, BitVector(0, 1)),
+        Print(circ.I),
         Expect(circ.O, BitVector(0, 1)),
         # TODO(rsetaluri): Figure out how to set clock value directly with the
         # coreir simulator. Currently it does not allow this.
@@ -65,5 +66,7 @@ def test_magma_simulator_target_clock(backend, capfd):
     ]
     run(circ, actions, circ.CLK, backend)
     out, err = capfd.readouterr()
-    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
-        "Print output incorrect"
+    lines = out.splitlines()
+
+    assert lines[-2] == "BasicClkCircuit.I = 0", "Print output incorrect"
+    assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -41,6 +41,7 @@ def test_verilator_target_clock(capfd):
     circ = common.TestBasicClkCircuit
     actions = [
         Poke(circ.I, 0),
+        Print(circ.I),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),
         Print(circ.O),
@@ -51,5 +52,8 @@ def test_verilator_target_clock(capfd):
     ]
     run(circ, actions, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
-    assert out.splitlines()[-1] == "BasicClkCircuit.O = 1", \
-        "Print output incorrect"
+    lines = out.splitlines()
+
+    assert lines[-3] == "BasicClkCircuit.I = 0", "Print output incorrect"
+    assert lines[-2] == "BasicClkCircuit.O = 0", "Print output incorrect"
+    assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"


### PR DESCRIPTION
Can be useful for debugging to see what the inputs are at the time of
expect failure.

Also, the error message has a stray `peek`