### PR TITLE
Refactor compile_and_run logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
-    - verilator
+      - g++-4.9
+      - verilator
 python:
     - "3.6"
 

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -57,6 +57,26 @@ class Expect(PortAction):
         super().__init__(port, value)
 
 
+class Peek(Action):
+    def __init__(self, port):
+        super().__init__()
+        if port.isoutput():
+            raise ValueError(f"Can only peek on outputs: {port.debug_name} "
+                             f"{type(port)}")
+        self.port = port
+
+    def retarget(self, new_circuit, clock):
+        cls = type(self)
+        new_port = new_circuit.interface.ports[str(self.port.name)]
+        return cls(new_port)
+
+    def __eq__(self, other):
+        return self.port == other.port
+
+    def __str__(self):
+        return f"Peek({self.port.debug_name})"
+
+
 class Eval(Action):
     def __init__(self):
         super().__init__()

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -2,14 +2,14 @@ from bit_vector import BitVector
 import magma as m
 from magma.simulator.python_simulator import PythonSimulator
 from magma.simulator.coreir_simulator import CoreIRSimulator
-import fault.actions as actions
+import fault.actions
 from fault.logging import warning
 from fault.target import Target
 
 
 class MagmaSimulatorTarget(Target):
-    def __init__(self, circuit, actions, clock=None, backend="coreir"):
-        super().__init__(circuit, actions)
+    def __init__(self, circuit, clock=None, backend="coreir"):
+        super().__init__(circuit)
         self.clock = clock
         self.backend_cls = MagmaSimulatorTarget.simulator_cls(backend)
 
@@ -38,10 +38,10 @@ class MagmaSimulatorTarget(Target):
             return
         assert got == expected, f"Got {got}, expected {expected}"
 
-    def run(self):
+    def run(self, actions):
         simulator = self.backend_cls(self.circuit, self.clock)
-        for action in self.actions:
-            if isinstance(action, actions.Poke):
+        for action in actions:
+            if isinstance(action, fault.actions.Poke):
                 value = action.value
                 # Python simulator does not support setting Bit with
                 # BitVector(1), so do conversion here
@@ -49,7 +49,7 @@ class MagmaSimulatorTarget(Target):
                         isinstance(value, BitVector):
                     value = value.as_uint()
                 simulator.set_value(action.port, value)
-            elif isinstance(action, actions.Print):
+            elif isinstance(action, fault.actions.Print):
                 got = simulator.get_value(action.port)
                 if isinstance(action.port, m.ArrayType) and \
                         isinstance(action.port.T, (m._BitType, m._BitKind)):
@@ -58,12 +58,12 @@ class MagmaSimulatorTarget(Target):
                     raise NotImplementedError("Printing complex nested arrays")
                 print(f'{action.port.debug_name} = {action.format_str}' %
                       got)
-            elif isinstance(action, actions.Expect):
+            elif isinstance(action, fault.actions.Expect):
                 got = simulator.get_value(action.port)
                 MagmaSimulatorTarget.check(got, action.port, action.value)
-            elif isinstance(action, actions.Eval):
+            elif isinstance(action, fault.actions.Eval):
                 simulator.evaluate()
-            elif isinstance(action, actions.Step):
+            elif isinstance(action, fault.actions.Step):
                 if self.clock is not action.clock:
                     raise RuntimeError(f"Using different clocks: {self.clock}, "
                                        f"{action.clock}")

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -60,7 +60,10 @@ class MagmaSimulatorTarget(Target):
                       got)
             elif isinstance(action, fault.actions.Expect):
                 got = simulator.get_value(action.port)
-                MagmaSimulatorTarget.check(got, action.port, action.value)
+                expected = action.value
+                if isinstance(expected, fault.actions.Peek):
+                    expected = simulator.get_value(expected.port)
+                MagmaSimulatorTarget.check(got, action.port, expected)
             elif isinstance(action, fault.actions.Eval):
                 simulator.evaluate()
             elif isinstance(action, fault.actions.Step):

--- a/fault/target.py
+++ b/fault/target.py
@@ -2,9 +2,8 @@ from abc import ABC, abstractmethod
 
 
 class Target(ABC):
-    def __init__(self, circuit, actions):
+    def __init__(self, circuit):
         self.circuit = circuit
-        self.actions = actions
 
     @abstractmethod
     def run(self):

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -69,7 +69,8 @@ class Tester:
         try:
             self.targets[target].run(self.actions)
         except KeyError:
