### PR TITLE
Sv include verilog

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -183,7 +183,7 @@ class SystemVerilogTarget(VerilogTarget):
         with open(test_bench_file, "w") as f:
             f.write(src)
         verilog_libraries = " ".join(str(x) for x in
-                                      self.include_verilog_libraries)
+                                     self.include_verilog_libraries)
         cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
         if self.simulator == "ncsim":
             with open(cmd_file, "w") as f:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -182,7 +182,7 @@ class SystemVerilogTarget(VerilogTarget):
         src = self.generate_code(actions)
         with open(test_bench_file, "w") as f:
             f.write(src)
-        verilog_libraries = ", ".join(str(x) for x in
+        verilog_libraries = " ".join(str(x) for x in
                                       self.include_verilog_libraries)
         cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
         if self.simulator == "ncsim":

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -182,7 +182,8 @@ class SystemVerilogTarget(VerilogTarget):
         src = self.generate_code(actions)
         with open(test_bench_file, "w") as f:
             f.write(src)
-        verilog_libraries = ", ".join(str(x) for x in self.include_verilog_libraries)
+        verilog_libraries = ", ".join(str(x) for x in
+                                      self.include_verilog_libraries)
         cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
         if self.simulator == "ncsim":
             with open(cmd_file, "w") as f:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -33,7 +33,8 @@ quit
 class SystemVerilogTarget(VerilogTarget):
     def __init__(self, circuit, circuit_name=None, directory="build/",
                  skip_compile=False, magma_output="coreir-verilog",
-                 simulator=None, timescale="1ns/1ns", clock_step_delay=5):
+                 include_verilog_libraries=[], simulator=None,
+                 timescale="1ns/1ns", clock_step_delay=5):
         """
         circuit: a magma circuit
 
@@ -56,7 +57,7 @@ class SystemVerilogTarget(VerilogTarget):
                           clock
         """
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         magma_output)
+                         include_verilog_libraries, magma_output)
         if simulator is None:
             raise ValueError("Must specify simulator when using system-verilog"
                              " target")
@@ -180,18 +181,18 @@ class SystemVerilogTarget(VerilogTarget):
         # Write the verilator driver to file.
         src = self.generate_code(actions)
         with open(test_bench_file, "w") as f:
-            print(src)
             f.write(src)
+        verilog_libraries = ", ".join(str(x) for x in self.include_verilog_libraries)
         cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
         if self.simulator == "ncsim":
             with open(cmd_file, "w") as f:
                 f.write(ncsim_cmd_string)
             cmd = f"""\
-irun -top {self.circuit_name}_tb -timescale {self.timescale} -access +rwc -notimingchecks -input {cmd_file} {test_bench_file} {self.verilog_file}
+irun -top {self.circuit_name}_tb -timescale {self.timescale} -access +rwc -notimingchecks -input {cmd_file} {test_bench_file} {self.verilog_file} {verilog_libraries}
 """  # nopep8
         else:
             cmd = f"""\
-vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-needed  {test_bench_file} {self.verilog_file}
+vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-needed  {test_bench_file} {self.verilog_file} {verilog_libraries}
 """  # nopep8
 
         print(f"Running command: {cmd}")

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -82,9 +82,8 @@ class VerilatorTarget(VerilogTarget):
                 -I<dir>                    Directory to search for includes
         """
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         magma_output)
+                         include_verilog_libraries, magma_output)
         self.flags = flags
-        self.include_verilog_libraries = include_verilog_libraries
         self.include_directories = include_directories
 
         # Compile the design using `verilator`

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -23,7 +23,8 @@ class VerilogTarget(Target):
     Provides reuseable target logic for compiling circuits into verilog files.
     """
     def __init__(self, circuit, circuit_name=None, directory="build/",
-                 skip_compile=False, magma_output="verilog"):
+                 skip_compile=False, include_verilog_libraries=[],
+                 magma_output="verilog"):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -34,6 +35,8 @@ class VerilogTarget(Target):
         self.directory = Path(directory)
 
         self.skip_compile = skip_compile
