### PR TITLE
Initialize System Verilog Target

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,2 +1,3 @@
 from .tester import Tester
 from .value import Value, AnyValue, UnknownValue
+import fault.random

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -1,0 +1,145 @@
+from fault.verilog_target import VerilogTarget
+import magma as m
+from pathlib import Path
+import fault.actions as actions
+import fault.verilator_utils as verilator_utils
+from bit_vector import BitVector
+import fault.value_utils as value_utils
+import subprocess
+
+
+src_tpl = """\
+`timescale 1ns/1ns
+
+module {circuit_name}_tb;
+{declarations}
+    initial begin
+{initial_body}
+        #20 $finish;
+    end
+
+    {circuit_name} dut (
+        {port_list}
+    );
+
+endmodule
+"""
+
+
+class SystemVerilogTarget(VerilogTarget):
+    def __init__(self, circuit, circuit_name=None, directory="build/",
+                 skip_compile=False, magma_output="verilog"):
+        super().__init__(circuit, circuit_name, directory, skip_compile,
+                         magma_output)
+
+    @staticmethod
+    def generate_action_code(i, action):
+        if isinstance(action, actions.Poke):
+            if isinstance(action.port, m.ArrayType) and \
+                    not isinstance(action.port.T, m.BitKind):
+                return VerilatorTarget.generate_array_action_code(i, action)
+            name = verilator_utils.verilator_name(action.port.name)
+            if isinstance(action.value, BitVector) and \
+                    action.value.num_bits > 32:
+                raise NotImplementedError()
+            else:
+                value = action.value
+                if isinstance(action.port, m.SIntType) and value < 0:
+                    # Handle sign extension for verilator since it expects and
+                    # unsigned c type
+                    port_len = len(action.port)
+                    value = BitVector(value, port_len).as_uint()
+                return [f"{name} = {value};"]
+        if isinstance(action, actions.Print):
+            name = verilator_utils.verilator_name(action.port.name)
+            if isinstance(action.port, m.ArrayType) and \
+                    not isinstance(action.port.T, m.BitKind):
+                return VerilatorTarget.generate_array_action_code(i, action)
+            else:
+                return [f'$display("{action.port.debug_name} = '
+                        f'{action.format_str}\\n", {name});']
+        if isinstance(action, actions.Expect):
+            # For verilator, if an expect is "AnyValue" we don't need to
+            # perform the expect.
+            if value_utils.is_any(action.value):
+                return []
+            if isinstance(action.port, m.ArrayType) and \
+                    not isinstance(action.port.T, m.BitKind):
+                return VerilatorTarget.generate_array_action_code(i, action)
+            name = verilator_utils.verilator_name(action.port.name)
+            value = action.value
+            if isinstance(value, actions.Peek):
+                value = f"{value.port.name}"
+            elif isinstance(action.port, m.SIntType) and value < 0:
+                # Handle sign extension for verilator since it expects and
+                # unsigned c type
+                port_len = len(action.port)
+                value = BitVector(value, port_len).as_uint()
+
+            return [f"assert(top->{name} == {value}) else $error(\"Failed on iteration=%d chekcing port {action.port.name}\");"]
+        if isinstance(action, actions.Eval):
+            # Eval implicit in SV simulations
+            return []
+        if isinstance(action, actions.Step):
+            name = verilator_utils.verilator_name(action.clock.name)
+            code = []
+            for step in range(action.steps):
+                # code.append("top->eval();")
+                # code.append("main_time++;")
+                # code.append("#if VM_TRACE")
+                # code.append("tracer->dump(main_time);")
+                # code.append("#endif")
+                code.append(f"#5 {name} ^= 1;")
+            return code
+        raise NotImplementedError(action)
+
+    def generate_code(self, actions):
+        initial_body = ""
+        port_list = []
+        declarations = ""
+        for name, value in self.circuit.IO.ports.items():
+            width_str = ""
+            if isinstance(value, m.ArrayType) and isinstance(value.T, m.BitKind):
+                width_str = f"[{len(value) - 1}:0] "
+            declarations += f"    wire {width_str}{name};\n"
+            port_list.append(f".{name}({name})")
+
+        for i, action in enumerate(actions):
+            code = SystemVerilogTarget.generate_action_code(i, action)
+            for line in code:
+                initial_body += f"        {line}\n"
+
+        src = src_tpl.format(
+            declarations=declarations,
+            initial_body=initial_body,
+            port_list=",\n        ".join(port_list),
+            circuit_name=self.circuit_name,
+        )
+
+        return src
+
+    def run(self, actions):
+        test_bench_file = self.directory / Path(f"{self.circuit_name}_tb.v")
+        # Write the verilator driver to file.
+        src = self.generate_code(actions)
+        with open(test_bench_file, "w") as f:
+            f.write(src)
+        cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
+        with open(cmd_file, "w") as f:
+            f.write("""\
+database -open -vcd vcddb -into verilog.vcd -default -timescale ps
+probe -create -all -vcd -depth all
+run 10000ns
+quit
+""")
+
+        # Run a series of commands: run the Makefile output by verilator, and
+        # finally run the executable created by verilator.
+        # top = self.circuit_name
+        # verilator_make_cmd = verilator_utils.verilator_make_cmd(top)
+        # assert not self.run_from_directory(verilator_make_cmd)
+        # assert not self.run_from_directory(f"./obj_dir/V{top}")
+        cmd = f"""\
+irun -top {self.circuit_name} -timescale 1ns/1ps -l {self.circuit_name}_irun.log -access +rwc -notimingchecks -input {self.circuit_name}_cmd.tcl {self.verilog_file}
+"""  # nopep8
+        assert not subprocess.call(cmd, cwd=self.directory, shell=True)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -6,6 +6,7 @@ import fault.verilator_utils as verilator_utils
 from bit_vector import BitVector
 import fault.value_utils as value_utils
 import subprocess
