### PR TITLE
[system-verilog-target] Don't use directory prefix in simulator commands

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -177,16 +177,17 @@ class SystemVerilogTarget(VerilogTarget):
         return src
 
     def run(self, actions):
-        test_bench_file = self.directory / Path(f"{self.circuit_name}_tb.sv")
+        test_bench_file = Path(f"{self.circuit_name}_tb.sv")
+
         # Write the verilator driver to file.
         src = self.generate_code(actions)
-        with open(test_bench_file, "w") as f:
+        with open(self.directory / test_bench_file, "w") as f:
             f.write(src)
         verilog_libraries = " ".join(str(x) for x in
                                      self.include_verilog_libraries)
-        cmd_file = self.directory / Path(f"{self.circuit_name}_cmd.tcl")
+        cmd_file = Path(f"{self.circuit_name}_cmd.tcl")
         if self.simulator == "ncsim":
-            with open(cmd_file, "w") as f:
+            with open(self.directory / cmd_file, "w") as f:
                 f.write(ncsim_cmd_string)
             cmd = f"""\
 irun -top {self.circuit_name}_tb -timescale {self.timescale} -access +rwc -notimingchecks -input {cmd_file} {test_bench_file} {self.verilog_file} {verilog_libraries}

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -40,12 +40,12 @@ class VerilogTarget(Target):
 
         self.magma_output = magma_output
 
-        self.verilog_file = self.directory / Path(f"{self.circuit_name}.v")
+        self.verilog_file = Path(f"{self.circuit_name}.v")
         # Optionally compile this module to verilog first.
         if not self.skip_compile:
-            prefix = str(self.verilog_file)[:-2]
+            prefix = str(self.directory / self.verilog_file)[:-2]
             m.compile(prefix, self.circuit, output=self.magma_output)
-            if not self.verilog_file.is_file():
+            if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f"Compiling {self.circuit} failed")
 
     def generate_array_action_code(self, i, action):


### PR DESCRIPTION
Fixes an issue for @alexcarsello where the simulator commands were using the full path of the file names including the `self.directory` field. Because the simulator commands are run inside `self.directory`, the prefix shouldn't be included in those commands. This changes the logic to only use `self.directory` when creating the test collateral (instead of also for the simulator commands)