### PR TITLE
Add primitive support for internal signals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.9
-    - verilator
 python:
 - '3.6'
 install:
+- sudo apt-get install -y make autoconf g++ flex bison
+- wget https://www.veripool.org/ftp/verilator-4.008.tgz
+- unset VERILATOR_ROOT
+- tar xvzf verilator*.t*gz
+- cd verilator*
+- ./configure
+- make
+- sudo make install
 - wget https://raw.githubusercontent.com/phanrahan/magma/master/.travis/install_coreir.sh
 - source install_coreir.sh
 - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 - ./configure
 - make
 - sudo make install
+- cd ..
 - wget https://raw.githubusercontent.com/phanrahan/magma/master/.travis/install_coreir.sh
 - source install_coreir.sh
 - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install -r requirements.txt
 - pip install -e .
 script:
-- pytest --cov fault --codestyle fault -v --cov-report term-missing tests
+- pytest --cov fault --codestyle fault -s -v --cov-report term-missing tests
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install -r requirements.txt
 - pip install -e .
 script:
-- pytest --cov fault --codestyle fault -s -v --cov-report term-missing tests
+- pytest --cov fault --codestyle fault -v --cov-report term-missing tests
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,10 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.9
+    - verilator
 python:
 - '3.6'
 install:
-- sudo apt-get install -y make autoconf g++ flex bison
-- wget https://www.veripool.org/ftp/verilator-4.008.tgz
-- unset VERILATOR_ROOT
-- tar xvzf verilator*.t*gz
-- cd verilator*
-- ./configure
-- make
-- sudo make install
-- cd ..
 - wget https://raw.githubusercontent.com/phanrahan/magma/master/.travis/install_coreir.sh
 - source install_coreir.sh
 - pip install python-coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added preliminary support for peek and expect on internal signals and poke on
+  internal registers
+
+[Unreleased]: https://github.com/leonardt/fault/compare/v1.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -3,3 +3,67 @@
 [![Coverage Status](https://coveralls.io/repos/github/leonardt/fault/badge.svg?branch=master)](https://coveralls.io/github/leonardt/fault?branch=master)
 
 A Python package for testing hardware (part of the magma ecosystem).
+
+## Example
+Here is a simple ALU defined in magma.
+```python
+import magma as m
+import mantle
+
+
+class ConfigReg(m.Circuit):
+    IO = ["D", m.In(m.Bits(2)), "Q", m.Out(m.Bits(2))] + \
+        m.ClockInterface(has_ce=True)
+
+    @classmethod
+    def definition(io):
+        reg = mantle.Register(2, has_ce=True, name="conf_reg")
+        io.Q <= reg(io.D, CE=io.CE)
+
+
+class SimpleALU(m.Circuit):
+    IO = ["a", m.In(m.UInt(16)),
+          "b", m.In(m.UInt(16)),
+          "c", m.Out(m.UInt(16)),
+          "config_data", m.In(m.Bits(2)),
+          "config_en", m.In(m.Enable),
+          ] + m.ClockInterface()
+
+    @classmethod
+    def definition(io):
+        opcode = ConfigReg(name="config_reg")(io.config_data, CE=io.config_en)
+        io.c <= mantle.mux(
+            [io.a + io.b, io.a - io.b, io.a * io.b, io.a / io.b], opcode)
+```
+
+Here's an example test in fault that uses the configuration interface, expects
+a value on the internal register, and checks the result of performing the
+expected operation.
+
+```python
+import operator
+
+ops = [operator.add, operator.sub, operator.mul, operator.div]
+tester = Tester(SimpleALU, SimpleALU.CLK)
+tester.circuit.CLK = 0
+tester.circuit.config_en = 1
+for i in range(0, 4):
+    tester.circuit.config_data = i
+    tester.step(2)
+    tester.circuit.a = 3
+    tester.circuit.b = 2
+    tester.eval()
+    tester.circuit.c.expect(ops[i](3, 2))
+    tester.circuit.config_reg.Q.expect(i)
+    signal = tester.circuit.config_reg.Q
+    tester.circuit.config_reg.Q.expect(signal)
+```
+
+We can run this with three different simulators
+
+```python
+tester.compile_and_run("verilator", flags=["-Wno-fatal"], 
+                       magma_opts={"verilator_debug": True}, directory="build")
+tester.compile_and_run("system-verilog", simulator="ncsim", directory="build")
+tester.compile_and_run("system-verilog", simulator="vcs", directory="build")
+```

--- a/doc/actions.md
+++ b/doc/actions.md
@@ -34,9 +34,7 @@ for i in range(n):
 
 ## WrappedVerilogInternalPort
 Fault has primitive support for working with internal verilog signals using the
-`verilator` target.  Note that this has only been tested using verilator
-version 4.008 (we've seen issues using 3.856 which is installed by default
-using apt on Ubuntu 14.04).
+`verilator` target.
 
 Suppose you had a file `simple_alu.v`. Notice that the desired internal
 signals, `ConfigReg->Q` and `SimpleALU->opcode` are marked with a comment

--- a/doc/actions.md
+++ b/doc/actions.md
@@ -33,7 +33,10 @@ for i in range(n):
 `format_str` allows for user-specified formatting of the printed output (similar to `printf` format strings).
 
 ## WrappedVerilogInternalPort
-Fault has primitive support for working with internal verilog signals.
+Fault has primitive support for working with internal verilog signals using the
+`verilator` target.  Note that this has only been tested using verilator
+version 4.008 (we've seen issues using 3.856 which is installed by default
+using apt on Ubuntu 14.04).
 
 Suppose you had a file `simple_alu.v`. Notice that the desired internal
 signals, `ConfigReg->Q` and `SimpleALU->opcode` are marked with a comment

--- a/doc/actions.md
+++ b/doc/actions.md
@@ -31,3 +31,100 @@ for i in range(n):
 `Print(port, format_str)` prints the value read at `port` (`port` can be an input or an output). Similar to Expect, the values read by output ports at the time of Print are the same as those at the time of the last Eval.
 
 `format_str` allows for user-specified formatting of the printed output (similar to `printf` format strings).
+
+## WrappedVerilogInternalPort
+Fault has primitive support for working with internal verilog signals.
+
+Suppose you had a file `simple_alu.v`. Notice that the desired internal
+signals, `ConfigReg->Q` and `SimpleALU->opcode` are marked with a comment
+`/*verilator public*/`.
+
+```
+// simple_alu.v
+module ConfigReg(input [1:0] D, output [1:0] Q, input CLK, input EN);
+reg Q/*verilator public*/;
+always @(posedge CLK) begin
+    if (EN) Q <= D;
+end
+endmodule
+
+module SimpleALU(input [15:0] a, input [15:0] b, output [15:0] c, input [1:0] config_data, input config_en, input CLK);
+
+wire [1:0] opcode/*verilator public*/;
+ConfigReg config_reg(config_data, opcode, CLK, config_en);
+
+
+always @(*) begin
+    case (opcode)
+        0: c = a + b;
+        1: c = a - b;
+        2: c = a * b;
+        3: c = a / b;
+    endcase
+end
+endmodule
+```
+
+We can wrap the verilog using magma
+
+```
+SimpleALU = m.DefineFromVerilogFile("tests/simple_alu.v",
+                                    type_map={"CLK": m.In(m.Clock)},
+                                    target_modules=["SimpleALU"])[0]
+
+circ = m.DefineCircuit("top",
+                       "a", m.In(m.Bits(16)),
+                       "b", m.In(m.Bits(16)),
+                       "c", m.Out(m.Bits(16)),
+                       "config_data", m.In(m.Bits(2)),
+                       "config_en", m.In(m.Bit),
+                       "CLK", m.In(m.Clock))
+simple_alu = SimpleALU()
+m.wire(simple_alu.a, circ.a)
+m.wire(simple_alu.b, circ.b)
+m.wire(simple_alu.c, circ.c)
+m.wire(simple_alu.config_data, circ.config_data)
+m.wire(simple_alu.config_en, circ.config_en)
+m.wire(simple_alu.CLK, circ.CLK)
+m.EndDefine()
+```
+
+Here's an example test we can write using the internal signals
+
+```
+    tester = fault.Tester(circ, circ.CLK)
+    tester.verilator_include("SimpleALU")
+    tester.verilator_include("ConfigReg")
+    tester.poke(circ.config_en, 1)
+    for i in range(0, 4):
+        tester.poke(circ.config_data, i)
+        tester.step(2)
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)),
+            i)
+        signal = tester.peek(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)))
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)),
+            signal)
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)),
+            i)
+        signal = tester.peek(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)))
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)),
+            signal)
+```
+
+Notice that the test must include the desired wrapped module with the statement
+`tester.verilator_include("simple_alu")`. This is so the generated C harness
+includes the verilator generated header.  To expect or peek a port, you can use
+`WrappedVerilogInternalPort` and provide the verilator C++ style path through
+the instance hierarchy to the desired port.

--- a/doc/actions.md
+++ b/doc/actions.md
@@ -39,7 +39,7 @@ Suppose you had a file `simple_alu.v`. Notice that the desired internal
 signals, `ConfigReg->Q` and `SimpleALU->opcode` are marked with a comment
 `/*verilator public*/`.
 
-```
+```verilog
 // simple_alu.v
 module ConfigReg(input [1:0] D, output [1:0] Q, input CLK, input EN);
 reg Q/*verilator public*/;
@@ -67,7 +67,7 @@ endmodule
 
 We can wrap the verilog using magma
 
-```
+```python
 SimpleALU = m.DefineFromVerilogFile("tests/simple_alu.v",
                                     type_map={"CLK": m.In(m.Clock)},
                                     target_modules=["SimpleALU"])[0]
@@ -91,7 +91,7 @@ m.EndDefine()
 
 Here's an example test we can write using the internal signals
 
-```
+```python
     tester = fault.Tester(circ, circ.CLK)
     tester.verilator_include("SimpleALU")
     tester.verilator_include("ConfigReg")

--- a/docs/actions.html
+++ b/docs/actions.html
@@ -23,6 +23,8 @@
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">from abc import ABC, abstractmethod
+import fault
+from fault.select_path import SelectPath
 
 
 class Action(ABC):
@@ -50,9 +52,18 @@ class PortAction(Action):
         return cls(new_port, self.value)
 
 
+def can_poke(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isinput()
+    else:
+        return not port.isinput()
+
+
 class Poke(PortAction):
     def __init__(self, port, value):
-        if port.isinput():
+        if not can_poke(port):
             raise ValueError(f&#34;Can only poke inputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         super().__init__(port, value)
@@ -73,9 +84,18 @@ class Print(Action):
         return cls(new_port, self.format_str)
 
 
+def is_output(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isoutput()
+    else:
+        return not port.isoutput()
+
+
 class Expect(PortAction):
     def __init__(self, port, value):
-        if port.isoutput():
+        if not is_output(port):
             raise ValueError(f&#34;Can only expect on outputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         super().__init__(port, value)
@@ -84,7 +104,7 @@ class Expect(PortAction):
 class Peek(Action):
     def __init__(self, port):
         super().__init__()
-        if port.isoutput():
+        if not is_output(port):
             raise ValueError(f&#34;Can only peek on outputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         self.port = port
@@ -131,6 +151,41 @@ class Step(Action):
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="fault.actions.can_poke"><code class="name flex">
+<span>def <span class="ident">can_poke</span></span>(<span>port)</span>
+</code></dt>
+<dd>
+<section class="desc"></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def can_poke(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isinput()
+    else:
+        return not port.isinput()}</code></pre>
+</details>
+</dd>
+<dt id="fault.actions.is_output"><code class="name flex">
+<span>def <span class="ident">is_output</span></span>(<span>port)</span>
+</code></dt>
+<dd>
+<section class="desc"></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def is_output(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isoutput()
+    else:
+        return not port.isoutput()}</code></pre>
+</details>
+</dd>
+</dl>
 </section>
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
@@ -241,7 +296,7 @@ inheritance.</p></section>
 <summary>Source code</summary>
 <pre><code class="python">class Expect(PortAction):
     def __init__(self, port, value):
-        if port.isoutput():
+        if not is_output(port):
             raise ValueError(f&#34;Can only expect on outputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         super().__init__(port, value)}</code></pre>
@@ -272,7 +327,7 @@ inheritance.</p></section>
 <pre><code class="python">class Peek(Action):
     def __init__(self, port):
         super().__init__()
-        if port.isoutput():
+        if not is_output(port):
             raise ValueError(f&#34;Can only peek on outputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         self.port = port
@@ -300,7 +355,7 @@ See help(type(self)) for accurate signature.</p></section>
 <summary>Source code</summary>
 <pre><code class="python">def __init__(self, port):
     super().__init__()
-    if port.isoutput():
+    if not is_output(port):
         raise ValueError(f&#34;Can only peek on outputs: {port.debug_name} &#34;
                          f&#34;{type(port)}&#34;)
     self.port = port}</code></pre>
@@ -331,7 +386,7 @@ inheritance.</p></section>
 <summary>Source code</summary>
 <pre><code class="python">class Poke(PortAction):
     def __init__(self, port, value):
-        if port.isinput():
+        if not can_poke(port):
             raise ValueError(f&#34;Can only poke inputs: {port.debug_name} &#34;
                              f&#34;{type(port)}&#34;)
         super().__init__(port, value)}</code></pre>
@@ -523,6 +578,12 @@ See help(type(self)) for accurate signature.</p></section>
 <li><h3>Super-module</h3>
 <ul>
 <li><code><a title="fault" href="index.html">fault</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="fault.actions.can_poke" href="#fault.actions.can_poke">can_poke</a></code></li>
+<li><code><a title="fault.actions.is_output" href="#fault.actions.is_output">is_output</a></code></li>
 </ul>
 </li>
 <li><h3><a href="#header-classes">Classes</a></h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,18 @@
 <summary>Source code</summary>
 <pre><code class="python">from .tester import Tester
 from .value import Value, AnyValue, UnknownValue
-import fault.random}</code></pre>
+import fault.random
+
+
+class WrappedVerilogInternalPort:
+    def __init__(self, path: str, type_):
+        &#34;&#34;&#34;
+        path: &lt;instance_name&gt;.&lt;port_name&gt; (can nest instances)
+
+        type_: magma type of the signal (e.g. m.Bits(2))
+        &#34;&#34;&#34;
+        self.path = path
+        self.type_ = type_}</code></pre>
 </details>
 </section>
 <section>
@@ -63,6 +74,10 @@ import fault.random}</code></pre>
 <section class="desc"></section>
 </dd>
 <dt><code class="name"><a title="fault.random" href="random.html">fault.random</a></code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt><code class="name"><a title="fault.select_path" href="select_path.html">fault.select_path</a></code></dt>
 <dd>
 <section class="desc"></section>
 </dd>
@@ -114,6 +129,14 @@ import fault.random}</code></pre>
 <dd>
 <section class="desc"></section>
 </dd>
+<dt><code class="name"><a title="fault.verilog_utils" href="verilog_utils.html">fault.verilog_utils</a></code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
+<dt><code class="name"><a title="fault.wrapper" href="wrapper.html">fault.wrapper</a></code></dt>
+<dd>
+<section class="desc"></section>
+</dd>
 </dl>
 </section>
 <section>
@@ -121,6 +144,52 @@ import fault.random}</code></pre>
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="fault.WrappedVerilogInternalPort"><code class="flex name class">
+<span>class <span class="ident">WrappedVerilogInternalPort</span></span>
+</code></dt>
+<dd>
+<section class="desc"></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">class WrappedVerilogInternalPort:
+    def __init__(self, path: str, type_):
+        &#34;&#34;&#34;
+        path: &lt;instance_name&gt;.&lt;port_name&gt; (can nest instances)
+
+        type_: magma type of the signal (e.g. m.Bits(2))
+        &#34;&#34;&#34;
+        self.path = path
+        self.type_ = type_}</code></pre>
+</details>
+<h3>Methods</h3>
+<dl>
+<dt id="fault.WrappedVerilogInternalPort.__init__"><code class="name flex">
+<span>def <span class="ident">__init__</span></span>(<span>self, path, type_)</span>
+</code></dt>
+<dd>
+<section class="desc"><dl>
+<dt><strong><code>path</code></strong> :&ensp;&lt;<code>instance_name</code>&gt;<code>.</code>&lt;<code>port_name</code>&gt; (<code>can</code> <code>nest</code> <code>instances</code>)</dt>
+<dd>&nbsp;</dd>
+<dt><strong><code>type_</code></strong> :&ensp;<code>magma</code> <code>type</code> of <code>the</code> <code>signal</code> (<code>e.g.</code> <code>m.Bits</code>(<code>2</code>))</dt>
+<dd>&nbsp;</dd>
+</dl></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def __init__(self, path: str, type_):
+    &#34;&#34;&#34;
+    path: &lt;instance_name&gt;.&lt;port_name&gt; (can nest instances)
+
+    type_: magma type of the signal (e.g. m.Bits(2))
+    &#34;&#34;&#34;
+    self.path = path
+    self.type_ = type_}</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
 </section>
 </article>
 <nav id="sidebar">
@@ -140,6 +209,7 @@ import fault.random}</code></pre>
 <li><code><a title="fault.logging" href="logging.html">fault.logging</a></code></li>
 <li><code><a title="fault.magma_simulator_target" href="magma_simulator_target.html">fault.magma_simulator_target</a></code></li>
 <li><code><a title="fault.random" href="random.html">fault.random</a></code></li>
+<li><code><a title="fault.select_path" href="select_path.html">fault.select_path</a></code></li>
 <li><code><a title="fault.system_verilog_target" href="system_verilog_target.html">fault.system_verilog_target</a></code></li>
 <li><code><a title="fault.target" href="target.html">fault.target</a></code></li>
 <li><code><a title="fault.test_vector_generator" href="test_vector_generator.html">fault.test_vector_generator</a></code></li>
@@ -152,6 +222,18 @@ import fault.random}</code></pre>
 <li><code><a title="fault.verilator_target" href="verilator_target.html">fault.verilator_target</a></code></li>
 <li><code><a title="fault.verilator_utils" href="verilator_utils.html">fault.verilator_utils</a></code></li>
 <li><code><a title="fault.verilog_target" href="verilog_target.html">fault.verilog_target</a></code></li>
