### PR TITLE
Initial peek support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
-    - verilator
+      - g++-4.9
+      - verilator
 python:
     - "3.6"
 

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -70,6 +70,9 @@ class Peek(Action):
         new_port = new_circuit.interface.ports[str(self.port.name)]
         return cls(new_port)
 
+    def __str__(self):
+        return f"Peek({self.port.debug_name})"
+
 
 class Eval(Action):
     def __init__(self):

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -70,6 +70,9 @@ class Peek(Action):
         new_port = new_circuit.interface.ports[str(self.port.name)]
         return cls(new_port)
 
+    def __eq__(self, other):
+        return self.port == other.port
+
     def __str__(self):
         return f"Peek({self.port.debug_name})"
 

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -57,6 +57,20 @@ class Expect(PortAction):
         super().__init__(port, value)
 
 
+class Peek(Action):
+    def __init__(self, port):
+        super().__init__()
+        if port.isoutput():
+            raise ValueError(f"Can only peek on outputs: {port.debug_name} "
+                             f"{type(port)}")
+        self.port = port
+
+    def retarget(self, new_circuit, clock):
+        cls = type(self)
+        new_port = new_circuit.interface.ports[str(self.port.name)]
+        return cls(new_port)
+
+
 class Eval(Action):
     def __init__(self):
         super().__init__()

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -61,10 +61,10 @@ class MagmaSimulatorTarget(Target):
             elif isinstance(action, fault.actions.Expect):
                 got = simulator.get_value(action.port)
                 expected = action.value
-                if isinstance(expected, actions.Peek):
+                if isinstance(expected, fault.actions.Peek):
                     expected = simulator.get_value(expected.port)
                 MagmaSimulatorTarget.check(got, action.port, expected)
-            elif isinstance(action, actions.Eval):
+            elif isinstance(action, fault.actions.Eval):
                 simulator.evaluate()
             elif isinstance(action, fault.actions.Step):
                 if self.clock is not action.clock:

--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -60,8 +60,11 @@ class MagmaSimulatorTarget(Target):
                       got)
             elif isinstance(action, fault.actions.Expect):
                 got = simulator.get_value(action.port)
-                MagmaSimulatorTarget.check(got, action.port, action.value)
-            elif isinstance(action, fault.actions.Eval):
+                expected = action.value
+                if isinstance(expected, actions.Peek):
+                    expected = simulator.get_value(expected.port)
+                MagmaSimulatorTarget.check(got, action.port, expected)
+            elif isinstance(action, actions.Eval):
                 simulator.evaluate()
             elif isinstance(action, fault.actions.Step):
                 if self.clock is not action.clock:

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -38,6 +38,9 @@ class Tester:
         value = make_value(port, value)
         self.actions.append(actions.Poke(port, value))
 
+    def peek(self, port):
+        return actions.Peek(port)
+
     def print(self, port, format_str=None):
         if format_str is None:
             format_str = self.default_print_format_str

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -47,7 +47,8 @@ class Tester:
         self.actions.append(actions.Print(port, format_str))
 
     def expect(self, port, value):
-        value = make_value(port, value)
+        if not isinstance(value, actions.Peek):
+            value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 
     def eval(self):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -128,7 +128,7 @@ class VerilatorTarget(Target):
             return code
         raise NotImplementedError(action)
 