-            raise Exception(f"Could not find target={target}, did you compile it first?")
+            raise Exception(f"Could not find target={target}, did you compile"
+                            " it first?")
 
     def compile_and_run(self, target="verilator", **kwargs):
         self.compile(target, **kwargs)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -38,13 +38,17 @@ class Tester:
         value = make_value(port, value)
         self.actions.append(actions.Poke(port, value))
 
+    def peek(self, port):
+        return actions.Peek(port)
+
     def print(self, port, format_str=None):
         if format_str is None:
             format_str = self.default_print_format_str
         self.actions.append(actions.Print(port, format_str))
 
     def expect(self, port, value):
-        value = make_value(port, value)
+        if not isinstance(value, actions.Peek):
+            value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 
     def eval(self):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {{
 
 
 class VerilatorTarget(Target):
-    def __init__(self, circuit, actions, directory="build/",
+    def __init__(self, circuit, directory="build/",
                  flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output="verilog"):
         """
@@ -54,13 +54,29 @@ class VerilatorTarget(Target):
             -I flag. From the the verilator docs:
                 -I<dir>                    Directory to search for includes
         """
-        super().__init__(circuit, actions)
+        super().__init__(circuit)
         self.directory = Path(directory)
         self.flags = flags
         self.skip_compile = skip_compile
         self.include_verilog_libraries = include_verilog_libraries
         self.include_directories = include_directories
         self.magma_output = magma_output
+
+        verilog_file = self.directory / Path(f"{self.circuit.name}.v")
+        # Optionally compile this module to verilog first.
+        if not self.skip_compile:
+            prefix = str(verilog_file)[:-2]
+            m.compile(prefix, self.circuit, output=self.magma_output)
+        if not verilog_file.is_file():
+            raise Exception(f"Compiling {self.circuit} failed")
+
+        # Compile the design using `verilator`
+        driver_file = self.directory / Path(f"{self.circuit.name}_driver.cpp")
+        verilator_cmd = verilator_utils.verilator_cmd(
+            self.circuit.name, verilog_file.name, self.include_verilog_libraries,
+            self.include_directories, driver_file.name, self.flags)
+        if self.run_from_directory(verilator_cmd):
+            raise Exception(f"Running verilator cmd {verilator_cmd} failed")
 
     @staticmethod
     def generate_array_action_code(i, action):
@@ -104,7 +120,7 @@ class VerilatorTarget(Target):
             return code
         raise NotImplementedError(action)
 
-    def generate_code(self):
+    def generate_code(self, actions):
         circuit_name = self.circuit.name
         includes = [
             f'"V{circuit_name}.h"',
@@ -113,7 +129,7 @@ class VerilatorTarget(Target):
         ]
 
         main_body = ""
-        for i, action in enumerate(self.actions):
+        for i, action in enumerate(actions):
             code = VerilatorTarget.generate_action_code(i, action)
             for line in code:
                 main_body += f"  {line}\n"
@@ -130,26 +146,16 @@ class VerilatorTarget(Target):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self):
+    def run(self, actions):
         verilog_file = self.directory / Path(f"{self.circuit.name}.v")
         driver_file = self.directory / Path(f"{self.circuit.name}_driver.cpp")
         top = self.circuit.name
-        # Optionally compile this module to verilog first.
-        if not self.skip_compile:
-            prefix = str(verilog_file)[:-2]
-            m.compile(prefix, self.circuit, output=self.magma_output)
-        assert verilog_file.is_file()
         # Write the verilator driver to file.
-        src = self.generate_code()
+        src = self.generate_code(actions)
         with open(driver_file, "w") as f:
             f.write(src)
-        # Run a series of commands: compile the design using 'verilator', run
-        # the Makefile output by verilator, and finally run the executable
-        # created by verilator.
-        verilator_cmd = verilator_utils.verilator_cmd(
-            top, verilog_file.name, self.include_verilog_libraries,
-            self.include_directories, driver_file.name, self.flags)
-        assert not self.run_from_directory(verilator_cmd)
+        # Run a series of commands: run the Makefile output by verilator, and
+        # finally run the executable created by verilator.
         verilator_make_cmd = verilator_utils.verilator_make_cmd(top)
         assert not self.run_from_directory(verilator_make_cmd)
         assert not self.run_from_directory(f"./obj_dir/V{top}")

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -73,8 +73,9 @@ class VerilatorTarget(Target):
         # Compile the design using `verilator`
         driver_file = self.directory / Path(f"{self.circuit.name}_driver.cpp")
         verilator_cmd = verilator_utils.verilator_cmd(
-            self.circuit.name, verilog_file.name, self.include_verilog_libraries,
-            self.include_directories, driver_file.name, self.flags)
+            self.circuit.name, verilog_file.name,
+            self.include_verilog_libraries, self.include_directories,
+            driver_file.name, self.flags)
         if self.run_from_directory(verilator_cmd):
             raise Exception(f"Running verilator cmd {verilator_cmd} failed")
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -28,3 +28,15 @@ TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy",
                                                 True)
 TestTupleCircuit = define_simple_circuit(m.Tuple(a=m.Bit, b=m.Bit),
                                          "TupleCircuit")