+<li><code><a title="fault.verilog_utils" href="verilog_utils.html">fault.verilog_utils</a></code></li>
+<li><code><a title="fault.wrapper" href="wrapper.html">fault.wrapper</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="fault.WrappedVerilogInternalPort" href="#fault.WrappedVerilogInternalPort">WrappedVerilogInternalPort</a></code></h4>
+<ul class="">
+<li><code><a title="fault.WrappedVerilogInternalPort.__init__" href="#fault.WrappedVerilogInternalPort.__init__">__init__</a></code></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>

--- a/docs/system_verilog_target.html
+++ b/docs/system_verilog_target.html
@@ -28,20 +28,24 @@ from pathlib import Path
 import fault.actions as actions
 from bit_vector import BitVector
 import fault.value_utils as value_utils
+from fault.select_path import SelectPath
 import subprocess
+from fault.wrapper import PortWrapper
+import fault
 
 
 src_tpl = &#34;&#34;&#34;\
 module {circuit_name}_tb;
 {declarations}
-    initial begin
-{initial_body}
-        #20 $finish;
-    end
 
     {circuit_name} dut (
         {port_list}
     );
+
+    initial begin
+{initial_body}
+        #20 $finish;
+    end
 
 endmodule
 &#34;&#34;&#34;
@@ -57,7 +61,7 @@ quit
 class SystemVerilogTarget(VerilogTarget):
     def __init__(self, circuit, circuit_name=None, directory=&#34;build/&#34;,
                  skip_compile=False, magma_output=&#34;coreir-verilog&#34;,
-                 include_verilog_libraries=[], simulator=None,
+                 magma_opts={}, include_verilog_libraries=[], simulator=None,
                  timescale=&#34;1ns/1ns&#34;, clock_step_delay=5):
         &#34;&#34;&#34;
         circuit: a magma circuit
@@ -72,6 +76,8 @@ class SystemVerilogTarget(VerilogTarget):
         magma_output: Set the output parameter to m.compile
                       (default coreir-verilog)
 
+        magma_opts: Options dictionary for `magma.compile` command
+
         simulator: &#34;ncsim&#34; or &#34;vcs&#34;
 
         timescale: Set the timescale for the verilog simulation
@@ -81,7 +87,7 @@ class SystemVerilogTarget(VerilogTarget):
                           clock
         &#34;&#34;&#34;
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output)
+                         include_verilog_libraries, magma_output, magma_opts)
         if simulator is None:
             raise ValueError(&#34;Must specify simulator when using system-verilog&#34;
                              &#34; target&#34;)
@@ -92,7 +98,12 @@ class SystemVerilogTarget(VerilogTarget):
         self.clock_step_delay = clock_step_delay
 
     def make_poke(self, i, action):
-        name = verilog_name(action.port.name)
+        if isinstance(action.port, SelectPath):
+            name = f&#34;dut.{action.port.system_verilog_path}&#34;
+        elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+            name = f&#34;dut.{action.port.path}&#34;
+        else:
+            name = verilog_name(action.port.name)
         if isinstance(action.value, BitVector) and \
                 action.value.num_bits &gt; 32:
             raise NotImplementedError()
@@ -113,10 +124,23 @@ class SystemVerilogTarget(VerilogTarget):
     def make_expect(self, i, action):
         if value_utils.is_any(action.value):
             return []
-        name = verilog_name(action.port.name)
+        if isinstance(action.port, SelectPath):
+            name = f&#34;dut.{action.port.system_verilog_path}&#34;
+            debug_name = action.port[-1].name
+        elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+            name = f&#34;dut.{action.port.path}&#34;
+            debug_name = name
+        else:
+            name = verilog_name(action.port.name)
+            debug_name = action.port.name
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f&#34;{value.port.name}&#34;
+            if isinstance(value.port, fault.WrappedVerilogInternalPort):
+                value = f&#34;dut.{value.port.path}&#34;
+            else:
+                value = f&#34;{value.port.name}&#34;
+        elif isinstance(value, PortWrapper):
+            value = f&#34;dut.{value.select_path.system_verilog_path}&#34;
         elif isinstance(action.port, m.SIntType) and value &lt; 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type
@@ -124,7 +148,7 @@ class SystemVerilogTarget(VerilogTarget):
             value = BitVector(value, port_len).as_uint()
 
         return [f&#34;if ({name} != {value}) $error(\&#34;Failed on action={i}&#34;
-                f&#34; checking port {action.port.name}. Expected %x, got %x\&#34;&#34;
+                f&#34; checking port {debug_name}. Expected %x, got %x\&#34;&#34;
                 f&#34;, {value}, {name});&#34;]
 
     def make_eval(self, i, action):
@@ -162,7 +186,7 @@ class SystemVerilogTarget(VerilogTarget):
     def generate_port_code(name, type_):
         is_array_of_bits = isinstance(type_, m.ArrayKind) and \
             not isinstance(type_.T, m.BitKind)
-        if array_of_bits or isinstance(type_, m.TupleKind):
+        if is_array_of_bits or isinstance(type_, m.TupleKind):
             return SystemVerilogTarget.generate_recursive_port_code(name, type_)
         else:
             width_str = &#34;&#34;
@@ -252,7 +276,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
 <pre><code class="python">class SystemVerilogTarget(VerilogTarget):
     def __init__(self, circuit, circuit_name=None, directory=&#34;build/&#34;,
                  skip_compile=False, magma_output=&#34;coreir-verilog&#34;,
-                 include_verilog_libraries=[], simulator=None,
+                 magma_opts={}, include_verilog_libraries=[], simulator=None,
                  timescale=&#34;1ns/1ns&#34;, clock_step_delay=5):
         &#34;&#34;&#34;
         circuit: a magma circuit
@@ -267,6 +291,8 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
         magma_output: Set the output parameter to m.compile
                       (default coreir-verilog)
 
+        magma_opts: Options dictionary for `magma.compile` command
+
         simulator: &#34;ncsim&#34; or &#34;vcs&#34;
 
         timescale: Set the timescale for the verilog simulation
@@ -276,7 +302,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
                           clock
         &#34;&#34;&#34;
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output)
+                         include_verilog_libraries, magma_output, magma_opts)
         if simulator is None:
             raise ValueError(&#34;Must specify simulator when using system-verilog&#34;
                              &#34; target&#34;)
@@ -287,7 +313,12 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
         self.clock_step_delay = clock_step_delay
 
     def make_poke(self, i, action):
-        name = verilog_name(action.port.name)
+        if isinstance(action.port, SelectPath):
+            name = f&#34;dut.{action.port.system_verilog_path}&#34;
+        elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+            name = f&#34;dut.{action.port.path}&#34;
+        else:
+            name = verilog_name(action.port.name)
         if isinstance(action.value, BitVector) and \
                 action.value.num_bits &gt; 32:
             raise NotImplementedError()
@@ -308,10 +339,23 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
     def make_expect(self, i, action):
         if value_utils.is_any(action.value):
             return []
-        name = verilog_name(action.port.name)
+        if isinstance(action.port, SelectPath):
+            name = f&#34;dut.{action.port.system_verilog_path}&#34;
+            debug_name = action.port[-1].name
+        elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+            name = f&#34;dut.{action.port.path}&#34;
+            debug_name = name
+        else:
+            name = verilog_name(action.port.name)
+            debug_name = action.port.name
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f&#34;{value.port.name}&#34;
+            if isinstance(value.port, fault.WrappedVerilogInternalPort):
+                value = f&#34;dut.{value.port.path}&#34;
+            else:
+                value = f&#34;{value.port.name}&#34;
+        elif isinstance(value, PortWrapper):
+            value = f&#34;dut.{value.select_path.system_verilog_path}&#34;
         elif isinstance(action.port, m.SIntType) and value &lt; 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type
@@ -319,7 +363,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
             value = BitVector(value, port_len).as_uint()
 
         return [f&#34;if ({name} != {value}) $error(\&#34;Failed on action={i}&#34;
-                f&#34; checking port {action.port.name}. Expected %x, got %x\&#34;&#34;
+                f&#34; checking port {debug_name}. Expected %x, got %x\&#34;&#34;
                 f&#34;, {value}, {name});&#34;]
 
     def make_eval(self, i, action):
@@ -357,7 +401,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
     def generate_port_code(name, type_):
         is_array_of_bits = isinstance(type_, m.ArrayKind) and \
             not isinstance(type_.T, m.BitKind)
-        if array_of_bits or isinstance(type_, m.TupleKind):
+        if is_array_of_bits or isinstance(type_, m.TupleKind):
             return SystemVerilogTarget.generate_recursive_port_code(name, type_)
         else:
             width_str = &#34;&#34;
@@ -435,7 +479,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
 def generate_port_code(name, type_):
     is_array_of_bits = isinstance(type_, m.ArrayKind) and \
         not isinstance(type_.T, m.BitKind)
-    if array_of_bits or isinstance(type_, m.TupleKind):
+    if is_array_of_bits or isinstance(type_, m.TupleKind):
         return SystemVerilogTarget.generate_recursive_port_code(name, type_)
     else:
         width_str = &#34;&#34;
@@ -483,7 +527,7 @@ def generate_recursive_port_code(name, type_):
 <h3>Methods</h3>
 <dl>
 <dt id="fault.system_verilog_target.SystemVerilogTarget.__init__"><code class="name flex">
-<span>def <span class="ident">__init__</span></span>(<span>self, circuit, circuit_name=None, directory=&#39;build/&#39;, skip_compile=False, magma_output=&#39;coreir-verilog&#39;, include_verilog_libraries=[], simulator=None, timescale=&#39;1ns/1ns&#39;, clock_step_delay=5)</span>
+<span>def <span class="ident">__init__</span></span>(<span>self, circuit, circuit_name=None, directory=&#39;build/&#39;, skip_compile=False, magma_output=&#39;coreir-verilog&#39;, magma_opts={}, include_verilog_libraries=[], simulator=None, timescale=&#39;1ns/1ns&#39;, clock_step_delay=5)</span>
 </code></dt>
 <dd>
 <section class="desc"><dl>
@@ -497,6 +541,8 @@ def generate_recursive_port_code(name, type_):
 <dd>&nbsp;</dd>
 <dt><strong><code>magma_output</code></strong> :&ensp;<code>Set</code> <code>the</code> <code>output</code> <code>parameter</code> <code>to</code> <code>m.compile</code></dt>
 <dd>(default coreir-verilog)</dd>
+<dt><strong><code>magma_opts</code></strong> :&ensp;<code>Options</code> <code>dictionary</code> <code>for</code> <code>magma.compile</code> <code>command</code></dt>
+<dd>&nbsp;</dd>
 <dt><strong><code>simulator</code></strong> :&ensp;<code>"ncsim"</code> or <code>"vcs"</code></dt>
 <dd>&nbsp;</dd>
 <dt><strong><code>timescale</code></strong> :&ensp;<code>Set</code> <code>the</code> <code>timescale</code> <code>for</code> <code>the</code> <code>verilog</code> <code>simulation</code></dt>
@@ -508,7 +554,7 @@ def generate_recursive_port_code(name, type_):
 <summary>Source code</summary>
 <pre><code class="python">def __init__(self, circuit, circuit_name=None, directory=&#34;build/&#34;,
              skip_compile=False, magma_output=&#34;coreir-verilog&#34;,
-             include_verilog_libraries=[], simulator=None,
+             magma_opts={}, include_verilog_libraries=[], simulator=None,
              timescale=&#34;1ns/1ns&#34;, clock_step_delay=5):
     &#34;&#34;&#34;
     circuit: a magma circuit
@@ -523,6 +569,8 @@ def generate_recursive_port_code(name, type_):
     magma_output: Set the output parameter to m.compile
                   (default coreir-verilog)
 
+    magma_opts: Options dictionary for `magma.compile` command
+
     simulator: &#34;ncsim&#34; or &#34;vcs&#34;
 
     timescale: Set the timescale for the verilog simulation
@@ -532,7 +580,7 @@ def generate_recursive_port_code(name, type_):
                       clock
     &#34;&#34;&#34;
     super().__init__(circuit, circuit_name, directory, skip_compile,
-                     include_verilog_libraries, magma_output)
+                     include_verilog_libraries, magma_output, magma_opts)
     if simulator is None:
         raise ValueError(&#34;Must specify simulator when using system-verilog&#34;
                          &#34; target&#34;)
@@ -596,10 +644,23 @@ def generate_recursive_port_code(name, type_):
 <pre><code class="python">def make_expect(self, i, action):
     if value_utils.is_any(action.value):
         return []
-    name = verilog_name(action.port.name)
+    if isinstance(action.port, SelectPath):
+        name = f&#34;dut.{action.port.system_verilog_path}&#34;
+        debug_name = action.port[-1].name
+    elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+        name = f&#34;dut.{action.port.path}&#34;
+        debug_name = name
+    else:
+        name = verilog_name(action.port.name)
+        debug_name = action.port.name
     value = action.value
     if isinstance(value, actions.Peek):
-        value = f&#34;{value.port.name}&#34;
+        if isinstance(value.port, fault.WrappedVerilogInternalPort):
+            value = f&#34;dut.{value.port.path}&#34;
+        else:
+            value = f&#34;{value.port.name}&#34;
+    elif isinstance(value, PortWrapper):
+        value = f&#34;dut.{value.select_path.system_verilog_path}&#34;
     elif isinstance(action.port, m.SIntType) and value &lt; 0:
         # Handle sign extension for verilator since it expects and
         # unsigned c type
@@ -607,7 +668,7 @@ def generate_recursive_port_code(name, type_):
         value = BitVector(value, port_len).as_uint()
 
     return [f&#34;if ({name} != {value}) $error(\&#34;Failed on action={i}&#34;
-            f&#34; checking port {action.port.name}. Expected %x, got %x\&#34;&#34;
+            f&#34; checking port {debug_name}. Expected %x, got %x\&#34;&#34;
             f&#34;, {value}, {name});&#34;]}</code></pre>
 </details>
 </dd>
@@ -619,7 +680,12 @@ def generate_recursive_port_code(name, type_):
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def make_poke(self, i, action):
-    name = verilog_name(action.port.name)
+    if isinstance(action.port, SelectPath):
+        name = f&#34;dut.{action.port.system_verilog_path}&#34;
+    elif isinstance(action.port, fault.WrappedVerilogInternalPort):
+        name = f&#34;dut.{action.port.path}&#34;
+    else:
+        name = verilog_name(action.port.name)
     if isinstance(action.value, BitVector) and \
             action.value.num_bits &gt; 32:
         raise NotImplementedError()

--- a/docs/tester.html
+++ b/docs/tester.html
@@ -32,6 +32,8 @@ from fault.verilator_target import VerilatorTarget
 from fault.system_verilog_target import SystemVerilogTarget
 from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
+from fault.select_path import SelectPath
+from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 import copy
 
 
@@ -75,13 +77,15 @@ class Tester:
         `default_print_format_str`: optional, this sets the default format
             string used for the `print` method
         &#34;&#34;&#34;
-        self.circuit = circuit
+        self._circuit = circuit
         self.actions = []
         if clock is not None and not isinstance(clock, m.ClockType):
             raise TypeError(f&#34;Expected clock port: {clock, type(clock)}&#34;)
         self.clock = clock
         self.default_print_format_str = default_print_format_str
         self.targets = {}
+        # For public verilator modules
+        self.verilator_includes = []
 
     def make_target(self, target: str, **kwargs):
         &#34;&#34;&#34;
@@ -92,15 +96,15 @@ class Tester:
             &#34;system-verilog&#34;
         &#34;&#34;&#34;
         if target == &#34;verilator&#34;:
-            return VerilatorTarget(self.circuit, **kwargs)
+            return VerilatorTarget(self._circuit, **kwargs)
         elif target == &#34;coreir&#34;:
-            return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+            return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                         backend=&#39;coreir&#39;, **kwargs)
         elif target == &#34;python&#34;:
-            return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+            return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                         backend=&#39;python&#39;, **kwargs)
         elif target == &#34;system-verilog&#34;:
-            return SystemVerilogTarget(self.circuit, **kwargs)
+            return SystemVerilogTarget(self._circuit, **kwargs)
         raise NotImplementedError(target)
 
     def poke(self, port, value):
@@ -131,7 +135,9 @@ class Tester:
         &#34;&#34;&#34;
         Expect the current value of `port` to be `value`
         &#34;&#34;&#34;
-        if not isinstance(value, actions.Peek):
+        is_peek = isinstance(value, actions.Peek)
+        is_port_wrapper = isinstance(value, PortWrapper)
+        if not (is_peek or is_port_wrapper):
             value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 
@@ -154,7 +160,7 @@ class Tester:
         &#34;&#34;&#34;
         Serialize the action sequence into a set of test vectors
         &#34;&#34;&#34;
-        builder = VectorBuilder(self.circuit)
+        builder = VectorBuilder(self._circuit)
         for action in self.actions:
             builder.process(action)
         return builder.vectors
@@ -177,7 +183,10 @@ class Tester:
         should call `compile` with `target` before calling `run`.
         &#34;&#34;&#34;
         try:
-            self.targets[target].run(self.actions)
+            if target == &#34;verilator&#34;:
+                self.targets[target].run(self.actions, self.verilator_includes)
+            else:
+                self.targets[target].run(self.actions)
         except KeyError:
             raise Exception(f&#34;Could not find target={target}, did you compile&#34;
                             &#34; it first?&#34;)
@@ -194,10 +203,10 @@ class Tester:
         Generates a new instance of the Tester object that targets
         `new_circuit`. This allows you to copy a set of actions for a new
         circuit with the same interface (or an interface that is a super set of
-        self.circuit)
+        self._circuit)
         &#34;&#34;&#34;
-        # Check that the interface of self.circuit is a subset of new_circuit
-        check_interface_is_subset(self.circuit, new_circuit)
+        # Check that the interface of self._circuit is a subset of new_circuit
+        check_interface_is_subset(self._circuit, new_circuit)
 
         new_tester = Tester(new_circuit, clock, self.default_print_format_str)
         new_tester.actions = [action.retarget(new_circuit, clock) for action in
@@ -209,9 +218,9 @@ class Tester:
         Set all the input ports to 0, useful for intiializing everything to a
         known value
         &#34;&#34;&#34;
-        for name, port in self.circuit.IO.ports.items():
+        for name, port in self._circuit.IO.ports.items():
             if port.isinput():
-                self.poke(self.circuit.interface.ports[name], 0)
+                self.poke(self._circuit.interface.ports[name], 0)
 
     def clear(self):
         &#34;&#34;&#34;
@@ -229,7 +238,14 @@ class Tester:
         s += &#34;Actions:\n&#34;
         for i, action in enumerate(self.actions):
             s += f&#34;    {i}: {action}\n&#34;
-        return s}</code></pre>
+        return s
+
+    def verilator_include(self, module_name):
+        self.verilator_includes.append(module_name)
+
+    @property
+    def circuit(self):
+        return CircuitWrapper(self._circuit, self)}</code></pre>
 </details>
 </section>
 <section>
@@ -312,13 +328,15 @@ execution of tests.</p>
         `default_print_format_str`: optional, this sets the default format
             string used for the `print` method
         &#34;&#34;&#34;
-        self.circuit = circuit
+        self._circuit = circuit
         self.actions = []
         if clock is not None and not isinstance(clock, m.ClockType):
             raise TypeError(f&#34;Expected clock port: {clock, type(clock)}&#34;)
         self.clock = clock
         self.default_print_format_str = default_print_format_str
         self.targets = {}
+        # For public verilator modules
+        self.verilator_includes = []
 
     def make_target(self, target: str, **kwargs):
         &#34;&#34;&#34;
@@ -329,15 +347,15 @@ execution of tests.</p>
             &#34;system-verilog&#34;
         &#34;&#34;&#34;
         if target == &#34;verilator&#34;:
-            return VerilatorTarget(self.circuit, **kwargs)
+            return VerilatorTarget(self._circuit, **kwargs)
         elif target == &#34;coreir&#34;:
-            return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+            return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                         backend=&#39;coreir&#39;, **kwargs)
         elif target == &#34;python&#34;:
-            return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+            return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                         backend=&#39;python&#39;, **kwargs)
         elif target == &#34;system-verilog&#34;:
-            return SystemVerilogTarget(self.circuit, **kwargs)
+            return SystemVerilogTarget(self._circuit, **kwargs)
         raise NotImplementedError(target)
 
     def poke(self, port, value):
@@ -368,7 +386,9 @@ execution of tests.</p>
         &#34;&#34;&#34;
         Expect the current value of `port` to be `value`
         &#34;&#34;&#34;
-        if not isinstance(value, actions.Peek):
+        is_peek = isinstance(value, actions.Peek)
+        is_port_wrapper = isinstance(value, PortWrapper)
+        if not (is_peek or is_port_wrapper):
             value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 
@@ -391,7 +411,7 @@ execution of tests.</p>
         &#34;&#34;&#34;
         Serialize the action sequence into a set of test vectors
         &#34;&#34;&#34;
-        builder = VectorBuilder(self.circuit)
+        builder = VectorBuilder(self._circuit)
         for action in self.actions:
             builder.process(action)
         return builder.vectors
@@ -414,7 +434,10 @@ execution of tests.</p>
         should call `compile` with `target` before calling `run`.
         &#34;&#34;&#34;
         try:
-            self.targets[target].run(self.actions)
+            if target == &#34;verilator&#34;:
+                self.targets[target].run(self.actions, self.verilator_includes)
+            else:
+                self.targets[target].run(self.actions)
         except KeyError:
             raise Exception(f&#34;Could not find target={target}, did you compile&#34;
                             &#34; it first?&#34;)
@@ -431,10 +454,10 @@ execution of tests.</p>
         Generates a new instance of the Tester object that targets
         `new_circuit`. This allows you to copy a set of actions for a new
         circuit with the same interface (or an interface that is a super set of
-        self.circuit)
+        self._circuit)
         &#34;&#34;&#34;
-        # Check that the interface of self.circuit is a subset of new_circuit
-        check_interface_is_subset(self.circuit, new_circuit)
+        # Check that the interface of self._circuit is a subset of new_circuit
+        check_interface_is_subset(self._circuit, new_circuit)
 
         new_tester = Tester(new_circuit, clock, self.default_print_format_str)
         new_tester.actions = [action.retarget(new_circuit, clock) for action in
@@ -446,9 +469,9 @@ execution of tests.</p>
         Set all the input ports to 0, useful for intiializing everything to a
         known value
         &#34;&#34;&#34;
-        for name, port in self.circuit.IO.ports.items():
+        for name, port in self._circuit.IO.ports.items():
             if port.isinput():
-                self.poke(self.circuit.interface.ports[name], 0)
+                self.poke(self._circuit.interface.ports[name], 0)
 
     def clear(self):
         &#34;&#34;&#34;
@@ -466,8 +489,28 @@ execution of tests.</p>
         s += &#34;Actions:\n&#34;
         for i, action in enumerate(self.actions):
             s += f&#34;    {i}: {action}\n&#34;
-        return s}</code></pre>
+        return s
+
+    def verilator_include(self, module_name):
+        self.verilator_includes.append(module_name)
+
+    @property
+    def circuit(self):
+        return CircuitWrapper(self._circuit, self)}</code></pre>
 </details>
+<h3>Instance variables</h3>
+<dl>
+<dt id="fault.tester.Tester.circuit"><code class="name">var <span class="ident">circuit</span></code></dt>
+<dd>
+<section class="desc"></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">@property
+def circuit(self):
+    return CircuitWrapper(self._circuit, self)}</code></pre>
+</details>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="fault.tester.Tester.__init__"><code class="name flex">
@@ -488,13 +531,15 @@ string used for the <code>print</code> method</p></section>
     `default_print_format_str`: optional, this sets the default format
         string used for the `print` method
     &#34;&#34;&#34;
-    self.circuit = circuit
+    self._circuit = circuit
     self.actions = []
     if clock is not None and not isinstance(clock, m.ClockType):
         raise TypeError(f&#34;Expected clock port: {clock, type(clock)}&#34;)
     self.clock = clock
     self.default_print_format_str = default_print_format_str
-    self.targets = {}}</code></pre>
+    self.targets = {}
+    # For public verilator modules
+    self.verilator_includes = []}</code></pre>
 </details>
 </dd>
 <dt id="fault.tester.Tester.clear"><code class="name flex">
@@ -579,7 +624,9 @@ this avoids having to call verilator multiple times)</p></section>
     &#34;&#34;&#34;
     Expect the current value of `port` to be `value`
     &#34;&#34;&#34;
-    if not isinstance(value, actions.Peek):
+    is_peek = isinstance(value, actions.Peek)
+    is_port_wrapper = isinstance(value, PortWrapper)
+    if not (is_peek or is_port_wrapper):
         value = make_value(port, value)
     self.actions.append(actions.Expect(port, value))}</code></pre>
 </details>
@@ -603,15 +650,15 @@ corresponding target object.</p>
         &#34;system-verilog&#34;
     &#34;&#34;&#34;
     if target == &#34;verilator&#34;:
-        return VerilatorTarget(self.circuit, **kwargs)
+        return VerilatorTarget(self._circuit, **kwargs)
     elif target == &#34;coreir&#34;:
-        return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+        return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                     backend=&#39;coreir&#39;, **kwargs)
     elif target == &#34;python&#34;:
-        return MagmaSimulatorTarget(self.circuit, clock=self.clock,
+        return MagmaSimulatorTarget(self._circuit, clock=self.clock,
                                     backend=&#39;python&#39;, **kwargs)
     elif target == &#34;system-verilog&#34;:
-        return SystemVerilogTarget(self.circuit, **kwargs)
+        return SystemVerilogTarget(self._circuit, **kwargs)
     raise NotImplementedError(target)}</code></pre>
 </details>
 </dd>
@@ -672,7 +719,7 @@ corresponding target object.</p>
 <section class="desc"><p>Generates a new instance of the Tester object that targets
 <code>new_circuit</code>. This allows you to copy a set of actions for a new
 circuit with the same interface (or an interface that is a super set of
-self.circuit)</p></section>
+self._circuit)</p></section>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def retarget(self, new_circuit, clock=None):
@@ -680,10 +727,10 @@ self.circuit)</p></section>
     Generates a new instance of the Tester object that targets
     `new_circuit`. This allows you to copy a set of actions for a new
     circuit with the same interface (or an interface that is a super set of
-    self.circuit)
+    self._circuit)
     &#34;&#34;&#34;
-    # Check that the interface of self.circuit is a subset of new_circuit
-    check_interface_is_subset(self.circuit, new_circuit)
+    # Check that the interface of self._circuit is a subset of new_circuit
+    check_interface_is_subset(self._circuit, new_circuit)
 
     new_tester = Tester(new_circuit, clock, self.default_print_format_str)
     new_tester.actions = [action.retarget(new_circuit, clock) for action in
@@ -706,7 +753,10 @@ should call <code>compile</code> with <code>target</code> before calling <code>r
     should call `compile` with `target` before calling `run`.
     &#34;&#34;&#34;
     try:
-        self.targets[target].run(self.actions)
+        if target == &#34;verilator&#34;:
+            self.targets[target].run(self.actions, self.verilator_includes)
+        else:
+            self.targets[target].run(self.actions)
     except KeyError:
         raise Exception(f&#34;Could not find target={target}, did you compile&#34;
                         &#34; it first?&#34;)}</code></pre>
@@ -723,7 +773,7 @@ should call <code>compile</code> with <code>target</code> before calling <code>r
     &#34;&#34;&#34;
     Serialize the action sequence into a set of test vectors
     &#34;&#34;&#34;
-    builder = VectorBuilder(self.circuit)
+    builder = VectorBuilder(self._circuit)
     for action in self.actions:
         builder.process(action)
     return builder.vectors}</code></pre>
@@ -746,6 +796,17 @@ should call <code>compile</code> with <code>target</code> before calling <code>r
     self.actions.append(actions.Step(self.clock, steps))}</code></pre>
 </details>
 </dd>
+<dt id="fault.tester.Tester.verilator_include"><code class="name flex">
+<span>def <span class="ident">verilator_include</span></span>(<span>self, module_name)</span>
+</code></dt>
+<dd>
+<section class="desc"></section>
+<details class="source">
+<summary>Source code</summary>
+<pre><code class="python">def verilator_include(self, module_name):
+    self.verilator_includes.append(module_name)}</code></pre>
+</details>
+</dd>
 <dt id="fault.tester.Tester.zero_inputs"><code class="name flex">
 <span>def <span class="ident">zero_inputs</span></span>(<span>self)</span>
 </code></dt>
