### PR TITLE
Rename vector generator to action generator

### DIFF
--- a/fault/action_generators.py
+++ b/fault/action_generators.py
@@ -1,0 +1,31 @@
+import fault
+from fault.common import get_renamed_port
+
+def generate_actions_from_streams(circuit, functional_model, streams,
+                                       num_vectors=10, input_mapping=None):
+    tester = fault.Tester(circuit)
+
+    for i in range(num_vectors):
+        inputs = []
+        for name, stream in streams.items():
+            if callable(stream):
+                val = stream(name, getattr(circuit, name))
+            else:
+                val = stream
+            inputs.append(val)
+            # stream_port = get_renamed_port(circuit, name)
+            tester.poke(getattr(circuit, name), inputs[-1])
+        tester.eval()
+        # Used to handle differences between circuit's interface and
+        # functional_model interface. For example, the simple_cb interface
+        # is packed for the genesis version
+        if input_mapping:
+            inputs = input_mapping(*inputs)
+        functional_model(*inputs)
+        for name, port in circuit.interface.items():
+            if port.isoutput():
+                # Handle renamed output ports
+                fn_model_port = get_renamed_port(circuit, name)
+                tester.expect(getattr(circuit, name),
+                              getattr(functional_model, fn_model_port))
+    return tester.actions

--- a/fault/test_vector_generator.py
+++ b/fault/test_vector_generator.py
@@ -62,33 +62,3 @@ def generate_random_test_vectors(circuit, functional_model,
                 tester.expect(getattr(circuit, name),
                               getattr(functional_model, fn_model_port))
     return tester.test_vectors
-
-
-def generate_test_vectors_from_streams(circuit, functional_model, streams,
-                                       num_vectors=10, input_mapping=None):
-    tester = fault.Tester(circuit)
-
-    for i in range(num_vectors):
-        inputs = []
-        for name, stream in streams.items():
-            if callable(stream):
-                val = stream(name, getattr(circuit, name))
-            else:
-                val = stream
-            inputs.append(val)
-            # stream_port = get_renamed_port(circuit, name)
-            tester.poke(getattr(circuit, name), inputs[-1])
-        tester.eval()
-        # Used to handle differences between circuit's interface and
-        # functional_model interface. For example, the simple_cb interface
-        # is packed for the genesis version
-        if input_mapping:
-            inputs = input_mapping(*inputs)
-        functional_model(*inputs)
-        for name, port in circuit.interface.items():
-            if port.isoutput():
-                # Handle renamed output ports
-                fn_model_port = get_renamed_port(circuit, name)
-                tester.expect(getattr(circuit, name),
-                              getattr(functional_model, fn_model_port))
-    return tester.test_vectors


### PR DESCRIPTION
This is just a name change to better reflect the semantics of the tester API. Since the action API is default, I think we should have these generators create actions, then the user can use the `serialize` method to get test vectors.