+from fault.util import flatten
 
 
 src_tpl = """\
@@ -33,11 +34,25 @@ class SystemVerilogTarget(VerilogTarget):
                          magma_output)
 
     @staticmethod
+    def generate_array_action_code(i, action):
+        result = []
+        for j in range(action.port.N):
+            if isinstance(action, actions.Print):
+                value = action.format_str
+            else:
+                value = action.value[j]
+            result += [
+                SystemVerilogTarget.generate_action_code(
+                    i, type(action)(action.port[j], value)
+                )]
+        return flatten(result)
+
+    @staticmethod
     def generate_action_code(i, action):
         if isinstance(action, actions.Poke):
             if isinstance(action.port, m.ArrayType) and \
                     not isinstance(action.port.T, m.BitKind):
-                return VerilatorTarget.generate_array_action_code(i, action)
+                return SystemVerilogTarget.generate_array_action_code(i, action)
             name = verilator_utils.verilator_name(action.port.name)
             if isinstance(action.value, BitVector) and \
                     action.value.num_bits > 32:
@@ -49,15 +64,15 @@ class SystemVerilogTarget(VerilogTarget):
                     # unsigned c type
                     port_len = len(action.port)
                     value = BitVector(value, port_len).as_uint()
-                return [f"{name} = {value};", "#1"]
+                return [f"{name} = {value};", "#5"]
         if isinstance(action, actions.Print):
             name = verilator_utils.verilator_name(action.port.name)
             if isinstance(action.port, m.ArrayType) and \
                     not isinstance(action.port.T, m.BitKind):
-                return VerilatorTarget.generate_array_action_code(i, action)
+                return SystemVerilogTarget.generate_array_action_code(i, action)
             else:
                 return [f'$display("{action.port.debug_name} = '
-                        f'{action.format_str}\\n", {name});']
+                        f'{action.format_str}", {name});']
         if isinstance(action, actions.Expect):
             # For verilator, if an expect is "AnyValue" we don't need to
             # perform the expect.
@@ -65,7 +80,7 @@ class SystemVerilogTarget(VerilogTarget):
                 return []
             if isinstance(action.port, m.ArrayType) and \
                     not isinstance(action.port.T, m.BitKind):
-                return VerilatorTarget.generate_array_action_code(i, action)
+                return SystemVerilogTarget.generate_array_action_code(i, action)
             name = verilator_utils.verilator_name(action.port.name)
             value = action.value
             if isinstance(value, actions.Peek):
@@ -76,7 +91,7 @@ class SystemVerilogTarget(VerilogTarget):
                 port_len = len(action.port)
                 value = BitVector(value, port_len).as_uint()
 
-            return [f"if ({name} != {value}) $error(\"Failed on iteration={i} checking port {action.port.name}\");"]
+            return [f"if ({name} != {value}) $error(\"Failed on action={i} checking port {action.port.name}. Expected %x, got %x\", {value}, {name});"]
         if isinstance(action, actions.Eval):
             # Eval implicit in SV simulations
             return []
@@ -93,22 +108,52 @@ class SystemVerilogTarget(VerilogTarget):
             return code
         raise NotImplementedError(action)
 
-    def generate_code(self, actions):
-        initial_body = ""
-        port_list = []
+    @staticmethod
+    def generate_recursive_port_code(name, type_):
         declarations = ""
-        for name, value in self.circuit.IO.ports.items():
+        port_list = []
+        if isinstance(type_, m.ArrayKind):
+            for j in range(type_.N):
+                result = SystemVerilogTarget.generate_port_code(
+                    name + "_" + str(j), type_.T
+                )
+                declarations += result[0]
+                port_list.extend(result[1])
+        elif isinstance(type_, m.TupleKind):
+            for k, t in zip(type_.Ks, type_.Ts):
+                result = SystemVerilogTarget.generate_port_code(
+                    name + "_" + str(k), t
+                )
+                declarations += result[0]
+                port_list.extend(result[1])
+        return declarations, port_list
+
+    @staticmethod
+    def generate_port_code(name, type_):
+        if (isinstance(type_, m.ArrayKind) and not isinstance(type_.T, m.BitKind)) or \
+                isinstance(type_, m.TupleKind):
+            return SystemVerilogTarget.generate_recursive_port_code(name, type_)
+        else:
             width_str = ""
-            if isinstance(value, m.ArrayType) and isinstance(value.T, m.BitKind):
-                width_str = f"[{len(value) - 1}:0] "
-            if value.isoutput():
+            print(type_)
+            if isinstance(type_, m.ArrayKind) and isinstance(type_.T, m.BitKind):
+                width_str = f"[{len(type_) - 1}:0] "
+            if type_.isoutput():
                 t = "wire"
-            elif value.isinput():
+            elif type_.isinput():
                 t = "reg"
             else:
                 raise NotImplementedError()
-            declarations += f"    {t} {width_str}{name};\n"
-            port_list.append(f".{name}({name})")
+            return f"    {t} {width_str}{name};\n", [f".{name}({name})"]
+
+    def generate_code(self, actions):
+        initial_body = ""
+        declarations = ""
+        port_list = []
+        for name, type_ in self.circuit.IO.ports.items():
+            result = SystemVerilogTarget.generate_port_code(name, type_)
+            declarations += result[0]
+            port_list.extend(result[1])
 
         for i, action in enumerate(actions):
             code = SystemVerilogTarget.generate_action_code(i, action)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -5,6 +5,7 @@ from fault.logging import warning
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
+from fault.system_verilog_target import SystemVerilogTarget
 from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
 import copy

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -8,10 +8,7 @@ import fault.value_utils as value_utils
 import fault.verilator_utils as verilator_utils
 import math
 from bit_vector import BitVector, SIntVector
-
-
-def flatten(l):
-    return [item for sublist in l for item in sublist]
+from fault.util import flatten
 
 
 src_tpl = """\

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -27,6 +27,8 @@ def verilator_make_cmd(top):
     return f"make -C obj_dir -j -f V{top}.mk V{top}"
 
 