@@ -759,9 +820,9 @@ known value</p></section>
     Set all the input ports to 0, useful for intiializing everything to a
     known value
     &#34;&#34;&#34;
-    for name, port in self.circuit.IO.ports.items():
+    for name, port in self._circuit.IO.ports.items():
         if port.isinput():
-            self.poke(self.circuit.interface.ports[name], 0)}</code></pre>
+            self.poke(self._circuit.interface.ports[name], 0)}</code></pre>
 </details>
 </dd>
 </dl>
@@ -786,6 +847,7 @@ known value</p></section>
 <h4><code><a title="fault.tester.Tester" href="#fault.tester.Tester">Tester</a></code></h4>
 <ul class="two-column">
 <li><code><a title="fault.tester.Tester.__init__" href="#fault.tester.Tester.__init__">__init__</a></code></li>
+<li><code><a title="fault.tester.Tester.circuit" href="#fault.tester.Tester.circuit">circuit</a></code></li>
 <li><code><a title="fault.tester.Tester.clear" href="#fault.tester.Tester.clear">clear</a></code></li>
 <li><code><a title="fault.tester.Tester.compile" href="#fault.tester.Tester.compile">compile</a></code></li>
 <li><code><a title="fault.tester.Tester.compile_and_run" href="#fault.tester.Tester.compile_and_run">compile_and_run</a></code></li>
