### PR TITLE
Fix verilator peek

### DIFF
--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -128,7 +128,7 @@ class VerilatorTarget(VerilogTarget):
         name = verilog_name(action.port.name)
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f"top->{value.port.name}"
+            value = f"top->{verilog_name(value.port.name)}"
         elif isinstance(action.port, m.SIntType) and value < 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -11,6 +11,21 @@ import os.path
 import pytest
 
 
+def test_verilator_peeks():
+    circ = common.TestBasicCircuit
+    actions = [
+        Poke(circ.I, 1),
+        Expect(circ.O, Peek(circ.O))
+    ]
+    flags = ["-Wno-lint"]
+    with tempfile.TemporaryDirectory() as tempdir:
+        m.compile(f"{tempdir}/{circ.name}", circ, output="coreir-verilog")
+        target = fault.verilator_target.VerilatorTarget(
+            circ, directory=f"{tempdir}/",
+            flags=flags, skip_compile=True)
+        target.run(actions)
+
+
 def test_verilator_trace():
     circ = common.TestBasicClkCircuit
     actions = [


### PR DESCRIPTION
Fixes a bug in how we generate code for `Peek`s in the verilator backend.

https://github.com/StanfordAHA/garnet/pull/122 is blocked on this.