### PR TITLE
Set __test__ = False for Tester

### DIFF
--- a/fault/tester.py
+++ b/fault/tester.py
@@ -11,6 +11,7 @@ import copy
 
 
 class Tester:
+    __test__ = False
     def __init__(self, circuit, clock=None, default_print_format_str="%x"):
         self.circuit = circuit
         self.actions = []


### PR DESCRIPTION
This avoids the `Tester` object from being auto discovered by pytest, e.g. if you do `from fault import Tester`