+
+        self.include_verilog_libraries = include_verilog_libraries
 
         self.magma_output = magma_output
 

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -5,7 +5,16 @@ import magma as m
 import os
 
 
-def test_include_verilog():
+def pytest_generate_tests(metafunc):
+    if "target" in metafunc.fixturenames:
+        targets = [("verilator", None)]
+        if not os.getenv("TRAVIS", False):
+            targets.append(("system-verilog", "ncsim"))
+            targets.append(("system-verilog", "vcs"))
+        metafunc.parametrize("target,simulator", targets)
+
+
+def test_include_verilog(target, simulator):
     SB_DFF = m.DeclareCircuit('SB_DFF', "D", m.In(m.Bit), "Q", m.Out(m.Bit),
                               "C", m.In(m.Clock))
     main = m.DefineCircuit('main', "I", m.In(m.Bit), "O", m.Out(m.Bit),
@@ -22,13 +31,18 @@ def test_include_verilog():
     tester.step(2)
     tester.expect(main.O, 1)
     sb_dff_filename = pathlib.Path("tests/sb_dff_sim.v").resolve()
+
+    kwargs = {}
+    if simulator is not None:
+        kwargs["simulator"] = simulator
+
     with tempfile.TemporaryDirectory() as tmp_dir:
-        tester.compile_and_run(target="verilator", directory=tmp_dir,
-                               include_verilog_libraries=[sb_dff_filename])
+        tester.compile_and_run(target=target, directory=tmp_dir,
+                               include_verilog_libraries=[sb_dff_filename], **kwargs)
 
     # Should work by including the tests/ directory which contains the verilog
     # file SB_DFF.v
     dir_path = os.path.dirname(os.path.realpath(__file__))
     with tempfile.TemporaryDirectory() as tmp_dir:
-        tester.compile_and_run(target="verilator", directory=tmp_dir,
-                               include_directories=[dir_path])
+        tester.compile_and_run(target=target, directory=tmp_dir,
+                               include_directories=[dir_path], **kwargs)

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -39,11 +39,12 @@ def test_include_verilog(target, simulator):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tester.compile_and_run(target=target, directory=tmp_dir,
-                               include_verilog_libraries=[sb_dff_filename], **kwargs)
+                               include_verilog_libraries=[sb_dff_filename],
+                               **kwargs)
 
     if target in ["verilator"]:
-        # Should work by including the tests/ directory which contains the verilog
-        # file SB_DFF.v
+        # Should work by including the tests/ directory which contains the
+        # verilog file SB_DFF.v
         dir_path = os.path.dirname(os.path.realpath(__file__))
         with tempfile.TemporaryDirectory() as tmp_dir:
             tester.compile_and_run(target=target, directory=tmp_dir,

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -25,6 +25,7 @@ def test_include_verilog(target, simulator):
     m.EndDefine()
 
     tester = fault.Tester(main, main.CLK)
+    tester.poke(main.CLK, 0)
     tester.poke(main.I, 1)
     tester.eval()
     tester.expect(main.O, 0)
@@ -40,9 +41,10 @@ def test_include_verilog(target, simulator):
         tester.compile_and_run(target=target, directory=tmp_dir,
                                include_verilog_libraries=[sb_dff_filename], **kwargs)
 
-    # Should work by including the tests/ directory which contains the verilog
-    # file SB_DFF.v
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tester.compile_and_run(target=target, directory=tmp_dir,
-                               include_directories=[dir_path], **kwargs)
+    if target in ["verilator"]:
+        # Should work by including the tests/ directory which contains the verilog
+        # file SB_DFF.v
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tester.compile_and_run(target=target, directory=tmp_dir,
+                                   include_directories=[dir_path], **kwargs)


### PR DESCRIPTION
Adds support for the `include_verilog_libraries` parameter to the system verilog target. This allows the user to provide a list of verilog files which will be passed to the simulator when running (e.g. for including standard cell libraries).

This functionality already existed for the verilator target, so I moved the interface to the `VerilogTarget` parent class and updated the test to be parametrized over target.

I have not yet added include directories because I'm not aware of how to do this with ncsim/vcs, but should be simple enough to add if we need it (and can figure out the right option to pass to the simulators).