+
+T = m.Bits(3)
+
+
+class TestPeekCircuit(m.Circuit):
+    __test__ = False   # Disable pytest discovery
+    IO = ["I", m.In(T), "O0", m.Out(T), "O1", m.Out(T)]
+
+    @classmethod
+    def definition(io):
+        m.wire(io.I, io.O0)
+        m.wire(io.I, io.O1)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,4 @@
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common
 
 
@@ -9,3 +9,4 @@ def test_action_strs():
     assert str(Eval()) == 'Eval()'
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
     assert str(Print(circ.O, "%08x")) == 'Print(BasicClkCircuit.O, "%08x")'
+    assert str(Peek(circ.O)) == 'Peek(BasicClkCircuit.O)'

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -6,8 +6,10 @@ import mantle
 import os
 import shutil
 import tempfile
+import pytest
 
 
+@pytest.mark.skip("Blocked by https://github.com/rdaly525/coreir/issues/627")
 def test_configuration():
     class ConfigurationTester(FunctionalTester):
         def configure(self, addr, data):
@@ -49,7 +51,8 @@ def test_configuration():
     tester.configure(0, 23)
     tester.configure(1, 41)
     with tempfile.TemporaryDirectory() as tmp_dir:
-        m.compile(f"{tmp_dir}/Configurable", Configurable,
+        m.compile(f"{tmp_dir}/global_Configurable", Configurable,
                   output="coreir-verilog")
         tester.compile_and_run(directory=tmp_dir, target="verilator",
-                               flags=["-Wno-fatal"], skip_compile=True)
+                               flags=["-Wno-fatal"], skip_compile=True,
+                               circuit_name="global_Configurable")

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -51,8 +51,8 @@ def test_configuration():
     tester.configure(0, 23)
     tester.configure(1, 41)
     with tempfile.TemporaryDirectory() as tmp_dir:
-        m.compile(f"{tmp_dir}/global_Configurable", Configurable,
+        m.compile(f"{tmp_dir}/Configurable", Configurable,
                   output="coreir-verilog")
         tester.compile_and_run(directory=tmp_dir, target="verilator",
                                flags=["-Wno-fatal"], skip_compile=True,
-                               circuit_name="global_Configurable")
+                               circuit_name="Configurable")

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -1,6 +1,6 @@
 from bit_vector import BitVector
 import common
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.random import random_bv
 
@@ -80,3 +80,14 @@ def test_magma_simulator_target_clock(backend, capfd):
 
     assert lines[-2] == "BasicClkCircuit.I = 0", "Print output incorrect"
     assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"
+
+
+def test_magma_simulator_target_peek(backend):
+    circ = common.TestPeekCircuit
+    actions = []
+    for i in range(3):
+        x = random_bv(3)
+        actions.append(Poke(circ.I, x))
+        actions.append(Eval())
+        actions.append(Expect(circ.O0, Peek(circ.O1)))
+    run(circ, actions, None, backend)

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -14,8 +14,8 @@ def pytest_generate_tests(metafunc):
 
 
 def run(circ, actions, clock, backend):
-    target = MagmaSimulatorTarget(circ, actions, clock, backend=backend)
-    target.run()
+    target = MagmaSimulatorTarget(circ, clock, backend=backend)
+    target.run(actions)
 
 
 def test_magma_simulator_target_basic(backend):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -23,6 +23,8 @@ def test_tester_basic():
     check(tester.actions[3], Print(circ.O, "%08x"))
     tester.eval()
     check(tester.actions[4], Eval())
+    tester.compile_and_run("verilator")
+    tester.compile_and_run("coreir")
 
 
 def test_tester_clock():

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,7 +1,7 @@
 import random
 from bit_vector import BitVector
 import fault
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common
 import tempfile
 