-    def generate_code(self):
+    def generate_code(self, actions):
         circuit_name = self.circuit_name
         includes = [
             f'"V{circuit_name}.h"',

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -112,7 +112,10 @@ class VerilatorTarget(Target):
                     not isinstance(action.port.T, m.BitKind):
                 return VerilatorTarget.generate_array_action_code(i, action)
             name = verilator_utils.verilator_name(action.port.name)
-            return [f"my_assert(top->{name}, {action.value}, "
+            value = action.value
+            if isinstance(value, actions.Peek):
+                value = f"top->{value.port.name}"
+            return [f"my_assert(top->{name}, {value}, "
                     f"{i}, \"{action.port.name}\");"]
         if isinstance(action, actions.Eval):
             return ["top->eval();"]

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -66,7 +66,7 @@ class VerilatorTarget(Target):
         if circuit_name is None:
             self.circuit_name = self.circuit.name
 
-        verilog_file = self.directory / Path(f"{self.circuit.name}.v")
+        verilog_file = self.directory / Path(f"{self.circuit_name}.v")
         # Optionally compile this module to verilog first.
         if not self.skip_compile:
             prefix = str(verilog_file)[:-2]
@@ -75,9 +75,9 @@ class VerilatorTarget(Target):
             raise Exception(f"Compiling {self.circuit} failed")
 
         # Compile the design using `verilator`
-        driver_file = self.directory / Path(f"{self.circuit.name}_driver.cpp")
+        driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
         verilator_cmd = verilator_utils.verilator_cmd(
-            self.circuit.name, verilog_file.name,
+            self.circuit_name, verilog_file.name,
             self.include_verilog_libraries, self.include_directories,
             driver_file.name, self.flags)
         if self.run_from_directory(verilator_cmd):
@@ -155,9 +155,9 @@ class VerilatorTarget(Target):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
     def run(self, actions):
-        verilog_file = self.directory / Path(f"{self.circuit.name}.v")
-        driver_file = self.directory / Path(f"{self.circuit.name}_driver.cpp")
-        top = self.circuit.name
+        verilog_file = self.directory / Path(f"{self.circuit_name}.v")
+        driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
+        top = self.circuit_name
         # Write the verilator driver to file.
         src = self.generate_code(actions)
         with open(driver_file, "w") as f:

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -128,13 +128,8 @@ class VerilatorTarget(Target):
             return code
         raise NotImplementedError(action)
 
-<<<<<<< HEAD
-    def generate_code(self, actions):
-        circuit_name = self.circuit.name
-=======
     def generate_code(self):
         circuit_name = self.circuit_name
->>>>>>> Add global_ prefixes for coreir output name change
         includes = [
             f'"V{circuit_name}.h"',
             '"verilated.h"',

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -43,7 +43,8 @@ int main(int argc, char **argv) {{
 class VerilatorTarget(Target):
     def __init__(self, circuit, directory="build/",
                  flags=[], skip_compile=False, include_verilog_libraries=[],
-                 include_directories=[], magma_output="verilog"):
+                 include_directories=[], magma_output="verilog",
+                 circuit_name=None):
         """
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -61,6 +62,9 @@ class VerilatorTarget(Target):
         self.include_verilog_libraries = include_verilog_libraries
         self.include_directories = include_directories
         self.magma_output = magma_output
+        self.circuit_name = circuit_name
+        if circuit_name is None:
+            self.circuit_name = self.circuit.name
 
         verilog_file = self.directory / Path(f"{self.circuit.name}.v")
         # Optionally compile this module to verilog first.
@@ -121,8 +125,13 @@ class VerilatorTarget(Target):
             return code
         raise NotImplementedError(action)
 
+<<<<<<< HEAD
     def generate_code(self, actions):
         circuit_name = self.circuit.name
+=======
+    def generate_code(self):
+        circuit_name = self.circuit_name
+>>>>>>> Add global_ prefixes for coreir output name change
         includes = [
             f'"V{circuit_name}.h"',
             '"verilated.h"',

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,6 +30,8 @@ TestTupleCircuit = define_simple_circuit(m.Tuple(a=m.Bit, b=m.Bit),
                                          "TupleCircuit")
 
 T = m.Bits(3)
+
+
 class TestPeekCircuit(m.Circuit):
     __test__ = False   # Disable pytest discovery
     IO = ["I", m.In(T), "O0", m.Out(T), "O1", m.Out(T)]

--- a/tests/common.py
+++ b/tests/common.py
@@ -28,3 +28,13 @@ TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy",
                                                 True)
 TestTupleCircuit = define_simple_circuit(m.Tuple(a=m.Bit, b=m.Bit),
                                          "TupleCircuit")
+
+T = m.Bits(3)
+class TestPeekCircuit(m.Circuit):
+    __test__ = False   # Disable pytest discovery
+    IO = ["I", m.In(T), "O0", m.Out(T), "O1", m.Out(T)]
+
+    @classmethod
+    def definition(io):
+        m.wire(io.I, io.O0)
+        m.wire(io.I, io.O1)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,4 @@
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common
 
 
@@ -9,3 +9,4 @@ def test_action_strs():
     assert str(Eval()) == 'Eval()'
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
     assert str(Print(circ.O, "%08x")) == 'Print(BasicClkCircuit.O, "%08x")'
+    assert str(Peek(circ.O)) == 'Peek(BasicClkCircuit.O)'

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -9,7 +9,7 @@ import tempfile
 import pytest
 
 
-@pytest.skip("Blocked by https://github.com/rdaly525/coreir/issues/627")
+@pytest.mark.skip("Blocked by https://github.com/rdaly525/coreir/issues/627")
 def test_configuration():
     class ConfigurationTester(FunctionalTester):
         def configure(self, addr, data):

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -48,8 +48,10 @@ def test_configuration():
     tester.configure(1, 32)
     tester.configure(0, 23)
     tester.configure(1, 41)
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        m.compile(f"{tmp_dir}/Configurable", Configurable,
-                  output="coreir-verilog")
-        tester.compile_and_run(directory=tmp_dir, target="verilator",
-                               flags=["-Wno-fatal"], skip_compile=True)
+    # with tempfile.TemporaryDirectory() as tmp_dir:
+    tmp_dir = "tmp"
+    m.compile(f"{tmp_dir}/global_Configurable", Configurable,
+              output="coreir-verilog")
+    tester.compile_and_run(directory=tmp_dir, target="verilator",
+                           flags=["-Wno-fatal"], skip_compile=True,
+                           circuit_name="global_Configurable")

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -50,10 +50,9 @@ def test_configuration():
     tester.configure(1, 32)
     tester.configure(0, 23)
     tester.configure(1, 41)
-    # with tempfile.TemporaryDirectory() as tmp_dir:
-    tmp_dir = "tmp"
-    m.compile(f"{tmp_dir}/global_Configurable", Configurable,
-              output="coreir-verilog")
-    tester.compile_and_run(directory=tmp_dir, target="verilator",
-                           flags=["-Wno-fatal"], skip_compile=True,
-                           circuit_name="global_Configurable")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        m.compile(f"{tmp_dir}/global_Configurable", Configurable,
+                  output="coreir-verilog")
+        tester.compile_and_run(directory=tmp_dir, target="verilator",
+                               flags=["-Wno-fatal"], skip_compile=True,
+                               circuit_name="global_Configurable")

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -6,8 +6,10 @@ import mantle
 import os
 import shutil
 import tempfile
+import pytest
 
 
+@pytest.skip("Blocked by https://github.com/rdaly525/coreir/issues/627")
 def test_configuration():
     class ConfigurationTester(FunctionalTester):
         def configure(self, addr, data):

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -1,6 +1,6 @@
 from bit_vector import BitVector
 import common
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 from fault.magma_simulator_target import MagmaSimulatorTarget
 from fault.random import random_bv
 
@@ -80,3 +80,14 @@ def test_magma_simulator_target_clock(backend, capfd):
 
     assert lines[-2] == "BasicClkCircuit.I = 0", "Print output incorrect"
     assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"
+
+
+def test_magma_simulator_target_peek(backend):
+    circ = common.TestPeekCircuit
+    actions = []
+    for i in range(3):
+        x = random_bv(3)
+        actions.append(Poke(circ.I, x))
+        actions.append(Eval())
+        actions.append(Expect(circ.O0, Peek(circ.O1)))
+    run(circ, actions, None, backend)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,7 +1,7 @@
 import random
 from bit_vector import BitVector
 import fault
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common
 import tempfile
 
@@ -29,6 +29,15 @@ def test_tester_basic():
     tester.compile_and_run("coreir")
     tester.clear()
     assert tester.actions == []
+
+
+def test_tester_clock():
+    circ = common.TestPeekCircuit
+    tester = fault.Tester(circ)
+    tester.poke(circ.I, 0)
+    tester.expect(circ.O0, tester.peek(circ.O1))
+    check(tester.actions[0], Poke(circ.I, 0))
+    check(tester.actions[1], Expect(circ.O0, Peek(circ.O1)))
 
 
 def test_tester_clock():

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -40,7 +40,7 @@ def test_tester_clock():
     check(tester.actions[1], Expect(circ.O0, Peek(circ.O1)))
 
 
-def test_tester_clock():
+def test_tester_peek():
     circ = common.TestBasicClkCircuit
     tester = fault.Tester(circ, circ.CLK)
     tester.poke(circ.I, 0)

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -11,7 +11,8 @@ import copy
 
 def run(circ, actions, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
-        m.compile(f"{tempdir}/global_{circ.name}", circ, output="coreir-verilog")
+        m.compile(f"{tempdir}/global_{circ.name}", circ,
+                  output="coreir-verilog")
         target = fault.verilator_target.VerilatorTarget(
             circ, directory=f"{tempdir}/",
             flags=flags, skip_compile=True, circuit_name="global_" + circ.name)

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -4,7 +4,8 @@ import fault
 from bit_vector import BitVector
 import common
 import random
-from fault.actions import Poke, Expect, Eval, Step, Print
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
+from fault.random import random_bv
 import copy
 
 
@@ -23,6 +24,17 @@ def test_verilator_target_basic():
     """
     circ = common.TestBasicCircuit
     actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 0))
+    run(circ, actions)
+
+
+def test_verilator_target_peek():
+    circ = common.TestPeekCircuit
+    actions = []
+    for i in range(3):
+        x = random_bv(3)
+        actions.append(Poke(circ.I, x))
+        actions.append(Eval())
+        actions.append(Expect(circ.O0, Peek(circ.O1)))
     run(circ, actions)
 
 
@@ -76,9 +88,9 @@ def test_verilator_target_clock(capfd):
     out, err = capfd.readouterr()
     lines = out.splitlines()
 
-    assert lines[-3] == "global_BasicClkCircuit.I = 0", "Print output incorrect"
-    assert lines[-2] == "global_BasicClkCircuit.O = 0", "Print output incorrect"
-    assert lines[-1] == "global_BasicClkCircuit.O = 1", "Print output incorrect"
+    assert lines[-3] == "BasicClkCircuit.I = 0", "Print output incorrect"
+    assert lines[-2] == "BasicClkCircuit.O = 0", "Print output incorrect"
+    assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"
 
 
 def test_verilator_target_tuple():

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -5,14 +5,15 @@ from bit_vector import BitVector
 import common
 import random
 from fault.actions import Poke, Expect, Eval, Step, Print
+import copy
 
 
 def run(circ, actions, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
-        m.compile(f"{tempdir}/{circ.name}", circ, output="coreir-verilog")
+        m.compile(f"{tempdir}/global_{circ.name}", circ, output="coreir-verilog")
         target = fault.verilator_target.VerilatorTarget(
             circ, directory=f"{tempdir}/",
-            flags=flags, skip_compile=True)
+            flags=flags, skip_compile=True, circuit_name="global_" + circ.name)
         target.run(actions)
 
 
@@ -75,9 +76,9 @@ def test_verilator_target_clock(capfd):
     out, err = capfd.readouterr()
     lines = out.splitlines()
 
-    assert lines[-3] == "BasicClkCircuit.I = 0", "Print output incorrect"
-    assert lines[-2] == "BasicClkCircuit.O = 0", "Print output incorrect"
-    assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"
+    assert lines[-3] == "global_BasicClkCircuit.I = 0", "Print output incorrect"
+    assert lines[-2] == "global_BasicClkCircuit.O = 0", "Print output incorrect"
+    assert lines[-1] == "global_BasicClkCircuit.O = 1", "Print output incorrect"
 
 
 def test_verilator_target_tuple():


### PR DESCRIPTION
Feature request from @alexcarsello. Allows you to `expect` that two ports are equal. Here's the simple test case
```
# common.py
T = m.Bits(3)
class TestPeekCircuit(m.Circuit):
    __test__ = False   # Disable pytest discovery
    IO = ["I", m.In(T), "O0", m.Out(T), "O1", m.Out(T)]

    @classmethod
    def definition(io):
        m.wire(io.I, io.O0)
        m.wire(io.I, io.O1)
```

```
# test.py
def test_tester_clock():
    circ = common.TestPeekCircuit
    tester = fault.Tester(circ)
    tester.poke(circ.I, 0)
    tester.expect(circ.O0, tester.peek(circ.O1))
    check(tester.actions[0], Poke(circ.I, 0))
    check(tester.actions[1], Expect(circ.O0, Peek(circ.O1)))
```

Currently this depends on the latest coreir release 

It includes test skipped due to https://github.com/rdaly525/coreir/issues/627, and workarounds for https://github.com/rdaly525/coreir/issues/625 until it is resolved.

Pulling this into the `optimize-verilator` branch since there's changes to the same code, we should get that branch merged as well, but I think right now coreir is blocking things so we should keep these branches around so we have workarounds.

@alexcarsello can you try out this fault branch to see if the `peek` feature works for you? Currently, it only allows `peek`ing an top level output port. You can't do anything with the value, but a follow up feature might be saying things like `Peek(porta) + Peek(portb)` or something of that nature.

To checkout this branch and install it locally for yourself, you can do
```
git clone https://github.com/leonardt/fault
cd fault
git checkout -b init-peek
pip install --user .
```
You may want to do this in a virtualenvironment, or remember to uninstall this version when you want to get back onto the fault release. Let me know if you need help using this experimental branch, or we can get just try to get a release in quickly so you can stick to the standard flow.