+# TODO: This should be renamed to `verilog_name`, it just defines the mapping
+# from coreir types to verilog (rather than being verilator specific)
 def verilator_name(name):
     if isinstance(name, magma.ref.DefnRef):
         return str(name)

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -1,0 +1,31 @@
+import magma as m
+from fault.target import Target
+from pathlib import Path
+
+
+class VerilogTarget(Target):
+    """
+    Provides reuseable target logic for compiling circuits into verilog files.
+    """
+    def __init__(self, circuit, circuit_name=None, directory="build/",
+                 skip_compile=False, magma_output="verilog"):
+        super().__init__(circuit)
+
+        if circuit_name is None:
+            self.circuit_name = self.circuit.name
+        else:
+            self.circuit_name = circuit_name
+
+        self.directory = Path(directory)
+
+        self.skip_compile = skip_compile
+
+        self.magma_output = magma_output
+
+        self.verilog_file = self.directory / Path(f"{self.circuit_name}.v")
+        # Optionally compile this module to verilog first.
+        if not self.skip_compile:
+            prefix = str(self.verilog_file)[:-2]
+            m.compile(prefix, self.circuit, output=self.magma_output)
+            if not self.verilog_file.is_file():
+                raise Exception(f"Compiling {self.circuit} failed")

--- a/tests/common.py
+++ b/tests/common.py
@@ -26,7 +26,7 @@ TestDoubleNestedArraysCircuit = define_simple_circuit(
 TestBasicClkCircuit = define_simple_circuit(m.Bit, "BasicClkCircuit", True)
 TestBasicClkCircuitCopy = define_simple_circuit(m.Bit, "BasicClkCircuitCopy",
                                                 True)
-TestTupleCircuit = define_simple_circuit(m.Tuple(a=m.Bit, b=m.Bit),
+TestTupleCircuit = define_simple_circuit(m.Tuple(a=m.Bits(4), b=m.Bits(4)),
                                          "TupleCircuit")
 
 T = m.Bits(3)

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -1,0 +1,27 @@
+import tempfile
+import magma as m
+import fault
+from bit_vector import BitVector
+import common
+import random
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek
+from fault.random import random_bv
+import copy
+import os.path
+import pytest
+
+
+def run(circ, actions, flags=[]):
+    with tempfile.TemporaryDirectory() as tempdir:
+        target = fault.system_verilog_target.SystemVerilogTarget(
+            circ, directory=f"{tempdir}/", magma_output="coreir-verilog")
+        target.run(actions)
+
+
+def test_verilator_target_basic():
+    """
+    Test basic verilator workflow with a simple circuit.
+    """
+    circ = common.TestBasicCircuit
+    actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 1))
+    run(circ, actions)

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -23,5 +23,5 @@ def test_verilator_target_basic():
     Test basic verilator workflow with a simple circuit.
     """
     circ = common.TestBasicCircuit
-    actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 1))
+    actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 0))
     run(circ, actions)

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -11,26 +11,37 @@ import os.path
 import pytest
 
 
-def run(circ, actions, flags=[]):
+def pytest_generate_tests(metafunc):
+    if "target" in metafunc.fixturenames:
+        metafunc.parametrize("target", [fault.verilator_target.VerilatorTarget,
+                                        fault.system_verilog_target.SystemVerilogTarget])
+
+
+def run(circ, actions, target, flags=[]):
     with tempfile.TemporaryDirectory() as tempdir:
         m.compile(f"{tempdir}/{circ.name}", circ,
                   output="coreir-verilog")
-        target = fault.verilator_target.VerilatorTarget(
-            circ, directory=f"{tempdir}/",
-            flags=flags, skip_compile=True)
+        if target == fault.verilator_target.VerilatorTarget:
+            target = target(
+                circ, directory=f"{tempdir}/",
+                flags=flags, skip_compile=True)
+        else:
+            target = target(
+                circ, directory=f"{tempdir}/",
+                skip_compile=True)
         target.run(actions)
 
 
-def test_verilator_target_basic():
+def test_target_basic(target):
     """