@@ -799,6 +861,7 @@ known value</p></section>
 <li><code><a title="fault.tester.Tester.run" href="#fault.tester.Tester.run">run</a></code></li>
 <li><code><a title="fault.tester.Tester.serialize" href="#fault.tester.Tester.serialize">serialize</a></code></li>
 <li><code><a title="fault.tester.Tester.step" href="#fault.tester.Tester.step">step</a></code></li>
+<li><code><a title="fault.tester.Tester.verilator_include" href="#fault.tester.Tester.verilator_include">verilator_include</a></code></li>
 <li><code><a title="fault.tester.Tester.zero_inputs" href="#fault.tester.Tester.zero_inputs">zero_inputs</a></code></li>
 </ul>
 </li>

--- a/docs/value_utils.html
+++ b/docs/value_utils.html
@@ -22,18 +22,25 @@
 <section id="section-intro">
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">import magma
+<pre><code class="python">import fault
+import magma
 from bit_vector import BitVector
 from fault.value import AnyValue, UnknownValue
 from fault.array import Array
+from fault.select_path import SelectPath
 
 
 def make_value(port, value):
-    if isinstance(port, (magma._BitType, magma._BitKind)):
+    switch = port
+    if isinstance(switch, SelectPath):
+        switch = switch[-1]
+    if isinstance(switch, fault.WrappedVerilogInternalPort):
+        switch = switch.type_
+    if isinstance(switch, (magma._BitType, magma._BitKind)):
         return make_bit(value)
-    if isinstance(port, (magma.ArrayType, magma.ArrayKind)):
-        return make_array(port.T, port.N, value)
-    raise NotImplementedError(port, value)
+    if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):
+        return make_array(switch.T, switch.N, value)
+    raise NotImplementedError(switch, value)
 
 
 def make_bit(value):
@@ -163,11 +170,16 @@ def is_any(value):
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def make_value(port, value):
-    if isinstance(port, (magma._BitType, magma._BitKind)):
+    switch = port
+    if isinstance(switch, SelectPath):
+        switch = switch[-1]
+    if isinstance(switch, fault.WrappedVerilogInternalPort):
+        switch = switch.type_
+    if isinstance(switch, (magma._BitType, magma._BitKind)):
         return make_bit(value)
-    if isinstance(port, (magma.ArrayType, magma.ArrayKind)):
-        return make_array(port.T, port.N, value)
-    raise NotImplementedError(port, value)}</code></pre>
+    if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):
+        return make_array(switch.T, switch.N, value)
+    raise NotImplementedError(switch, value)}</code></pre>
 </details>
 </dd>
 </dl>

--- a/docs/verilator_target.html
+++ b/docs/verilator_target.html
@@ -22,7 +22,8 @@
 <section id="section-intro">
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">from .array import Array
+<pre><code class="python">import fault
+from .array import Array
 from pathlib import Path
 import subprocess
 import magma as m
@@ -30,8 +31,11 @@ import fault.actions as actions
 from fault.verilog_target import VerilogTarget, verilog_name
 import fault.value_utils as value_utils
 import fault.verilator_utils as verilator_utils
+from fault.select_path import SelectPath
+from fault.wrapper import PortWrapper, InstanceWrapper
 import math
 from bit_vector import BitVector, SIntVector
+import subprocess
 
 
 src_tpl = &#34;&#34;&#34;\
@@ -94,7 +98,7 @@ class VerilatorTarget(VerilogTarget):
     def __init__(self, circuit, directory=&#34;build/&#34;,
                  flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output=&#34;coreir-verilog&#34;,
-                 circuit_name=None):
+                 circuit_name=None, magma_opts={}):
         &#34;&#34;&#34;
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -106,7 +110,7 @@ class VerilatorTarget(VerilogTarget):
                 -I&lt;dir&gt;                    Directory to search for includes
         &#34;&#34;&#34;
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output)
+                         include_verilog_libraries, magma_output, magma_opts)
         self.flags = flags
         self.include_directories = include_directories
 