@@ -32,6 +32,15 @@ def test_tester_basic():
 
 
 def test_tester_clock():
+    circ = common.TestPeekCircuit
+    tester = fault.Tester(circ)
+    tester.poke(circ.I, 0)
+    tester.expect(circ.O0, tester.peek(circ.O1))
+    check(tester.actions[0], Poke(circ.I, 0))
+    check(tester.actions[1], Expect(circ.O0, Peek(circ.O1)))
+
+
+def test_tester_peek():
     circ = common.TestBasicClkCircuit
     tester = fault.Tester(circ, circ.CLK)
     tester.poke(circ.I, 0)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -3,6 +3,7 @@ from bit_vector import BitVector
 import fault
 from fault.actions import Poke, Expect, Eval, Step, Print
 import common
+import tempfile
 
 
 def check(got, expected):
@@ -23,7 +24,8 @@ def test_tester_basic():
     check(tester.actions[3], Print(circ.O, "%08x"))
     tester.eval()
     check(tester.actions[4], Eval())
-    tester.compile_and_run("verilator")
+    with tempfile.TemporaryDirectory() as _dir:
+        tester.compile_and_run("verilator", directory=_dir)
     tester.compile_and_run("coreir")
     tester.clear()
     assert tester.actions == []

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -25,6 +25,8 @@ def test_tester_basic():
     check(tester.actions[4], Eval())
     tester.compile_and_run("verilator")
     tester.compile_and_run("coreir")
+    tester.clear()
+    assert tester.actions == []
 
 
 def test_tester_clock():

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -98,3 +98,12 @@ def test_retarget_tester():
     ]
     for i, exp in enumerate(copy_expected):
         check(copy.actions[i], exp)
+
+
+def test_run_error():
+    try:
+        circ = common.TestBasicCircuit
+        fault.Tester(circ).run("bad_target")
+        assert False, "Should raise an exception"
+    except Exception as e:
+        assert str(e) == f"Could not find target=bad_target, did you compile it first?"  # noqa

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -11,11 +11,11 @@ import copy
 
 def run(circ, actions, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
-        m.compile(f"{tempdir}/global_{circ.name}", circ,
+        m.compile(f"{tempdir}/{circ.name}", circ,
                   output="coreir-verilog")
         target = fault.verilator_target.VerilatorTarget(
             circ, directory=f"{tempdir}/",
-            flags=flags, skip_compile=True, circuit_name="global_" + circ.name)
+            flags=flags, skip_compile=True)
         target.run(actions)
 
 

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -11,9 +11,9 @@ def run(circ, actions, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
         m.compile(f"{tempdir}/{circ.name}", circ, output="coreir-verilog")
         target = fault.verilator_target.VerilatorTarget(
-            circ, actions, directory=f"{tempdir}/",
+            circ, directory=f"{tempdir}/",
             flags=flags, skip_compile=True)
-        target.run()
+        target.run(actions)
 
 
 def test_verilator_target_basic():

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -4,15 +4,18 @@ import fault
 from bit_vector import BitVector
 import common
 import random
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
+from fault.random import random_bv
+import copy
 
 
 def run(circ, actions, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
-        m.compile(f"{tempdir}/{circ.name}", circ, output="coreir-verilog")
+        m.compile(f"{tempdir}/global_{circ.name}", circ,
+                  output="coreir-verilog")
         target = fault.verilator_target.VerilatorTarget(
             circ, directory=f"{tempdir}/",
-            flags=flags, skip_compile=True)
+            flags=flags, skip_compile=True, circuit_name="global_" + circ.name)
         target.run(actions)
 
 
@@ -22,6 +25,17 @@ def test_verilator_target_basic():
     """
     circ = common.TestBasicCircuit
     actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 0))
+    run(circ, actions)
+
+
+def test_verilator_target_peek():
+    circ = common.TestPeekCircuit
+    actions = []
+    for i in range(3):
+        x = random_bv(3)
+        actions.append(Poke(circ.I, x))
+        actions.append(Eval())
+        actions.append(Expect(circ.O0, Peek(circ.O1)))
     run(circ, actions)
 
 


### PR DESCRIPTION
This separates compilation (creating a target) from running (with a set of actions). This allows the user to compile a verilator binary once, then regenerate the harness with a new set of actions. Also adds a `clear` method as a mechanism for resetting the `actions` list.

The main change here is to have `actions` be an argument to `run` (which generates the harness with the new list of actions), rather than having `actions` be an argument to the target constructor.

Let me know if you have better ideas on how to organize this.