-    Test basic verilator workflow with a simple circuit.
+    Test basic workflow with a simple circuit.
     """
     circ = common.TestBasicCircuit
     actions = (Poke(circ.I, 0), Eval(), Expect(circ.O, 0))
-    run(circ, actions)
+    run(circ, actions, target)
 
 
-def test_verilator_target_peek():
+def test_target_peek(target):
     circ = common.TestPeekCircuit
     actions = []
     for i in range(3):
@@ -38,10 +49,10 @@ def test_verilator_target_peek():
         actions.append(Poke(circ.I, x))
         actions.append(Eval())
         actions.append(Expect(circ.O0, Peek(circ.O1)))
-    run(circ, actions)
+    run(circ, actions, target)
 
 
-def test_verilator_target_nested_arrays_by_element():
+def test_target_nested_arrays_by_element(target):
     circ = common.TestNestedArraysCircuit
     expected = [random.randint(0, (1 << 4) - 1) for i in range(3)]
     actions = []
@@ -50,20 +61,20 @@ def test_verilator_target_nested_arrays_by_element():
     actions.append(Eval())
     for i, val in enumerate(expected):
         actions.append(Expect(circ.O[i], val))
-    run(circ, actions)
+    run(circ, actions, target)
 
 
-def test_verilator_target_nested_arrays_bulk():
+def test_target_nested_arrays_bulk(target):
     circ = common.TestNestedArraysCircuit
     expected = [random.randint(0, (1 << 4) - 1) for i in range(3)]
     actions = []
     actions.append(Poke(circ.I, expected))
     actions.append(Eval())
     actions.append(Expect(circ.O, expected))
-    run(circ, actions)
+    run(circ, actions, target)
 
 
-def test_verilator_target_double_nested_arrays_bulk():
+def test_target_double_nested_arrays_bulk(target):
     circ = common.TestDoubleNestedArraysCircuit
     expected = [[random.randint(0, (1 << 4) - 1) for i in range(3)]
                 for _ in range(2)]
@@ -71,10 +82,10 @@ def test_verilator_target_double_nested_arrays_bulk():
     actions.append(Poke(circ.I, expected))
     actions.append(Eval())
     actions.append(Expect(circ.O, expected))
-    run(circ, actions)
+    run(circ, actions, target)
 
 
-def test_verilator_target_clock(capfd):
+def test_target_clock(capfd, target):
     circ = common.TestBasicClkCircuit
     actions = [
         Poke(circ.I, 0),
@@ -87,16 +98,21 @@ def test_verilator_target_clock(capfd):
         Eval(),
         Print(circ.O),
     ]
-    run(circ, actions, flags=["-Wno-lint"])
+    run(circ, actions, target, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
     lines = out.splitlines()
 
-    assert lines[-3] == "BasicClkCircuit.I = 0", "Print output incorrect"
-    assert lines[-2] == "BasicClkCircuit.O = 0", "Print output incorrect"
-    assert lines[-1] == "BasicClkCircuit.O = 1", "Print output incorrect"
+    if target == fault.verilator_target.VerilatorTarget:
+        assert lines[-3] == "BasicClkCircuit.I = 0", out
+        assert lines[-2] == "BasicClkCircuit.O = 0", out
+        assert lines[-1] == "BasicClkCircuit.O = 1", out
+    else:
+        assert lines[-6] == "BasicClkCircuit.I = 0", out
+        assert lines[-5] == "BasicClkCircuit.O = 0", out
+        assert lines[-4] == "BasicClkCircuit.O = 1", out
 
 
-def test_verilator_print_nested_arrays(capfd):
+def test_print_nested_arrays(capfd, target):
     circ = common.TestNestedArraysCircuit
     actions = [
         Poke(circ.I, [BitVector(i, 4) for i in range(3)]),
@@ -108,9 +124,13 @@ def test_verilator_print_nested_arrays(capfd):
         Eval(),
         Print(circ.O),
     ]
-    run(circ, actions, flags=["-Wno-lint"])
+    run(circ, actions, target, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
-    assert "\n".join(out.splitlines()[-9:]) == """\
+    if target == fault.verilator_target.VerilatorTarget:
+        actual = "\n".join(out.splitlines()[-9:])
+    else:
+        actual = "\n".join(out.splitlines()[-9 - 3: -3])
+    assert actual == """\
 NestedArraysCircuit.I[0] = 0
 NestedArraysCircuit.I[1] = 1
 NestedArraysCircuit.I[2] = 2
@@ -119,10 +139,10 @@ NestedArraysCircuit.O[1] = 1
 NestedArraysCircuit.O[2] = 2
 NestedArraysCircuit.O[0] = 4
 NestedArraysCircuit.O[1] = 3
-NestedArraysCircuit.O[2] = 2""", "Print output incorrect"
+NestedArraysCircuit.O[2] = 2""", out
 
 
-def test_verilator_print_double_nested_arrays(capfd):
+def test_print_double_nested_arrays(capfd, target):
     circ = common.TestDoubleNestedArraysCircuit
     actions = [
         Poke(circ.I, [[BitVector(i + j * 3, 4) for i in range(3)]
@@ -137,10 +157,14 @@ def test_verilator_print_double_nested_arrays(capfd):
         Eval(),
         Print(circ.O),
     ]
-    run(circ, actions, flags=["-Wno-lint"])
+    run(circ, actions, target, flags=["-Wno-lint"])
     out, err = capfd.readouterr()
     print(out)
-    assert "\n".join(out.splitlines()[-18:]) == """\
+    if target == fault.verilator_target.VerilatorTarget:
+        actual = "\n".join(out.splitlines()[-18:])
+    else:
+        actual = "\n".join(out.splitlines()[-18 - 3: -3])
+    assert actual == """\
 DoubleNestedArraysCircuit.I[0][0] = 0
 DoubleNestedArraysCircuit.I[0][1] = 1
 DoubleNestedArraysCircuit.I[0][2] = 2
@@ -159,10 +183,10 @@ DoubleNestedArraysCircuit.O[0][2] = 5
 DoubleNestedArraysCircuit.O[1][0] = 6
 DoubleNestedArraysCircuit.O[1][1] = 7
 DoubleNestedArraysCircuit.O[1][2] = 8\
-""", "Print output incorrect"
+""", out
 
 
-def test_verilator_target_tuple():
+def test_target_tuple(target):
     circ = common.TestTupleCircuit
     actions = [
         Poke(circ.I.a, 5),
@@ -171,48 +195,4 @@ def test_verilator_target_tuple():
         Expect(circ.O.a, 5),
         Expect(circ.O.b, 11),
     ]
-    run(circ, actions)
-
-
-def test_verilator_trace():
-    circ = common.TestBasicClkCircuit
-    actions = [
-        Poke(circ.I, 0),
-        Print(circ.I),
-        Expect(circ.O, 0),
-        Poke(circ.CLK, 0),
-        Print(circ.O),
-        Step(circ.CLK, 1),
-        Poke(circ.I, BitVector(1, 1)),
-        Eval(),
-        Print(circ.O),
-    ]
-    flags = ["-Wno-lint", "--trace"]
-
-    with tempfile.TemporaryDirectory() as tempdir:
-        assert not os.path.isfile(f"{tempdir}/logs/BasicClkCircuit.vcd"), \
-            "Expected logs to be empty"
-        m.compile(f"{tempdir}/{circ.name}", circ,
-                  output="coreir-verilog")
-        target = fault.verilator_target.VerilatorTarget(
-            circ, directory=f"{tempdir}/",
-            flags=flags, skip_compile=True)
-        target.run(actions)
-        assert os.path.isfile(f"{tempdir}/logs/BasicClkCircuit.vcd"), \
-            "Expected VCD to exist"
-
-
-# @pytest.mark.parametrize("width", range(1, 33))
-# Select random subset of range to speed up test, TODO: Maybe actually make
-# this random
-@pytest.mark.parametrize("width", [1, 4, 5, 7, 8, 11, 13, 16, 19, 22, 24, 27,
-                                   31, 32])
-def test_verilator_target_sint_sign_extend(width):
-    circ = common.define_simple_circuit(
-        m.SInt(width), f"test_verilator_target_sint_sign_extend_{width}")
-    actions = [
-        Poke(circ.I, -2),
-        Eval(),
-        Expect(circ.O, -2),
-    ]
-    run(circ, actions)
+    run(circ, actions, target)


### PR DESCRIPTION
This PR adds initial support for commercial simulators by generating a SystemVerilog test bench.

It's been tested locally using NCSIM, before merging I'd also like to test and use VCS.

@rsetaluri There's some refactoring to do here since there's a lot of shared logic between the verilator target and the system verilog target. One nice thing is that we can use the same test suite, and parametrize over target. This means the new SV backend supports all the tests (and use cases) of the verilator backend, so any existing verilator tests should in theory be portable to this new target.

I'd also like to add some end to end tests (right now it instantiates the target directly, but we should be testing the code paths for users via the `Tester` object). One thing we should test is the ability to invoke different simulators (NCSIM vs VCS).

@rsetaluri can you review these changes with those notes in mind? @alexcarsello and @priyanka-raina have been asking for this feature, so I'd like to get the changes merged ASAP so they can start testing it out. This shouldn't affect any existing test benches, so I'm not worried about that, but may need to be careful if I end up refactoring the verilator target to share code with this new target (example the recursive array code is duplicated). So, basically I'm looking for a review (approval) on functionality/design (modulo refactoring code).