@@ -118,9 +122,45 @@ class VerilatorTarget(VerilogTarget):
             driver_file.name, self.flags)
         if self.run_from_directory(verilator_cmd):
             raise Exception(f&#34;Running verilator cmd {verilator_cmd} failed&#34;)
+        self.debug_includes = set()
+        verilator_version = subprocess.check_output(&#34;verilator --version&#34;,
+                                                    shell=True)
+        # Need to check version since they changed how internal signal access
+        # works
+        self.verilator_version = float(verilator_version.split()[1])
 
     def make_poke(self, i, action):
-        name = verilog_name(action.port.name)
+        if self.verilator_version &gt; 3.874:
+            prefix = f&#34;{self.circuit_name}&#34;
+        else:
+            prefix = f&#34;v&#34;
+        if isinstance(action.port, fault.WrappedVerilogInternalPort):
+            path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+            name = f&#34;{prefix}-&gt;{path}&#34;
+        elif isinstance(action.port, SelectPath):
+            # TODO: Find the version that they changed this, 3.874 is known to
+            # use top-&gt;v instead of top-&gt;{circuit_name}
+            name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+            self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+            for item in action.port[1:-1]:
+                circuit = type(item.instance)
+                circuit_name = circuit.verilog_name
+                # Verilator specializes each parametrization into a separate
+                # mdoule, this is an attempt to reverse engineer the naming
+                # scheme
+                if circuit_name == &#34;coreir_reg&#34;:
+                    circuit_name += &#34;_&#34;
+                    circuit_name += f&#34;_I{circuit.coreir_configargs[&#39;init&#39;]}&#34;
+                    circuit_name += f&#34;_W{circuit.coreir_genargs[&#39;width&#39;]}&#34;
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+        else:
+            name = verilog_name(action.port.name)
+
+        # Special case poking internal registers
+        is_reg_poke = isinstance(action.port, SelectPath) and \
+            isinstance(action.port[-1], fault.WrappedVerilogInternalPort) \
+            and action.port[-1].path == &#34;outReg&#34;
+
         if isinstance(action.value, BitVector) and \
                 action.value.num_bits &gt; 32:
             asserts = []
@@ -128,6 +168,8 @@ class VerilatorTarget(VerilogTarget):
                 value = action.value[i * 32:min(
                     (i + 1) * 32, action.value.num_bits)]
                 asserts += [f&#34;top-&gt;{name}[{i}] = {value};&#34;]
+            if is_reg_poke:
+                raise NotImplementedError()
             return asserts
         else:
             value = action.value
@@ -136,7 +178,20 @@ class VerilatorTarget(VerilogTarget):
                 # unsigned c type
                 port_len = len(action.port)
                 value = BitVector(value, port_len).as_uint()
-            return [f&#34;top-&gt;{name} = {value};&#34;]
+            result = [f&#34;top-&gt;{name} = {value};&#34;]
+            # Hack to support verilator&#39;s semantics, need to set the register
+            # mux values for expected behavior
+            if is_reg_poke:
+                action.port[-1].path = &#34;out&#34;
+                result += self.make_poke(i, action)
+                action.port[-1].path = &#34;in&#34;
+                result += self.make_poke(i, action)
+                if &#34;enable_mux&#34; in action.port[-3].instance_map:
+                    mux_inst = action.port[-3].instance_map[&#34;enable_mux&#34;]
+                    action.port[-2] = InstanceWrapper(mux_inst, action.port[-3])
+                    action.port[-1] = type(mux_inst).I0
+                    result += self.make_poke(i, action)
+            return result
 
     def make_print(self, i, action):
         name = verilog_name(action.port.name)
@@ -148,10 +203,41 @@ class VerilatorTarget(VerilogTarget):
         # perform the expect.
         if value_utils.is_any(action.value):
             return []
-        name = verilog_name(action.port.name)
+        if self.verilator_version &gt; 3.874:
+            prefix = f&#34;{self.circuit_name}&#34;
+        else:
+            prefix = f&#34;v&#34;
+        if isinstance(action.port, fault.WrappedVerilogInternalPort):
+            path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+            name = f&#34;{prefix}-&gt;{path}&#34;
+            debug_name = name
+        elif isinstance(action.port, SelectPath):
+            name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+            self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+            for item in action.port[1:-1]:
+                circuit_name = type(item.instance).name
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+            debug_name = action.port[-1].debug_name
+        else:
+            name = verilog_name(action.port.name)
+            debug_name = action.port.debug_name
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+            if isinstance(value.port, fault.WrappedVerilogInternalPort):
+                path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+                value = f&#34;top-&gt;{prefix}-&gt;{path}&#34;
+            else:
+                value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+        elif isinstance(value, PortWrapper):
+            self.debug_includes.add(f&#34;{value.select_path[0].circuit.name}&#34;)
+            for item in value.select_path[1:-1]:
+                circuit_name = type(item.instance).name
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+            if self.verilator_version &gt; 3.874:
+                prefix = f&#34;{self.circuit_name}&#34;
+            else:
+                prefix = f&#34;v&#34;
+            value = f&#34;top-&gt;{prefix}-&gt;&#34; + value.select_path.verilator_path
         elif isinstance(action.port, m.SIntType) and value &lt; 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type
@@ -159,7 +245,7 @@ class VerilatorTarget(VerilogTarget):
             value = BitVector(value, port_len).as_uint()
 
         return [f&#34;my_assert(top-&gt;{name}, {value}, &#34;
-                f&#34;{i}, \&#34;{action.port.name}\&#34;);&#34;]
+                f&#34;{i}, \&#34;{debug_name}\&#34;);&#34;]
 
     def make_eval(self, i, action):
         return [&#34;top-&gt;eval();&#34;, &#34;main_time++;&#34;, &#34;#if VM_TRACE&#34;,
@@ -177,9 +263,15 @@ class VerilatorTarget(VerilogTarget):
             code.append(f&#34;top-&gt;{name} ^= 1;&#34;)
         return code
 
-    def generate_code(self, actions):
+    def generate_code(self, actions, verilator_includes):
+        if verilator_includes:
+            # Include the top circuit by default
+            verilator_includes.insert(
+                0, f&#39;{self.circuit_name}&#39;)
         includes = [
             f&#39;&#34;V{self.circuit_name}.h&#34;&#39;,
+        ] + [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+             verilator_includes] + [
             &#39;&#34;verilated.h&#34;&#39;,
             &#39;&lt;iostream&gt;&#39;,
             &#39;&lt;verilated_vcd_c.h&gt;&#39;,
@@ -193,6 +285,9 @@ class VerilatorTarget(VerilogTarget):
             for line in code:
                 main_body += f&#34;  {line}\n&#34;
 
+        includes += [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+                     self.debug_includes]
+
         includes_src = &#34;\n&#34;.join([&#34;#include &#34; + i for i in includes])
         src = src_tpl.format(
             includes=includes_src,
@@ -205,10 +300,10 @@ class VerilatorTarget(VerilogTarget):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self, actions):
+    def run(self, actions, verilator_includes=[]):
         driver_file = self.directory / Path(f&#34;{self.circuit_name}_driver.cpp&#34;)
         # Write the verilator driver to file.
-        src = self.generate_code(actions)
+        src = self.generate_code(actions, verilator_includes)
         with open(driver_file, &#34;w&#34;) as f:
             f.write(src)
         # Run a series of commands: run the Makefile output by verilator, and
@@ -244,7 +339,7 @@ class VerilatorTarget(VerilogTarget):
     def __init__(self, circuit, directory=&#34;build/&#34;,
                  flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output=&#34;coreir-verilog&#34;,
-                 circuit_name=None):
+                 circuit_name=None, magma_opts={}):
         &#34;&#34;&#34;
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -256,7 +351,7 @@ class VerilatorTarget(VerilogTarget):
                 -I&lt;dir&gt;                    Directory to search for includes
         &#34;&#34;&#34;
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output)
+                         include_verilog_libraries, magma_output, magma_opts)
         self.flags = flags
         self.include_directories = include_directories
 
@@ -268,9 +363,45 @@ class VerilatorTarget(VerilogTarget):
             driver_file.name, self.flags)
         if self.run_from_directory(verilator_cmd):
             raise Exception(f&#34;Running verilator cmd {verilator_cmd} failed&#34;)
+        self.debug_includes = set()
+        verilator_version = subprocess.check_output(&#34;verilator --version&#34;,
+                                                    shell=True)
+        # Need to check version since they changed how internal signal access
+        # works
+        self.verilator_version = float(verilator_version.split()[1])
 
     def make_poke(self, i, action):
-        name = verilog_name(action.port.name)
+        if self.verilator_version &gt; 3.874:
+            prefix = f&#34;{self.circuit_name}&#34;
+        else:
+            prefix = f&#34;v&#34;
+        if isinstance(action.port, fault.WrappedVerilogInternalPort):
+            path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+            name = f&#34;{prefix}-&gt;{path}&#34;
+        elif isinstance(action.port, SelectPath):
+            # TODO: Find the version that they changed this, 3.874 is known to
+            # use top-&gt;v instead of top-&gt;{circuit_name}
+            name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+            self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+            for item in action.port[1:-1]:
+                circuit = type(item.instance)
+                circuit_name = circuit.verilog_name
+                # Verilator specializes each parametrization into a separate
+                # mdoule, this is an attempt to reverse engineer the naming
+                # scheme
+                if circuit_name == &#34;coreir_reg&#34;:
+                    circuit_name += &#34;_&#34;
+                    circuit_name += f&#34;_I{circuit.coreir_configargs[&#39;init&#39;]}&#34;
+                    circuit_name += f&#34;_W{circuit.coreir_genargs[&#39;width&#39;]}&#34;
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+        else:
+            name = verilog_name(action.port.name)
+
+        # Special case poking internal registers
+        is_reg_poke = isinstance(action.port, SelectPath) and \
+            isinstance(action.port[-1], fault.WrappedVerilogInternalPort) \
+            and action.port[-1].path == &#34;outReg&#34;
+
         if isinstance(action.value, BitVector) and \
                 action.value.num_bits &gt; 32:
             asserts = []
@@ -278,6 +409,8 @@ class VerilatorTarget(VerilogTarget):
                 value = action.value[i * 32:min(
                     (i + 1) * 32, action.value.num_bits)]
                 asserts += [f&#34;top-&gt;{name}[{i}] = {value};&#34;]
+            if is_reg_poke:
+                raise NotImplementedError()
             return asserts
         else:
             value = action.value
@@ -286,7 +419,20 @@ class VerilatorTarget(VerilogTarget):
                 # unsigned c type
                 port_len = len(action.port)
                 value = BitVector(value, port_len).as_uint()
-            return [f&#34;top-&gt;{name} = {value};&#34;]
+            result = [f&#34;top-&gt;{name} = {value};&#34;]
+            # Hack to support verilator&#39;s semantics, need to set the register
+            # mux values for expected behavior
+            if is_reg_poke:
+                action.port[-1].path = &#34;out&#34;
+                result += self.make_poke(i, action)
+                action.port[-1].path = &#34;in&#34;
+                result += self.make_poke(i, action)
+                if &#34;enable_mux&#34; in action.port[-3].instance_map:
+                    mux_inst = action.port[-3].instance_map[&#34;enable_mux&#34;]
+                    action.port[-2] = InstanceWrapper(mux_inst, action.port[-3])
+                    action.port[-1] = type(mux_inst).I0
+                    result += self.make_poke(i, action)
+            return result
 
     def make_print(self, i, action):
         name = verilog_name(action.port.name)
@@ -298,10 +444,41 @@ class VerilatorTarget(VerilogTarget):
         # perform the expect.
         if value_utils.is_any(action.value):
             return []
-        name = verilog_name(action.port.name)
+        if self.verilator_version &gt; 3.874:
+            prefix = f&#34;{self.circuit_name}&#34;
+        else:
+            prefix = f&#34;v&#34;
+        if isinstance(action.port, fault.WrappedVerilogInternalPort):
+            path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+            name = f&#34;{prefix}-&gt;{path}&#34;
+            debug_name = name
+        elif isinstance(action.port, SelectPath):
+            name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+            self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+            for item in action.port[1:-1]:
+                circuit_name = type(item.instance).name
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+            debug_name = action.port[-1].debug_name
+        else:
+            name = verilog_name(action.port.name)
+            debug_name = action.port.debug_name
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+            if isinstance(value.port, fault.WrappedVerilogInternalPort):
+                path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+                value = f&#34;top-&gt;{prefix}-&gt;{path}&#34;
+            else:
+                value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+        elif isinstance(value, PortWrapper):
+            self.debug_includes.add(f&#34;{value.select_path[0].circuit.name}&#34;)
+            for item in value.select_path[1:-1]:
+                circuit_name = type(item.instance).name
+                self.debug_includes.add(f&#34;{circuit_name}&#34;)
+            if self.verilator_version &gt; 3.874:
+                prefix = f&#34;{self.circuit_name}&#34;
+            else:
+                prefix = f&#34;v&#34;
+            value = f&#34;top-&gt;{prefix}-&gt;&#34; + value.select_path.verilator_path
         elif isinstance(action.port, m.SIntType) and value &lt; 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type
@@ -309,7 +486,7 @@ class VerilatorTarget(VerilogTarget):
             value = BitVector(value, port_len).as_uint()
 
         return [f&#34;my_assert(top-&gt;{name}, {value}, &#34;
-                f&#34;{i}, \&#34;{action.port.name}\&#34;);&#34;]
+                f&#34;{i}, \&#34;{debug_name}\&#34;);&#34;]
 
     def make_eval(self, i, action):
         return [&#34;top-&gt;eval();&#34;, &#34;main_time++;&#34;, &#34;#if VM_TRACE&#34;,
@@ -327,9 +504,15 @@ class VerilatorTarget(VerilogTarget):
             code.append(f&#34;top-&gt;{name} ^= 1;&#34;)
         return code
 
-    def generate_code(self, actions):
+    def generate_code(self, actions, verilator_includes):
+        if verilator_includes:
+            # Include the top circuit by default
+            verilator_includes.insert(
+                0, f&#39;{self.circuit_name}&#39;)
         includes = [
             f&#39;&#34;V{self.circuit_name}.h&#34;&#39;,
+        ] + [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+             verilator_includes] + [
             &#39;&#34;verilated.h&#34;&#39;,
             &#39;&lt;iostream&gt;&#39;,
             &#39;&lt;verilated_vcd_c.h&gt;&#39;,
@@ -343,6 +526,9 @@ class VerilatorTarget(VerilogTarget):
             for line in code:
                 main_body += f&#34;  {line}\n&#34;
 
+        includes += [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+                     self.debug_includes]
+
         includes_src = &#34;\n&#34;.join([&#34;#include &#34; + i for i in includes])
         src = src_tpl.format(
             includes=includes_src,
@@ -355,10 +541,10 @@ class VerilatorTarget(VerilogTarget):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self, actions):
+    def run(self, actions, verilator_includes=[]):
         driver_file = self.directory / Path(f&#34;{self.circuit_name}_driver.cpp&#34;)
         # Write the verilator driver to file.
-        src = self.generate_code(actions)
+        src = self.generate_code(actions, verilator_includes)
         with open(driver_file, &#34;w&#34;) as f:
             f.write(src)
         # Run a series of commands: run the Makefile output by verilator, and
@@ -371,7 +557,7 @@ class VerilatorTarget(VerilogTarget):
 <h3>Methods</h3>
 <dl>
 <dt id="fault.verilator_target.VerilatorTarget.__init__"><code class="name flex">
-<span>def <span class="ident">__init__</span></span>(<span>self, circuit, directory=&#39;build/&#39;, flags=[], skip_compile=False, include_verilog_libraries=[], include_directories=[], magma_output=&#39;coreir-verilog&#39;, circuit_name=None)</span>
+<span>def <span class="ident">__init__</span></span>(<span>self, circuit, directory=&#39;build/&#39;, flags=[], skip_compile=False, include_verilog_libraries=[], include_directories=[], magma_output=&#39;coreir-verilog&#39;, circuit_name=None, magma_opts={})</span>
 </code></dt>
 <dd>
 <section class="desc"><dl>
@@ -393,7 +579,7 @@ Directory to search for includes</p>
 <pre><code class="python">def __init__(self, circuit, directory=&#34;build/&#34;,
              flags=[], skip_compile=False, include_verilog_libraries=[],
              include_directories=[], magma_output=&#34;coreir-verilog&#34;,
-             circuit_name=None):
+             circuit_name=None, magma_opts={}):
     &#34;&#34;&#34;
     Params:
         `include_verilog_libraries`: a list of verilog libraries to include
@@ -405,7 +591,7 @@ Directory to search for includes</p>
             -I&lt;dir&gt;                    Directory to search for includes
     &#34;&#34;&#34;
     super().__init__(circuit, circuit_name, directory, skip_compile,
-                     include_verilog_libraries, magma_output)
+                     include_verilog_libraries, magma_output, magma_opts)
     self.flags = flags
     self.include_directories = include_directories
 
@@ -416,19 +602,31 @@ Directory to search for includes</p>
         self.include_verilog_libraries, self.include_directories,
         driver_file.name, self.flags)
     if self.run_from_directory(verilator_cmd):
-        raise Exception(f&#34;Running verilator cmd {verilator_cmd} failed&#34;)}</code></pre>
+        raise Exception(f&#34;Running verilator cmd {verilator_cmd} failed&#34;)
+    self.debug_includes = set()
+    verilator_version = subprocess.check_output(&#34;verilator --version&#34;,
+                                                shell=True)
+    # Need to check version since they changed how internal signal access
+    # works
+    self.verilator_version = float(verilator_version.split()[1])}</code></pre>
 </details>
 </dd>
 <dt id="fault.verilator_target.VerilatorTarget.generate_code"><code class="name flex">
-<span>def <span class="ident">generate_code</span></span>(<span>self, actions)</span>
+<span>def <span class="ident">generate_code</span></span>(<span>self, actions, verilator_includes)</span>
 </code></dt>
 <dd>
 <section class="desc"></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def generate_code(self, actions):
+<pre><code class="python">def generate_code(self, actions, verilator_includes):
+    if verilator_includes:
+        # Include the top circuit by default
+        verilator_includes.insert(
+            0, f&#39;{self.circuit_name}&#39;)
     includes = [
         f&#39;&#34;V{self.circuit_name}.h&#34;&#39;,
+    ] + [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+         verilator_includes] + [
         &#39;&#34;verilated.h&#34;&#39;,
         &#39;&lt;iostream&gt;&#39;,
         &#39;&lt;verilated_vcd_c.h&gt;&#39;,
@@ -441,6 +639,9 @@ Directory to search for includes</p>
         code = self.generate_action_code(i, action)
         for line in code:
             main_body += f&#34;  {line}\n&#34;
+
+    includes += [f&#39;&#34;V{self.circuit_name}_{include}.h&#34;&#39; for include in
+                 self.debug_includes]
 
     includes_src = &#34;\n&#34;.join([&#34;#include &#34; + i for i in includes])
     src = src_tpl.format(
@@ -476,10 +677,41 @@ Directory to search for includes</p>
     # perform the expect.
     if value_utils.is_any(action.value):
         return []
-    name = verilog_name(action.port.name)
+    if self.verilator_version &gt; 3.874:
+        prefix = f&#34;{self.circuit_name}&#34;
+    else:
+        prefix = f&#34;v&#34;
+    if isinstance(action.port, fault.WrappedVerilogInternalPort):
+        path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+        name = f&#34;{prefix}-&gt;{path}&#34;
+        debug_name = name
+    elif isinstance(action.port, SelectPath):
+        name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+        self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+        for item in action.port[1:-1]:
+            circuit_name = type(item.instance).name
+            self.debug_includes.add(f&#34;{circuit_name}&#34;)
+        debug_name = action.port[-1].debug_name
+    else:
+        name = verilog_name(action.port.name)
+        debug_name = action.port.debug_name
     value = action.value
     if isinstance(value, actions.Peek):
-        value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+        if isinstance(value.port, fault.WrappedVerilogInternalPort):
+            path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+            value = f&#34;top-&gt;{prefix}-&gt;{path}&#34;
+        else:
+            value = f&#34;top-&gt;{verilog_name(value.port.name)}&#34;
+    elif isinstance(value, PortWrapper):
+        self.debug_includes.add(f&#34;{value.select_path[0].circuit.name}&#34;)
+        for item in value.select_path[1:-1]:
+            circuit_name = type(item.instance).name
+            self.debug_includes.add(f&#34;{circuit_name}&#34;)
+        if self.verilator_version &gt; 3.874:
+            prefix = f&#34;{self.circuit_name}&#34;
+        else:
+            prefix = f&#34;v&#34;
+        value = f&#34;top-&gt;{prefix}-&gt;&#34; + value.select_path.verilator_path
     elif isinstance(action.port, m.SIntType) and value &lt; 0:
         # Handle sign extension for verilator since it expects and
         # unsigned c type
@@ -487,7 +719,7 @@ Directory to search for includes</p>
         value = BitVector(value, port_len).as_uint()
 
     return [f&#34;my_assert(top-&gt;{name}, {value}, &#34;
-            f&#34;{i}, \&#34;{action.port.name}\&#34;);&#34;]}</code></pre>
+            f&#34;{i}, \&#34;{debug_name}\&#34;);&#34;]}</code></pre>
 </details>
 </dd>
 <dt id="fault.verilator_target.VerilatorTarget.make_poke"><code class="name flex">
@@ -498,7 +730,37 @@ Directory to search for includes</p>
 <details class="source">
 <summary>Source code</summary>
 <pre><code class="python">def make_poke(self, i, action):
-    name = verilog_name(action.port.name)
+    if self.verilator_version &gt; 3.874:
+        prefix = f&#34;{self.circuit_name}&#34;
+    else:
+        prefix = f&#34;v&#34;
+    if isinstance(action.port, fault.WrappedVerilogInternalPort):
+        path = action.port.path.replace(&#34;.&#34;, &#34;-&gt;&#34;)
+        name = f&#34;{prefix}-&gt;{path}&#34;
+    elif isinstance(action.port, SelectPath):
+        # TODO: Find the version that they changed this, 3.874 is known to
+        # use top-&gt;v instead of top-&gt;{circuit_name}
+        name = f&#34;{prefix}-&gt;&#34; + action.port.verilator_path
+        self.debug_includes.add(f&#34;{action.port[0].circuit.name}&#34;)
+        for item in action.port[1:-1]:
+            circuit = type(item.instance)
+            circuit_name = circuit.verilog_name
+            # Verilator specializes each parametrization into a separate
+            # mdoule, this is an attempt to reverse engineer the naming
+            # scheme
+            if circuit_name == &#34;coreir_reg&#34;:
+                circuit_name += &#34;_&#34;
+                circuit_name += f&#34;_I{circuit.coreir_configargs[&#39;init&#39;]}&#34;
+                circuit_name += f&#34;_W{circuit.coreir_genargs[&#39;width&#39;]}&#34;
+            self.debug_includes.add(f&#34;{circuit_name}&#34;)
+    else:
+        name = verilog_name(action.port.name)
+
+    # Special case poking internal registers
+    is_reg_poke = isinstance(action.port, SelectPath) and \
+        isinstance(action.port[-1], fault.WrappedVerilogInternalPort) \
+        and action.port[-1].path == &#34;outReg&#34;
+
     if isinstance(action.value, BitVector) and \
             action.value.num_bits &gt; 32:
         asserts = []
@@ -506,6 +768,8 @@ Directory to search for includes</p>
             value = action.value[i * 32:min(
                 (i + 1) * 32, action.value.num_bits)]
             asserts += [f&#34;top-&gt;{name}[{i}] = {value};&#34;]
+        if is_reg_poke:
+            raise NotImplementedError()
         return asserts
     else:
         value = action.value
@@ -514,7 +778,20 @@ Directory to search for includes</p>
             # unsigned c type
             port_len = len(action.port)
             value = BitVector(value, port_len).as_uint()
-        return [f&#34;top-&gt;{name} = {value};&#34;]}</code></pre>
+        result = [f&#34;top-&gt;{name} = {value};&#34;]
+        # Hack to support verilator&#39;s semantics, need to set the register
+        # mux values for expected behavior
+        if is_reg_poke:
+            action.port[-1].path = &#34;out&#34;
+            result += self.make_poke(i, action)
+            action.port[-1].path = &#34;in&#34;
+            result += self.make_poke(i, action)
+            if &#34;enable_mux&#34; in action.port[-3].instance_map:
+                mux_inst = action.port[-3].instance_map[&#34;enable_mux&#34;]
+                action.port[-2] = InstanceWrapper(mux_inst, action.port[-3])
+                action.port[-1] = type(mux_inst).I0
+                result += self.make_poke(i, action)
+        return result}</code></pre>
 </details>
 </dd>
 <dt id="fault.verilator_target.VerilatorTarget.make_print"><code class="name flex">
@@ -551,16 +828,16 @@ Directory to search for includes</p>
 </details>
 </dd>
 <dt id="fault.verilator_target.VerilatorTarget.run"><code class="name flex">
-<span>def <span class="ident">run</span></span>(<span>self, actions)</span>
+<span>def <span class="ident">run</span></span>(<span>self, actions, verilator_includes=[])</span>
 </code></dt>
 <dd>
 <section class="desc"></section>
 <details class="source">
 <summary>Source code</summary>
-<pre><code class="python">def run(self, actions):
+<pre><code class="python">def run(self, actions, verilator_includes=[]):
     driver_file = self.directory / Path(f&#34;{self.circuit_name}_driver.cpp&#34;)
     # Write the verilator driver to file.
-    src = self.generate_code(actions)
+    src = self.generate_code(actions, verilator_includes)
     with open(driver_file, &#34;w&#34;) as f:
         f.write(src)
     # Run a series of commands: run the Makefile output by verilator, and

--- a/docs/verilog_target.html
+++ b/docs/verilog_target.html
@@ -48,7 +48,7 @@ class VerilogTarget(Target):
     &#34;&#34;&#34;
     def __init__(self, circuit, circuit_name=None, directory=&#34;build/&#34;,
                  skip_compile=False, include_verilog_libraries=[],
-                 magma_output=&#34;verilog&#34;):
+                 magma_output=&#34;verilog&#34;, magma_opts={}):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -63,12 +63,14 @@ class VerilogTarget(Target):
         self.include_verilog_libraries = include_verilog_libraries
 
         self.magma_output = magma_output
+        self.magma_opts = magma_opts
 
         self.verilog_file = Path(f&#34;{self.circuit_name}.v&#34;)
         # Optionally compile this module to verilog first.
         if not self.skip_compile:
             prefix = str(self.directory / self.verilog_file)[:-2]
-            m.compile(prefix, self.circuit, output=self.magma_output)
+            m.compile(prefix, self.circuit, output=self.magma_output,
+                      **self.magma_opts)
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f&#34;Compiling {self.circuit} failed&#34;)
 
@@ -169,7 +171,7 @@ class VerilogTarget(Target):
     &#34;&#34;&#34;
     def __init__(self, circuit, circuit_name=None, directory=&#34;build/&#34;,
                  skip_compile=False, include_verilog_libraries=[],
-                 magma_output=&#34;verilog&#34;):
+                 magma_output=&#34;verilog&#34;, magma_opts={}):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -184,12 +186,14 @@ class VerilogTarget(Target):
         self.include_verilog_libraries = include_verilog_libraries
 
         self.magma_output = magma_output
+        self.magma_opts = magma_opts
 
         self.verilog_file = Path(f&#34;{self.circuit_name}.v&#34;)
         # Optionally compile this module to verilog first.
         if not self.skip_compile:
             prefix = str(self.directory / self.verilog_file)[:-2]
-            m.compile(prefix, self.circuit, output=self.magma_output)
+            m.compile(prefix, self.circuit, output=self.magma_output,
+                      **self.magma_opts)
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f&#34;Compiling {self.circuit} failed&#34;)
 

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,3 +1,14 @@
 from .tester import Tester
 from .value import Value, AnyValue, UnknownValue
 import fault.random
+
+
+class WrappedVerilogInternalPort:
+    def __init__(self, path: str, type_):
+        """
+        path: <instance_name>.<port_name> (can nest instances)
+
+        type_: magma type of the signal (e.g. m.Bits(2))
+        """
+        self.path = path
+        self.type_ = type_

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import fault
 
 
 class Action(ABC):
@@ -51,7 +52,8 @@ class Print(Action):
 
 class Expect(PortAction):
     def __init__(self, port, value):
-        if port.isoutput():
+        if not isinstance(port, fault.WrappedVerilogInternalPort) and \
+                port.isoutput() or port.type_.isoutput():
             raise ValueError(f"Can only expect on outputs: {port.debug_name} "
                              f"{type(port)}")
         super().__init__(port, value)
@@ -60,7 +62,8 @@ class Expect(PortAction):
 class Peek(Action):
     def __init__(self, port):
         super().__init__()
-        if port.isoutput():
+        if not isinstance(port, fault.WrappedVerilogInternalPort) and \
+                port.isoutput() or port.type_.isoutput():
             raise ValueError(f"Can only peek on outputs: {port.debug_name} "
                              f"{type(port)}")
         self.port = port

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -50,10 +50,16 @@ class Print(Action):
         return cls(new_port, self.format_str)
 
 
+def is_output(port):
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isoutput()
+    else:
+        return not port.isoutput()
+
+
 class Expect(PortAction):
     def __init__(self, port, value):
-        if not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                port.isoutput() or port.type_.isoutput():
+        if not is_output(port):
             raise ValueError(f"Can only expect on outputs: {port.debug_name} "
                              f"{type(port)}")
         super().__init__(port, value)
@@ -62,8 +68,7 @@ class Expect(PortAction):
 class Peek(Action):
     def __init__(self, port):
         super().__init__()
-        if not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                port.isoutput() or port.type_.isoutput():
+        if not is_output(port):
             raise ValueError(f"Can only peek on outputs: {port.debug_name} "
                              f"{type(port)}")
         self.port = port

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -28,9 +28,18 @@ class PortAction(Action):
         return cls(new_port, self.value)
 
 
+def can_poke(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        return not port.type_.isinput()
+    else:
+        return not port.isinput()
+
+
 class Poke(PortAction):
     def __init__(self, port, value):
-        if port.isinput():
+        if not can_poke(port):
             raise ValueError(f"Can only poke inputs: {port.debug_name} "
                              f"{type(port)}")
         super().__init__(port, value)

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import fault
+from fault.select_path import SelectPath
 
 
 class Action(ABC):
@@ -51,6 +52,8 @@ class Print(Action):
 
 
 def is_output(port):
+    if isinstance(port, SelectPath):
+        port = port[-1]
     if isinstance(port, fault.WrappedVerilogInternalPort):
         return not port.type_.isoutput()
     else:

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -1,5 +1,5 @@
 import fault
-from fault.verilog_target import verilog_name
+from fault.verilog_utils import verilog_name
 
 
 class SelectPath:

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -1,0 +1,22 @@
+from fault.verilog_target import verilog_name
+
+
+class SelectPath:
+    def __init__(self, init=None):
+        self.path = [] if init is None else init
+
+    def insert(self, index, value):
+        self.path.insert(index, value)
+
+    def __getitem__(self, index):
+        return self.path[index]
+
+    @property
+    def verilator_path(self):
+        path_str = ""
+        # Skip outermost circuit definition (top) and innermost port
+        # (appended next)
+        for x in self.path[1:-1]:
+            path_str += x.instance.name + "->"
+        path_str += verilog_name(self.path[-1].name)
+        return path_str

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -1,3 +1,4 @@
+import fault
 from fault.verilog_target import verilog_name
 
 
@@ -18,5 +19,8 @@ class SelectPath:
         # (appended next)
         for x in self.path[1:-1]:
             path_str += x.instance.name + "->"
-        path_str += verilog_name(self.path[-1].name)
+        if isinstance(self.path[-1], fault.WrappedVerilogInternalPort):
+            path_str += self.path[-1].path
+        else:
+            path_str += verilog_name(self.path[-1].name)
         return path_str

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -12,15 +12,26 @@ class SelectPath:
     def __getitem__(self, index):
         return self.path[index]
 
-    @property
-    def verilator_path(self):
+    # TODO: Do we want to support mutability?
+    def __setitem__(self, index, value):
+        self.path[index] = value
+
+    def make_path(self, separator):
         path_str = ""
         # Skip outermost circuit definition (top) and innermost port
         # (appended next)
         for x in self.path[1:-1]:
-            path_str += x.instance.name + "->"
+            path_str += x.instance.name + separator
         if isinstance(self.path[-1], fault.WrappedVerilogInternalPort):
             path_str += self.path[-1].path
         else:
             path_str += verilog_name(self.path[-1].name)
         return path_str
+
+    @property
+    def system_verilog_path(self):
+        return self.make_path(".")
+
+    @property
+    def verilator_path(self):
+        return self.make_path("->")

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -138,7 +138,7 @@ class SystemVerilogTarget(VerilogTarget):
     def generate_port_code(name, type_):
         is_array_of_bits = isinstance(type_, m.ArrayKind) and \
             not isinstance(type_.T, m.BitKind)
-        if array_of_bits or isinstance(type_, m.TupleKind):
+        if is_array_of_bits or isinstance(type_, m.TupleKind):
             return SystemVerilogTarget.generate_recursive_port_code(name, type_)
         else:
             width_str = ""

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -74,7 +74,7 @@ class SystemVerilogTarget(VerilogTarget):
 
     def make_poke(self, i, action):
         if isinstance(action.port, SelectPath):
-            name = f"{self.circuit_name}.{action.port.system_verilog_path}"
+            name = f"dut.{action.port.system_verilog_path}"
         else:
             name = verilog_name(action.port.name)
         if isinstance(action.value, BitVector) and \
@@ -98,7 +98,7 @@ class SystemVerilogTarget(VerilogTarget):
         if value_utils.is_any(action.value):
             return []
         if isinstance(action.port, SelectPath):
-            name = f"{self.circuit_name}.{action.port.system_verilog_path}"
+            name = f"dut.{action.port.system_verilog_path}"
             debug_name = action.port[-1].name
         else:
             name = verilog_name(action.port.name)
@@ -107,7 +107,7 @@ class SystemVerilogTarget(VerilogTarget):
         if isinstance(value, actions.Peek):
             value = f"{value.port.name}"
         elif isinstance(value, PortWrapper):
-            value = f"{self.circuit_name}.{value.select_path.system_verilog_path}"
+            value = f"dut.{value.select_path.system_verilog_path}"
         elif isinstance(action.port, m.SIntType) and value < 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -58,6 +58,8 @@ class Tester:
         self.clock = clock
         self.default_print_format_str = default_print_format_str
         self.targets = {}
+        # For public verilator modules
+        self.verilator_includes = []
 
     def make_target(self, target: str, **kwargs):
         """
@@ -153,7 +155,7 @@ class Tester:
         should call `compile` with `target` before calling `run`.
         """
         try:
-            self.targets[target].run(self.actions)
+            self.targets[target].run(self)
         except KeyError:
             raise Exception(f"Could not find target={target}, did you compile"
                             " it first?")
@@ -206,3 +208,6 @@ class Tester:
         for i, action in enumerate(self.actions):
             s += f"    {i}: {action}\n"
         return s
+
+    def verilator_include(self, module_name):
+        self.verilator_includes.append(module_name)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -155,7 +155,10 @@ class Tester:
         should call `compile` with `target` before calling `run`.
         """
         try:
-            self.targets[target].run(self)
+            if target == "verilator":
+                self.targets[target].run(self.actions, self.verilator_includes)
+            else:
+                self.targets[target].run(self.actions)
         except KeyError:
             raise Exception(f"Could not find target={target}, did you compile"
                             " it first?")

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -8,10 +8,10 @@ from fault.select_path import SelectPath
 
 def make_value(port, value):
     switch = port
-    if isinstance(port, fault.WrappedVerilogInternalPort):
-        switch = port.type_
-    elif isinstance(port, SelectPath):
-        switch = port[-1]
+    if isinstance(switch, SelectPath):
+        switch = switch[-1]
+    if isinstance(switch, fault.WrappedVerilogInternalPort):
+        switch = switch.type_
     if isinstance(switch, (magma._BitType, magma._BitKind)):
         return make_bit(value)
     if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -1,3 +1,4 @@
+import fault
 import magma
 from bit_vector import BitVector
 from fault.value import AnyValue, UnknownValue
@@ -5,11 +6,14 @@ from fault.array import Array
 
 
 def make_value(port, value):
-    if isinstance(port, (magma._BitType, magma._BitKind)):
+    switch = port
+    if isinstance(port, fault.WrappedVerilogInternalPort):
+        switch = port.type_
+    if isinstance(switch, (magma._BitType, magma._BitKind)):
         return make_bit(value)
-    if isinstance(port, (magma.ArrayType, magma.ArrayKind)):
-        return make_array(port.T, port.N, value)
-    raise NotImplementedError(port, value)
+    if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):
+        return make_array(switch.T, switch.N, value)
+    raise NotImplementedError(switch, value)
 
 
 def make_bit(value):

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -3,12 +3,15 @@ import magma
 from bit_vector import BitVector
 from fault.value import AnyValue, UnknownValue
 from fault.array import Array
+from fault.select_path import SelectPath
 
 
 def make_value(port, value):
     switch = port
     if isinstance(port, fault.WrappedVerilogInternalPort):
         switch = port.type_
+    elif isinstance(port, SelectPath):
+        switch = port[-1]
     if isinstance(switch, (magma._BitType, magma._BitKind)):
         return make_bit(value)
     if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -99,7 +99,7 @@ class VerilatorTarget(VerilogTarget):
         if self.run_from_directory(verilator_cmd):
             raise Exception(f"Running verilator cmd {verilator_cmd} failed")
         self.debug_includes = set()
-        verilator_version = subprocess.check_output(["verilator", "--version"])
+        verilator_version = subprocess.check_output("verilator --version", shell=True)
         # Need to check version since they changed how internal signal access
         # works
         self.verilator_version = float(verilator_version.split()[1])
@@ -133,7 +133,7 @@ class VerilatorTarget(VerilogTarget):
         # Special case poking internal registers
         is_reg_poke = isinstance(action.port, SelectPath) and \
             isinstance(action.port[-1], fault.WrappedVerilogInternalPort) \
-            and action.port.path == "outReg"
+            and action.port[-1].path == "outReg"
 
         if isinstance(action.value, BitVector) and \
                 action.value.num_bits > 32:

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -133,6 +133,10 @@ class VerilatorTarget(VerilogTarget):
             debug_name = name
         elif isinstance(action.port, SelectPath):
             name = f"{self.circuit_name}->" + action.port.verilator_path
+            self.debug_includes.add(f"{action.port[0].circuit.name}")
+            for item in action.port[1:-1]:
+                circuit_name = type(item.instance).name
+                self.debug_includes.add(f"{circuit_name}")
             debug_name = action.port[-1].debug_name
         else:
             name = verilog_name(action.port.name)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -73,7 +73,7 @@ class VerilatorTarget(VerilogTarget):
     def __init__(self, circuit, directory="build/",
                  flags=[], skip_compile=False, include_verilog_libraries=[],
                  include_directories=[], magma_output="coreir-verilog",
-                 circuit_name=None):
+                 circuit_name=None, magma_opts={}):
         """
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -85,7 +85,7 @@ class VerilatorTarget(VerilogTarget):
                 -I<dir>                    Directory to search for includes
         """
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output)
+                         include_verilog_libraries, magma_output, magma_opts)
         self.flags = flags
         self.include_directories = include_directories
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -99,7 +99,8 @@ class VerilatorTarget(VerilogTarget):
         if self.run_from_directory(verilator_cmd):
             raise Exception(f"Running verilator cmd {verilator_cmd} failed")
         self.debug_includes = set()
-        verilator_version = subprocess.check_output("verilator --version", shell=True)
+        verilator_version = subprocess.check_output("verilator --version",
+                                                    shell=True)
         # Need to check version since they changed how internal signal access
         # works
         self.verilator_version = float(verilator_version.split()[1])

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -1,3 +1,4 @@
+import fault
 from .array import Array
 from pathlib import Path
 import subprocess
@@ -124,10 +125,18 @@ class VerilatorTarget(VerilogTarget):
         # perform the expect.
         if value_utils.is_any(action.value):
             return []
-        name = verilog_name(action.port.name)
+        if isinstance(action.port, fault.WrappedVerilogInternalPort):
+            name = action.port.path
+            debug_name = name
+        else:
+            name = verilog_name(action.port.name)
+            debug_name = action.port.name
         value = action.value
         if isinstance(value, actions.Peek):
-            value = f"top->{verilog_name(value.port.name)}"
+            if isinstance(value.port, fault.WrappedVerilogInternalPort):
+                value = "top->" + action.port.path
+            else:
+                value = f"top->{verilog_name(value.port.name)}"
         elif isinstance(action.port, m.SIntType) and value < 0:
             # Handle sign extension for verilator since it expects and
             # unsigned c type
@@ -135,7 +144,7 @@ class VerilatorTarget(VerilogTarget):
             value = BitVector(value, port_len).as_uint()
 
         return [f"my_assert(top->{name}, {value}, "
-                f"{i}, \"{action.port.name}\");"]
+                f"{i}, \"{debug_name}\");"]
 
     def make_eval(self, i, action):
         return ["top->eval();", "main_time++;", "#if VM_TRACE",
@@ -153,9 +162,12 @@ class VerilatorTarget(VerilogTarget):
             code.append(f"top->{name} ^= 1;")
         return code
 
-    def generate_code(self, actions):
+    def generate_code(self, tester):
         includes = [
             f'"V{self.circuit_name}.h"',
+            f'"V{self.circuit_name}_{self.circuit_name}.h"',
+        ] + [f'"V{self.circuit_name}_{include}.h"' for include in
+             tester.verilator_includes] + [
             '"verilated.h"',
             '<iostream>',
             '<verilated_vcd_c.h>',
@@ -164,7 +176,7 @@ class VerilatorTarget(VerilogTarget):
         ]
 
         main_body = ""
-        for i, action in enumerate(actions):
+        for i, action in enumerate(tester.actions):
             code = self.generate_action_code(i, action)
             for line in code:
                 main_body += f"  {line}\n"
@@ -181,10 +193,10 @@ class VerilatorTarget(VerilogTarget):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self, actions):
+    def run(self, tester):
         driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
         # Write the verilator driver to file.
-        src = self.generate_code(actions)
+        src = self.generate_code(tester)
         with open(driver_file, "w") as f:
             f.write(src)
         # Run a series of commands: run the Makefile output by verilator, and

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -162,12 +162,15 @@ class VerilatorTarget(VerilogTarget):
             code.append(f"top->{name} ^= 1;")
         return code
 
-    def generate_code(self, tester):
+    def generate_code(self, actions, verilator_includes):
+        if verilator_includes:
+            # Include the top circuit by default
+            verilator_includes.insert(
+                0, f'{self.circuit_name}')
         includes = [
             f'"V{self.circuit_name}.h"',
-            f'"V{self.circuit_name}_{self.circuit_name}.h"',
         ] + [f'"V{self.circuit_name}_{include}.h"' for include in
-             tester.verilator_includes] + [
+             verilator_includes] + [
             '"verilated.h"',
             '<iostream>',
             '<verilated_vcd_c.h>',
@@ -176,7 +179,7 @@ class VerilatorTarget(VerilogTarget):
         ]
 
         main_body = ""
-        for i, action in enumerate(tester.actions):
+        for i, action in enumerate(actions):
             code = self.generate_action_code(i, action)
             for line in code:
                 main_body += f"  {line}\n"
@@ -193,10 +196,10 @@ class VerilatorTarget(VerilogTarget):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self, tester):
+    def run(self, actions, verilator_includes=[]):
         driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
         # Write the verilator driver to file.
-        src = self.generate_code(tester)
+        src = self.generate_code(actions, verilator_includes)
         with open(driver_file, "w") as f:
             f.write(src)
         # Run a series of commands: run the Makefile output by verilator, and

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -256,8 +256,7 @@ class VerilatorTarget(VerilogTarget):
                 main_body += f"  {line}\n"
 
         includes += [f'"V{self.circuit_name}_{include}.h"' for include in
-             self.debug_includes]
-
+                     self.debug_includes]
 
         includes_src = "\n".join(["#include " + i for i in includes])
         src = src_tpl.format(

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -24,7 +24,7 @@ class VerilogTarget(Target):
     """
     def __init__(self, circuit, circuit_name=None, directory="build/",
                  skip_compile=False, include_verilog_libraries=[],
-                 magma_output="verilog"):
+                 magma_output="verilog", magma_opts={}):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -39,12 +39,14 @@ class VerilogTarget(Target):
         self.include_verilog_libraries = include_verilog_libraries
 
         self.magma_output = magma_output
+        self.magma_opts = magma_opts
 
         self.verilog_file = Path(f"{self.circuit_name}.v")
         # Optionally compile this module to verilog first.
         if not self.skip_compile:
             prefix = str(self.directory / self.verilog_file)[:-2]
-            m.compile(prefix, self.circuit, output=self.magma_output)
+            m.compile(prefix, self.circuit, output=self.magma_output,
+                      **self.magma_opts)
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f"Compiling {self.circuit} failed")
 

--- a/fault/verilog_utils.py
+++ b/fault/verilog_utils.py
@@ -1,0 +1,13 @@
+import magma as m
+
+
+def verilog_name(name):
+    if isinstance(name, m.ref.DefnRef):
+        return str(name)
+    if isinstance(name, m.ref.ArrayRef):
+        array_name = verilog_name(name.array.name)
+        return f"{array_name}_{name.index}"
+    if isinstance(name, m.ref.TupleRef):
+        tuple_name = verilog_name(name.tuple.name)
+        return f"{tuple_name}_{name.index}"
+    raise NotImplementedError(name, type(name))

--- a/fault/wrapper.py
+++ b/fault/wrapper.py
@@ -86,23 +86,6 @@ class InstanceWrapper(Wrapper):
                         InstanceWrapper(self.instance_map[attr], self))
                     select_path = wrapper.select_path
                     select_path.tester.poke(select_path, value)
-                    # Poke the input to the register too
-                    wrapper = PortWrapper(
-                        fault.WrappedVerilogInternalPort(
-                            "in", self.instance_map[attr].O),
-                        InstanceWrapper(self.instance_map[attr], self))
-                    select_path = wrapper.select_path
-                    select_path.tester.poke(select_path, value)
-                    wrapper = PortWrapper(
-                        fault.WrappedVerilogInternalPort(
-                            "out", self.instance_map[attr].O),
-                        InstanceWrapper(self.instance_map[attr], self))
-                    select_path = wrapper.select_path
-                    select_path.tester.poke(select_path, value)
-                    wrapper = PortWrapper(type(self.instance_map["enable_mux"]).I0,
-                        InstanceWrapper(self.instance_map["enable_mux"], self))
-                    select_path = wrapper.select_path
-                    select_path.tester.poke(select_path, value)
                 except Exception as e:
                     print(e)
                     exit(1)

--- a/fault/wrapper.py
+++ b/fault/wrapper.py
@@ -93,4 +93,3 @@ class InstanceWrapper(Wrapper):
                 object.__setattr__(self, attr, value)
         except Exception as e:
             object.__setattr__(self, attr, value)
-

--- a/fault/wrapper.py
+++ b/fault/wrapper.py
@@ -1,0 +1,68 @@
+import fault
+from fault.select_path import SelectPath
+
+
+class Wrapper:
+    def __init__(self, circuit, parent):
+        self.circuit = circuit
+        self.instance_map = {instance.name: instance for instance in
+                             circuit.instances}
+        self.parent = parent
+
+    def __setattr__(self, attr, value):
+        # Hack to stage this after __init__ has been run, should redefine this
+        # method in a metaclass? Could also use a try/except pattern, so the
+        # exceptions only occur during object instantiation
+        if hasattr(self, "circuit") and hasattr(self, "instance_map"):
+            if attr in self.circuit.interface.ports.keys():
+                if isinstance(self.parent, fault.Tester):
+                    self.parent.poke(self.circuit.interface.ports[attr], value)
+                else:
+                    exit(1)
+            else:
+                object.__setattr__(self, attr, value)
+        else:
+            object.__setattr__(self, attr, value)
+
+    def __getattr__(self, attr):
+        # Hack to stage this after __init__ has been run, should redefine this
+        # method in a metaclass?
+        try:
+            if attr in self.circuit.interface.ports.keys():
+                return PortWrapper(self.circuit.interface.ports[attr], self)
+            elif attr in self.instance_map:
+                return InstanceWrapper(self.instance_map[attr], self)
+            else:
+                object.__getattribute__(self, attr)
+        except Exception as e:
+            object.__getattribute__(self, attr)
+
+
+class CircuitWrapper(Wrapper):
+    pass
+
+
+class PortWrapper:
+    def __init__(self, port, parent):
+        self.port = port
+        self.parent = parent
+
+    def expect(self, value):
+        select_path = self.select_path
+        select_path.tester.expect(select_path, value)
+
+    @property
+    def select_path(self):
+        select_path = SelectPath([self.port])
+        parent = self.parent
+        while not isinstance(parent, fault.Tester):
+            select_path.insert(0, parent)
+            parent = parent.parent
+        select_path.tester = parent
+        return select_path
+
+
+class InstanceWrapper(Wrapper):
+    def __init__(self, instance, parent):
+        self.instance = instance
+        super().__init__(type(instance), parent)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e git://github.com/phanrahan/magma.git#egg=magma
 -e git://github.com/phanrahan/mantle.git#egg=mantle
+git+git://github.com/leonardt/Pyverilog.git#egg=pyverilog

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 import sys
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='fault',
     version='0.43',
@@ -16,5 +19,7 @@ setup(
     url='https://github.com/leonardt/fault',
     author='Leonard Truong',
     author_email='lenny@cs.stanford.edu',
-    python_requires='>=3.6'
+    python_requires='>=3.6',
+    long_description=long_description,
+    long_description_content_type="text/markdown"
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -49,7 +49,7 @@ class ConfigReg(m.Circuit):
 
     @classmethod
     def definition(io):
-        reg = mantle.Register(2, has_ce=True)
+        reg = mantle.Register(2, has_ce=True, name="conf_reg")
         io.Q <= reg(io.D, CE=io.CE)
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 import magma as m
+import mantle
 
 
 def define_simple_circuit(T, circ_name, has_clk=False):
@@ -40,3 +41,28 @@ class TestPeekCircuit(m.Circuit):
     def definition(io):
         m.wire(io.I, io.O0)
         m.wire(io.I, io.O1)
+
+
+class ConfigReg(m.Circuit):
+    IO = ["D", m.In(m.Bits(2)), "Q", m.Out(m.Bits(2))] + \
+        m.ClockInterface(has_ce=True)
+
+    @classmethod
+    def definition(io):
+        reg = mantle.Register(2, has_ce=True)
+        io.Q <= reg(io.D, CE=io.CE)
+
+
+class SimpleALU(m.Circuit):
+    IO = ["a", m.In(m.UInt(16)),
+          "b", m.In(m.UInt(16)),
+          "c", m.Out(m.UInt(16)),
+          "config_data", m.In(m.Bits(2)),
+          "config_en", m.In(m.Enable),
+          ] + m.ClockInterface()
+
+    @classmethod
+    def definition(io):
+        opcode = ConfigReg(name="config_reg")(io.config_data, CE=io.config_en)
+        io.c <= mantle.mux(
+            [io.a + io.b, io.a - io.b, io.a * io.b, io.a / io.b], opcode)

--- a/tests/simple_alu.v
+++ b/tests/simple_alu.v
@@ -1,0 +1,22 @@
+module ConfigReg(input [1:0] D, output [1:0] Q, input CLK, input EN);
+reg Q/*verilator public*/;
+always @(posedge CLK) begin
+    if (EN) Q <= D;
+end
+endmodule
+
+module SimpleALU(input [15:0] a, input [15:0] b, output [15:0] c, input [1:0] config_data, input config_en, input CLK);
+
+wire [1:0] opcode/*verilator public*/;
+ConfigReg config_reg(config_data, opcode, CLK, config_en);
+
+
+always @(*) begin
+    case (opcode)
+        0: c = a + b;
+        1: c = a - b;
+        2: c = a * b;
+        3: c = a / b;
+    endcase
+end
+endmodule

--- a/tests/test_include_verilog.py
+++ b/tests/test_include_verilog.py
@@ -3,13 +3,15 @@ import tempfile
 import fault
 import magma as m
 import os
+import shutil
 
 
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = [("verilator", None)]
-        if not os.getenv("TRAVIS", False):
+        if shutil.which("irun"):
             targets.append(("system-verilog", "ncsim"))
+        if shutil.which("vcs"):
             targets.append(("system-verilog", "vcs"))
         metafunc.parametrize("target,simulator", targets)
 

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -91,3 +91,7 @@ def test_magma_simulator_target_peek(backend):
         actions.append(Eval())
         actions.append(Expect(circ.O0, Peek(circ.O1)))
     run(circ, actions, None, backend)
+
+
+if __name__ == "__main__":
+    test_magma_simulator_target_basic("coreir")

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -9,7 +9,7 @@ def test_tester_magma_internal_signals():
     tester = Tester(circ, circ.CLK)
     tester.circuit.config_en = 1
     for i in range(0, 4):
-        tester.circuit.config_data = 1
+        tester.circuit.config_data = i
         tester.step(2)
         tester.circuit.config_reg.Q.expect(i)
         signal = tester.circuit.config_reg.Q
@@ -17,4 +17,5 @@ def test_tester_magma_internal_signals():
     with tempfile.TemporaryDirectory() as _dir:
         _dir = "build"
         tester.compile_and_run("verilator", directory=_dir,
-                               flags=["-Wno-fatal"])
+                               flags=["-Wno-fatal"],
+                               magma_opts={"verilator_debug": True})

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -28,7 +28,7 @@ def test_tester_magma_internal_signals(target, simulator):
         tester.circuit.config_reg.Q.expect(signal)
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {
-            "directory": "build",
+            "directory": _dir,
             "magma_opts": {"verilator_debug": True}
         }
         if target == "verilator":
@@ -51,7 +51,7 @@ def test_tester_poke_internal_register(target, simulator):
         tester.circuit.config_reg.conf_reg.O.expect(i)
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {
-            "directory": "build",
+            "directory": _dir,
             "magma_opts": {"verilator_debug": True}
         }
         if target == "verilator":

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -1,0 +1,17 @@
+import common
+from fault import Tester
+
+
+def test_tester_magma_internal_signals():
+    circ = common.SimpleALU
+
+    tester = Tester(circ, circ.CLK)
+    tester.circuit.config_en = 1
+    for i in range(0, 4):
+        tester.circuit.config_data = 1
+        tester.step(2)
+        tester.circuit.config_reg.Q.expect(i)
+        signal = tester.circuit.config_reg.Q
+        tester.circuit.config_reg.Q.expect(signal)
+    with tempfile.TemporaryDirectory() as _dir:
+        tester.compile_and_run(verilator, directory=_dir, flags=["-Wno-fatal"])

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -7,10 +7,10 @@ import shutil
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = [("verilator", None)]
-        if shutil.which("irun"):
-            targets.append(("system_verilog", "ncsim"))
+        # if shutil.which("irun"):
+        #     targets.append(("system-verilog", "ncsim"))
         if shutil.which("vcs"):
-            targets.append(("system_verilog", "vcs"))
+            targets.append(("system-verilog", "vcs"))
         metafunc.parametrize("target,simulator", targets)
 
 
@@ -27,10 +27,11 @@ def test_tester_magma_internal_signals(target, simulator):
         tester.circuit.config_reg.Q.expect(signal)
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {
-            "directory": _dir,
-            "flags": ["-Wno-fatal"],
+            "directory": "build",
             "magma_opts": {"verilator_debug": True}
         }
+        if target == "verilator":
+            kwargs["flags"] = ["-Wno-fatal"]
         if simulator is not None:
             kwargs["simulator"] = simulator
         tester.compile_and_run(target, **kwargs)
@@ -48,10 +49,11 @@ def test_tester_poke_internal_register(target, simulator):
         tester.circuit.config_reg.conf_reg.O.expect(i)
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {
-            "directory": _dir,
-            "flags": ["-Wno-fatal"],
+            "directory": "build",
             "magma_opts": {"verilator_debug": True}
         }
+        if target == "verilator":
+            kwargs["flags"] = ["-Wno-fatal"]
         if simulator is not None:
             kwargs["simulator"] = simulator
         tester.compile_and_run(target, **kwargs)

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -33,7 +33,7 @@ def test_tester_magma_internal_signals(target, simulator):
         }
         if simulator is not None:
             kwargs["simulator"] = simulator
-        tester.compile_and_run("verilator", **kwargs)
+        tester.compile_and_run(target, **kwargs)
 
 
 def test_tester_poke_internal_register(target, simulator):
@@ -47,7 +47,11 @@ def test_tester_poke_internal_register(target, simulator):
         tester.step(2)
         tester.circuit.config_reg.conf_reg.O.expect(i)
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
-        tester.compile_and_run("verilator", directory=_dir,
-                               flags=["-Wno-fatal", "--trace"],
-                               magma_opts={"verilator_debug": True})
+        kwargs = {
+            "directory": _dir,
+            "flags": ["-Wno-fatal"],
+            "magma_opts": {"verilator_debug": True}
+        }
+        if simulator is not None:
+            kwargs["simulator"] = simulator
+        tester.compile_and_run(target, **kwargs)

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -18,3 +18,20 @@ def test_tester_magma_internal_signals():
         tester.compile_and_run("verilator", directory=_dir,
                                flags=["-Wno-fatal"],
                                magma_opts={"verilator_debug": True})
+
+
+def test_tester_poke_internal_register():
+    circ = common.SimpleALU
+
+    tester = Tester(circ, circ.CLK)
+    # Initialize
+    tester.step(2)
+    for i in reversed(range(4)):
+        tester.circuit.config_reg.conf_reg.value = i
+        tester.step(2)
+        tester.circuit.config_reg.conf_reg.O.expect(i)
+    with tempfile.TemporaryDirectory() as _dir:
+        _dir = "build"
+        tester.compile_and_run("verilator", directory=_dir,
+                               flags=["-Wno-fatal", "--trace"],
+                               magma_opts={"verilator_debug": True})

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -7,8 +7,8 @@ import shutil
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = [("verilator", None)]
-        # if shutil.which("irun"):
-        #     targets.append(("system-verilog", "ncsim"))
+        if shutil.which("irun"):
+            targets.append(("system-verilog", "ncsim"))
         if shutil.which("vcs"):
             targets.append(("system-verilog", "vcs"))
         metafunc.parametrize("target,simulator", targets)
@@ -18,6 +18,7 @@ def test_tester_magma_internal_signals(target, simulator):
     circ = common.SimpleALU
 
     tester = Tester(circ, circ.CLK)
+    tester.circuit.CLK = 0
     tester.circuit.config_en = 1
     for i in range(0, 4):
         tester.circuit.config_data = i
@@ -41,6 +42,7 @@ def test_tester_poke_internal_register(target, simulator):
     circ = common.SimpleALU
 
     tester = Tester(circ, circ.CLK)
+    tester.circuit.CLK = 0
     # Initialize
     tester.step(2)
     for i in reversed(range(4)):

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -15,7 +15,6 @@ def test_tester_magma_internal_signals():
         signal = tester.circuit.config_reg.Q
         tester.circuit.config_reg.Q.expect(signal)
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
         tester.compile_and_run("verilator", directory=_dir,
                                flags=["-Wno-fatal"],
                                magma_opts={"verilator_debug": True})

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -1,4 +1,5 @@
 import common
+import tempfile
 from fault import Tester
 
 
@@ -14,4 +15,6 @@ def test_tester_magma_internal_signals():
         signal = tester.circuit.config_reg.Q
         tester.circuit.config_reg.Q.expect(signal)
     with tempfile.TemporaryDirectory() as _dir:
-        tester.compile_and_run(verilator, directory=_dir, flags=["-Wno-fatal"])
+        _dir = "build"
+        tester.compile_and_run("verilator", directory=_dir,
+                               flags=["-Wno-fatal"])

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -213,8 +213,7 @@ Actions:
 """  # nopep8
 
 
-def test_tester_verilog_wrapped():
-    target = "verilator"
+def test_tester_verilog_wrapped(target, simulator):
     SimpleALU = m.DefineFromVerilogFile("tests/simple_alu.v",
                                         type_map={"CLK": m.In(m.Clock)},
                                         target_modules=["SimpleALU"])[0]

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,3 +1,4 @@
+import magma as m
 import random
 from bit_vector import BitVector
 import fault
@@ -208,3 +209,61 @@ Actions:
     2: Expect(DoubleNestedArraysCircuit.O, Array([Array([BitVector(0, 4), BitVector(1, 4), BitVector(2, 4)], 3), Array([BitVector(3, 4), BitVector(4, 4), BitVector(5, 4)], 3)], 2))
     3: Print(DoubleNestedArraysCircuit.O, "%08x")
 """  # nopep8
+
+
+def test_tester_verilog_wrapped():
+    target = "verilator"
+    SimpleALU = m.DefineFromVerilogFile("tests/simple_alu.v",
+                                        type_map={"CLK": m.In(m.Clock)},
+                                        target_modules=["SimpleALU"])[0]
+
+    circ = m.DefineCircuit("top",
+                           "a", m.In(m.Bits(16)),
+                           "b", m.In(m.Bits(16)),
+                           "c", m.Out(m.Bits(16)),
+                           "config_data", m.In(m.Bits(2)),
+                           "config_en", m.In(m.Bit),
+                           "CLK", m.In(m.Clock))
+    simple_alu = SimpleALU()
+    m.wire(simple_alu.a, circ.a)
+    m.wire(simple_alu.b, circ.b)
+    m.wire(simple_alu.c, circ.c)
+    m.wire(simple_alu.config_data, circ.config_data)
+    m.wire(simple_alu.config_en, circ.config_en)
+    m.wire(simple_alu.CLK, circ.CLK)
+    m.EndDefine()
+
+    tester = fault.Tester(circ, circ.CLK)
+    tester.verilator_include("SimpleALU")
+    tester.verilator_include("ConfigReg")
+    tester.poke(circ.config_en, 1)
+    for i in range(0, 4):
+        tester.poke(circ.config_data, i)
+        tester.step(2)
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)),
+            i)
+        signal = tester.peek(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)))
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+                                             m.Bits(2)),
+            signal)
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)),
+            i)
+        signal = tester.peek(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)))
+        tester.expect(
+            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
+                                             m.Bits(2)),
+            signal)
+    with tempfile.TemporaryDirectory() as _dir:
+        if target == "verilator":
+            tester.compile_and_run(target, flags=["-Wno-fatal"])
+        else:
+            tester.compile_and_run(target, directory=_dir, simulator=simulator)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -6,14 +6,16 @@ from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common
 import tempfile
 import os
+import shutil
 
 
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = [("verilator", None)]
-        if not os.getenv("TRAVIS", False):
+        if shutil.which("irun"):
             targets.append(
                 ("system-verilog", "ncsim"))
+        if shutil.which("vcs"):
             targets.append(
                 ("system-verilog", "vcs"))
         metafunc.parametrize("target,simulator", targets)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -243,26 +243,26 @@ def test_tester_verilog_wrapped():
         tester.poke(circ.config_data, i)
         tester.step(2)
         tester.expect(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+            fault.WrappedVerilogInternalPort("SimpleALU_inst0->opcode",
                                              m.Bits(2)),
             i)
         signal = tester.peek(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+            fault.WrappedVerilogInternalPort("SimpleALU_inst0->opcode",
                                              m.Bits(2)))
         tester.expect(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->opcode",
+            fault.WrappedVerilogInternalPort("SimpleALU_inst0->opcode",
                                              m.Bits(2)),
             signal)
         tester.expect(
             fault.WrappedVerilogInternalPort(
-                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)),
+                "SimpleALU_inst0->config_reg->Q", m.Bits(2)),
             i)
         signal = tester.peek(
             fault.WrappedVerilogInternalPort(
-                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)))
+                "SimpleALU_inst0->config_reg->Q", m.Bits(2)))
         tester.expect(
             fault.WrappedVerilogInternalPort(
-                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)),
+                "SimpleALU_inst0->config_reg->Q", m.Bits(2)),
             signal)
     with tempfile.TemporaryDirectory() as _dir:
         if target == "verilator":

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -264,6 +264,6 @@ def test_tester_verilog_wrapped():
             signal)
     with tempfile.TemporaryDirectory() as _dir:
         if target == "verilator":
-            tester.compile_and_run(target, flags=["-Wno-fatal"])
+            tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
         else:
             tester.compile_and_run(target, directory=_dir, simulator=simulator)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -252,15 +252,15 @@ def test_tester_verilog_wrapped():
                                              m.Bits(2)),
             signal)
         tester.expect(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
-                                             m.Bits(2)),
+            fault.WrappedVerilogInternalPort(
+                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)),
             i)
         signal = tester.peek(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
-                                             m.Bits(2)))
+            fault.WrappedVerilogInternalPort(
+                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)))
         tester.expect(
-            fault.WrappedVerilogInternalPort("top->SimpleALU_inst0->config_reg->Q",
-                                             m.Bits(2)),
+            fault.WrappedVerilogInternalPort(
+                "top->SimpleALU_inst0->config_reg->Q", m.Bits(2)),
             signal)
     with tempfile.TemporaryDirectory() as _dir:
         if target == "verilator":

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -9,14 +9,16 @@ from fault.random import random_bv
 import copy
 import os.path
 import pytest
+import shutil
 
 
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = [(fault.verilator_target.VerilatorTarget, None)]
-        if not os.getenv("TRAVIS", False):
+        if shutil.which("irun"):
             targets.append(
                 (fault.system_verilog_target.SystemVerilogTarget, "ncsim"))
+        if shutil.which("vcs"):
             targets.append(
                 (fault.system_verilog_target.SystemVerilogTarget, "vcs"))
         metafunc.parametrize("target,simulator", targets)


### PR DESCRIPTION
Submitting this PR with the intention of blocking @Kuree. Basically, we need the ability to expect/peek internal signals. One issue is how to do this with wrapped verilog.

@Kuree, I think this should give the basic functionality required to expect values on the internal registers of the wrapped PE. You need to use `verilator_include` to include the public module (verilog module), you need to add a comment in the verilog file on the signals you want to be public, and then you can use `WrappedVerilogInternalPort`. It's clunky, but let me know if this gets you the functionality you require. Can you try checking out and installing this branch of fault? There are docs at https://github.com/leonardt/fault/blob/9c978320c970692b051bb4eaa11420f59d9f6910/doc/actions.md#wrappedveriloginternalport, let me know if you have any questions.

I'm going to continue to work on making this interface easier to use (ideally we can automatically determine the require `verilator_includes` and make it easier to specify a wrapped verilog signal by using standard dot notation) as well as extend it to support internal magma signals (this should be simpler to implement) as well as for the system verilog backend targets.