### PR TITLE
Adds initial implementation of the assume guarantee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ install:
 - pip install pytest-cov pytest-codestyle
 - pip install -r requirements.txt
 - pip install -e .
+# Begin setup CoSA dependencies
+- pysmt-install --z3 --confirm-agreement
+- export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
+- export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
+- pysmt-install --check
+# End setup CoSA dependencies
+
 script:
 - pytest --cov fault --codestyle fault -v --cov-report term-missing tests
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install -r requirements.txt
 - pip install -e .
 # Begin setup CoSA dependencies
-- pysmt-install --z3 --confirm-agreement
+- pysmt-install --msat --confirm-agreement
 - export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
 - export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
 - pysmt-install --check

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,6 +1,7 @@
 from .tester import Tester
 from .value import Value, AnyValue, UnknownValue
 import fault.random
+from .symbolic_tester import SymbolicTester
 
 
 class WrappedVerilogInternalPort:

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -28,18 +28,18 @@ class PortAction(Action):
         return cls(new_port, self.value)
 
 
-def can_poke(port):
+def is_input(port):
     if isinstance(port, SelectPath):
         port = port[-1]
     if isinstance(port, fault.WrappedVerilogInternalPort):
-        return not port.type_.isinput()
+        return port.type_.isinput()
     else:
-        return not port.isinput()
+        return port.isinput()
 
 
 class Poke(PortAction):
     def __init__(self, port, value):
-        if not can_poke(port):
+        if is_input(port):
             raise ValueError(f"Can only poke inputs: {port.debug_name} "
                              f"{type(port)}")
         super().__init__(port, value)

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -77,6 +77,22 @@ class Expect(PortAction):
         super().__init__(port, value)
 
 
+class Assume(PortAction):
+    def __init__(self, port, value):
+        if is_input(port):
+            raise ValueError(f"Can only assume inputs (got {port.debug_name}"
+                             f" of type {type(port)})")
+        super().__init__(port, value)
+
+
+class Guarantee(PortAction):
+    def __init__(self, port, value):
+        if not is_output(port):
+            raise ValueError(f"Can only guarantee on outputs (got"
+                             f"{port.debug_name} of type {type(port)})")
+        super().__init__(port, value)
+
+
 class Peek(Action):
     def __init__(self, port):
         super().__init__()

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -39,13 +39,14 @@ def get_width(port):
 class CoSATarget(VerilogTarget):
     def __init__(self, circuit, directory="build/", skip_compile=False,
                  include_verilog_libraries=[], magma_output="coreir-verilog",
-                 circuit_name=None, magma_opts={}):
+                 circuit_name=None, magma_opts={}, solver="msat"):
         super().__init__(circuit, circuit_name, directory, skip_compile,
                          include_verilog_libraries, magma_output, magma_opts)
         self.state_index = 0
         self.curr_state_pokes = []
         self.step_offset = 0
         self.states = []
+        self.solver = solver
 
     def make_eval(self, i, action):
         return
@@ -158,4 +159,4 @@ expected: True
         with open(ets_file, "w") as f:
             f.write(ets)
         assert not os.system(
-            f"CoSA --problem {problem_file} --solver z3")
+            f"CoSA --problem {problem_file} --solver {self.solver}")

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -1,0 +1,161 @@
+import magma as m
+from fault.verilog_target import VerilogTarget, verilog_name
+from pathlib import Path
+import fault.utils as utils
+import os
+import ast
+import astor
+
+
+class BVReplacer(ast.NodeTransformer):
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and node.func.id == "BitVector":
+            assert isinstance(node.args[0], ast.Num), \
+                "Non constant BVs not implemented"
+            assert isinstance(node.args[1], ast.Num), \
+                "Non constant BVs not implemented"
+            return ast.Name(str(node.args[0].n) + "_" + str(node.args[1].n),
+                            ast.Load())
+        return node
+
+
+class SelfPrefixer(ast.NodeTransformer):
+    def __init__(self, name):
+        self.name = name
+
+    def visit_Name(self, node):
+        if node.id == self.name:
+            return ast.Attribute(ast.Name("self", ast.Load()),
+                                 node.id, node.ctx)
+        return node
+
+
+def get_width(port):
+    if isinstance(port, m._BitType):
+        return 1
+    return len(port)
+
+
+class CoSATarget(VerilogTarget):
+    def __init__(self, circuit, directory="build/", skip_compile=False,
+                 include_verilog_libraries=[], magma_output="coreir-verilog",
+                 circuit_name=None, magma_opts={}):
+        super().__init__(circuit, circuit_name, directory, skip_compile,
+                         include_verilog_libraries, magma_output, magma_opts)
+        self.state_index = 0
+        self.curr_state_pokes = []
+        self.step_offset = 0
+        self.states = []
+
+    def make_eval(self, i, action):
+        return
+
+    def make_expect(self, i, action):
+        return
+
+    def make_poke(self, i, action):
+        name = verilog_name(action.port.name)
+        value = action.value
+        width = get_width(action.port)
+        # self.curr_state_pokes.append(
+        #     f"{name} = {value}_{width}")
+        self.curr_state_pokes.append(
+            f"self.{name} = {value}_{width}")
+
+    def make_print(self, i, action):
+        return
+
+    def make_step(self, i, action):
+        self.step_offset += action.steps
+        if self.step_offset % 2 == 0:
+            if len(self.states) > 0:
+                prefix = f"S{len(self.states) - 1}"
+            else:
+                prefix = "I"
+            self.states.append("\n".join(
+                f"{prefix}: {poke}" for poke in
+                self.curr_state_pokes))
+            self.states[-1] += f"\n{prefix}: pokes_done = False\n"
+            self.curr_state_pokes = []
+
+    def add_assumptions(self):
+        assumptions = []
+        for assumption in self.assumptions:
+            code = utils.get_short_lambda_body_text(assumption.value)
+            tree = ast.parse(code)
+            tree = self.prefix_io_with_self(tree)
+            tree = self.replace_bvs(tree)
+
+            code = astor.to_source(tree).rstrip()
+            assumptions.append(code)
+        assumptions = ";".join(x for x in assumptions)
+        return assumptions
+
+    def prefix_io_with_self(self, tree):
+        for name in self.circuit.interface.ports.keys():
+            tree = SelfPrefixer(name).visit(tree)
+        return tree
+
+    def replace_bvs(self, tree):
+        tree = BVReplacer().visit(tree)
+        return tree
+
+    def generate_code(self, actions):
+        for i, action in enumerate(actions):
+            code = self.generate_action_code(i, action)
+        ets = ""
+        # model_files = f"{self.circuit_name}.v[{self.circuit_name}]"
+        model_files = f"{self.circuit_name}.json"
+        if len(self.states) > 0:
+            for state in self.states:
+                ets += state + "\n"
+            if len(self.states) > 0:
+                prefix = f"S{len(self.states) - 2}"
+            else:
+                prefix = "I"
+            ets = "\n".join(ets.splitlines()[:-2])
+            ets += f"\n{prefix}: pokes_done = True\n\n"
+
+            ets += f"I -> S{0}\n"
+            for i in range(1, len(self.states) - 1):
+                ets += f"S{i - 1} -> S{i}\n"
+            last_i = len(self.states) - 2
+            ets += f"S{last_i} -> S{last_i}\n"
+            model_files += f",{self.circuit_name}.ets"
+        assumptions = self.add_assumptions()
+
+        src = f"""\
+[GENERAL]
+model_file: {model_files}
+add_clock: True
+
+[DEFAULT]
+strategy: ALL
+"""
+        for i, guarantee in enumerate(self.guarantees):
+            formula = utils.get_short_lambda_body_text(guarantee.value)
+            tree = ast.parse(formula)
+            tree = self.prefix_io_with_self(tree)
+            formula = astor.to_source(tree).rstrip()
+            # TODO: More robust symbol replacer on AST
+            formula = formula.replace("and", "&")
+            src += f"""\
+[Problem {i}]
+assumptions: {assumptions}
+formula: pokes_done -> ({formula})
+verification: safety
+prove: True
+expected: True
+"""
+        return src, ets
+
+    def run(self, actions):
+        problem_file = self.directory / Path(f"{self.circuit_name}_problem.txt")
+        ets_file = self.directory / Path(f"{self.circuit_name}.ets")
+        src, ets = self.generate_code(actions)
+        with open(problem_file, "w") as f:
+            f.write(src)
+        with open(ets_file, "w") as f:
+            f.write(ets)
+        assert not os.system(
+            f"CoSA --problem {problem_file} --solver z3")

--- a/fault/symbolic_tester.py
+++ b/fault/symbolic_tester.py
@@ -1,0 +1,90 @@
+import fault
+from fault.tester import Tester
+from fault.wrapper import Wrapper, PortWrapper, InstanceWrapper
+import fault.actions as actions
+
+
+class SymbolicWrapper(Wrapper):
+    def __init__(self, circuit, parent):
+        super().__init__(circuit, parent)
+
+    def __setattr__(self, attr, value):
+        # Hack to stage this after __init__ has been run, should redefine this
+        # method in a metaclass? Could also use a try/except pattern, so the
+        # exceptions only occur during object instantiation
+        if hasattr(self, "circuit") and hasattr(self, "instance_map"):
+            if attr in self.circuit.interface.ports.keys():
+                if isinstance(self.parent, fault.Tester):
+                    self.parent.poke(self.circuit.interface.ports[attr], value)
+                else:
+                    exit(1)
+            else:
+                object.__setattr__(self, attr, value)
+        else:
+            object.__setattr__(self, attr, value)
+
+    def __getattr__(self, attr):
+        # Hack to stage this after __init__ has been run, should redefine this
+        # method in a metaclass?
+        try:
+            if attr in self.circuit.interface.ports.keys():
+                return SymbolicPortWrapper(self.circuit.interface.ports[attr],
+                                           self)
+            elif attr in self.instance_map:
+                return SymbolicInstanceWrapper(self.instance_map[attr], self)
+            else:
+                object.__getattribute__(self, attr)
+        except Exception as e:
+            object.__getattribute__(self, attr)
+
+
+class SymbolicCircuitWrapper(SymbolicWrapper):
+    pass
+
+
+class SymbolicPortWrapper(PortWrapper):
+    def assume(self, pred):
+        select_path = self.select_path
+        select_path.tester.assume(select_path, pred)
+
+    def guarantee(self, pred):
+        select_path = self.select_path
+        select_path.tester.guarantee(select_path, pred)
+
+
+class SymbolicInstanceWrapper(InstanceWrapper):
+    pass
+
+
+class SymbolicTester(Tester):
+    def __init__(self, circuit, clock=None, num_tests=100):
+        super().__init__(circuit, clock)
+        self.num_tests = num_tests
+
+    def assume(self, port, constraint):
+        """
+        Place a constraint on an input port by providing a symbolic expression
+        as a Python lambda or function
+
+            symbolic_tester_inst.assume(top.I, lambda x : x >= 0)
+        """
+        self.actions.append(actions.Assume(port, constraint))
+
+    def guarantee(self, port, constraint):
+        """
+        Assert a property about an output port by providing a symbolic
+        expression as a Python lambda or function
+
+            symbolic_tester_inst.assume(top.O, lambda x : x >= 0)
+        """
+        self.actions.append(actions.Guarantee(port, constraint))
+
+    @property
+    def circuit(self):
+        return SymbolicCircuitWrapper(self._circuit, self)
+
+    def run(self, target="verilator"):
+        if target != "verilator":
+            raise NotImplementedError()
+        self.targets[target].run(self.actions, self.verilator_includes,
+                                 self.num_tests, self._circuit)

--- a/fault/symbolic_tester.py
+++ b/fault/symbolic_tester.py
@@ -1,6 +1,7 @@
 import fault
 from fault.tester import Tester
 from fault.wrapper import Wrapper, PortWrapper, InstanceWrapper
+from fault.cosa_target import CoSATarget
 import fault.actions as actions
 
 
@@ -84,7 +85,16 @@ class SymbolicTester(Tester):
         return SymbolicCircuitWrapper(self._circuit, self)
 
     def run(self, target="verilator"):
-        if target != "verilator":
+        if target == "verilator":
+            self.targets[target].run(self.actions, self.verilator_includes,
+                                     self.num_tests, self._circuit)
+        elif target == "cosa":
+            self.targets[target].run(self.actions)
+        else:
             raise NotImplementedError()
-        self.targets[target].run(self.actions, self.verilator_includes,
-                                 self.num_tests, self._circuit)
+
+    def make_target(self, target: str, **kwargs):
+        if target == "cosa":
+            return CoSATarget(self._circuit, **kwargs)
+        else:
+            return super().make_target(target, **kwargs)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -75,7 +75,11 @@ class SystemVerilogTarget(VerilogTarget):
 
     def make_poke(self, i, action):
         if isinstance(action.port, SelectPath):
-            name = f"dut.{action.port.system_verilog_path}"
+            if len(action.port) > 2:
+                name = f"dut.{action.port.system_verilog_path}"
+            else:
+                # Top level ports assign to the external reg
+                name = verilog_name(action.port[-1].name)
         elif isinstance(action.port, fault.WrappedVerilogInternalPort):
             name = f"dut.{action.port.path}"
         else:

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -8,7 +8,6 @@ from fault.verilator_target import VerilatorTarget
 from fault.system_verilog_target import SystemVerilogTarget
 from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
-from fault.select_path import SelectPath
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 import copy
 

--- a/fault/utils.py
+++ b/fault/utils.py
@@ -1,0 +1,67 @@
+import ast
+import inspect
+import os
+
+
+# From https://gist.github.com/Xion/617c1496ff45f3673a5692c3b0e3f75a
+def get_short_lambda_body_text(lambda_func):
+    """Return the source of a (short) lambda function.
+    If it's impossible to obtain, returns None.
+    """
+    try:
+        source_lines, _ = inspect.getsourcelines(lambda_func)
+    except (IOError, TypeError):
+        return None
+
+    # skip `def`-ed functions and long lambdas
+    if len(source_lines) != 1:
+        return None
+
+    source_text = os.linesep.join(source_lines).strip()
+
+    # find the AST node of a lambda definition
+    # so we can locate it in the source code
+    source_ast = ast.parse(source_text)
+    lambda_node = next((node for node in ast.walk(source_ast)
+                        if isinstance(node, ast.Lambda)), None)
+    if lambda_node is None:  # could be a single line `def fn(x): ...`
+        return None
+
+    # HACK: Since we can (and most likely will) get source lines
+    # where lambdas are just a part of bigger expressions, they will have
+    # some trailing junk after their definition.
+    #
+    # Unfortunately, AST nodes only keep their _starting_ offsets
+    # from the original source, so we have to determine the end ourselves.
+    # We do that by gradually shaving extra junk from after the definition.
+    lambda_text = source_text[lambda_node.col_offset:]
+    lambda_body_text = source_text[lambda_node.body.col_offset:]
+    min_length = len('lambda:_')  # shortest possible lambda expression
+    while len(lambda_text) > min_length:
+        try:
+            # What's annoying is that sometimes the junk even parses,
+            # but results in a *different* lambda. You'd probably have to
+            # be deliberately malicious to exploit it but here's one way:
+            #
+            #     bloop = lambda x: False, lambda x: True
+            #     get_short_lamnda_source(bloop[0])
+            #
+            # Ideally, we'd just keep shaving until we get the same code,
+            # but that most likely won't happen because we can't replicate
+            # the exact closure environment.
+            code = compile(lambda_body_text, '<unused filename>', 'eval')
+
+            # Thus the next best thing is to assume some divergence due
+            # to e.g. LOAD_GLOBAL in original code being LOAD_FAST in
+            # the one compiled above, or vice versa.
+            # But the resulting code should at least be the same *length*
+            # if otherwise the same operations are performed in it.
+            if len(code.co_code) == len(lambda_func.__code__.co_code):
+                # return lambda_text
+                return lambda_body_text
+        except SyntaxError:
+            pass
+        lambda_text = lambda_text[:-1]
+        lambda_body_text = lambda_body_text[:-1]
+
+    return None

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -14,9 +14,7 @@ import math
 from bit_vector import BitVector, SIntVector
 import subprocess
 from fault.random import random_bv
-import ast
-import inspect
-import os
+import fault.utils as utils
 
 
 src_tpl = """\
@@ -109,8 +107,6 @@ class VerilatorTarget(VerilogTarget):
         # Need to check version since they changed how internal signal access
         # works
         self.verilator_version = float(verilator_version.split()[1])
-        self.assumptions = []
-        self.guarantees = []
 
     def make_poke(self, i, action):
         if self.verilator_version > 3.874:
@@ -188,14 +184,6 @@ class VerilatorTarget(VerilogTarget):
         name = verilog_name(action.port.name)
         return [f'printf("{action.port.debug_name} = '
                 f'{action.format_str}\\n", top->{name});']
-
-    def make_assume(self, i, action):
-        self.assumptions.append(action)
-        return ""
-
-    def make_guarantee(self, i, action):
-        self.guarantees.append(action)
-        return ""
 
     def make_expect(self, i, action):
         # For verilator, if an expect is "AnyValue" we don't need to
@@ -352,7 +340,7 @@ class VerilatorTarget(VerilogTarget):
                         guarantee_port = guarantee_port[-1]
                     if guarantee_port is port:
                         # TODO: Support functions too
-                        code = get_short_lambda_body_text(guarantee.value)
+                        code = utils.get_short_lambda_body_text(guarantee.value)
                         # TODO: More robust symbol replacer on AST
                         for port in circuit.interface.ports:
                             code = code.replace("and", "&&")
@@ -371,67 +359,3 @@ class VerilatorTarget(VerilogTarget):
     }}
 """
         return main_body
-
-
-# From https://gist.github.com/Xion/617c1496ff45f3673a5692c3b0e3f75a
-def get_short_lambda_body_text(lambda_func):
-    """Return the source of a (short) lambda function.
-    If it's impossible to obtain, returns None.
-    """
-    try:
-        source_lines, _ = inspect.getsourcelines(lambda_func)
-    except (IOError, TypeError):
-        return None
-
-    # skip `def`-ed functions and long lambdas
-    if len(source_lines) != 1:
-        return None
-
-    source_text = os.linesep.join(source_lines).strip()
-
-    # find the AST node of a lambda definition
-    # so we can locate it in the source code
-    source_ast = ast.parse(source_text)
-    lambda_node = next((node for node in ast.walk(source_ast)
-                        if isinstance(node, ast.Lambda)), None)
-    if lambda_node is None:  # could be a single line `def fn(x): ...`
-        return None
-
-    # HACK: Since we can (and most likely will) get source lines
-    # where lambdas are just a part of bigger expressions, they will have
-    # some trailing junk after their definition.
-    #
-    # Unfortunately, AST nodes only keep their _starting_ offsets
-    # from the original source, so we have to determine the end ourselves.
-    # We do that by gradually shaving extra junk from after the definition.
-    lambda_text = source_text[lambda_node.col_offset:]
-    lambda_body_text = source_text[lambda_node.body.col_offset:]
-    min_length = len('lambda:_')  # shortest possible lambda expression
-    while len(lambda_text) > min_length:
-        try:
-            # What's annoying is that sometimes the junk even parses,
-            # but results in a *different* lambda. You'd probably have to
-            # be deliberately malicious to exploit it but here's one way:
-            #
-            #     bloop = lambda x: False, lambda x: True
-            #     get_short_lamnda_source(bloop[0])
-            #
-            # Ideally, we'd just keep shaving until we get the same code,
-            # but that most likely won't happen because we can't replicate
-            # the exact closure environment.
-            code = compile(lambda_body_text, '<unused filename>', 'eval')
-
-            # Thus the next best thing is to assume some divergence due
-            # to e.g. LOAD_GLOBAL in original code being LOAD_FAST in
-            # the one compiled above, or vice versa.
-            # But the resulting code should at least be the same *length*
-            # if otherwise the same operations are performed in it.
-            if len(code.co_code) == len(lambda_func.__code__.co_code):
-                # return lambda_text
-                return lambda_body_text
-        except SyntaxError:
-            pass
-        lambda_text = lambda_text[:-1]
-        lambda_body_text = lambda_body_text[:-1]
-
-    return None

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -14,6 +14,9 @@ import math
 from bit_vector import BitVector, SIntVector
 import subprocess
 from fault.random import random_bv
+import ast
+import inspect
+import os
 
 
 src_tpl = """\
@@ -287,7 +290,6 @@ class VerilatorTarget(VerilogTarget):
             main_body += self.add_guarantees(circuit, actions, i)
 
 
-
         includes += [f'"V{self.circuit_name}_{include}.h"' for include in
                      self.debug_includes]
 
@@ -371,11 +373,6 @@ class VerilatorTarget(VerilogTarget):
         return main_body
 
 
-import ast
-import inspect
-import os
-
-
 # From https://gist.github.com/Xion/617c1496ff45f3673a5692c3b0e3f75a
 def get_short_lambda_body_text(lambda_func):
     """Return the source of a (short) lambda function.
@@ -436,5 +433,5 @@ def get_short_lambda_body_text(lambda_func):
             pass
         lambda_text = lambda_text[:-1]
         lambda_body_text = lambda_body_text[:-1]
-    
+
     return None

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import subprocess
 import magma as m
 import fault.actions as actions
+from fault.actions import Poke, Eval
 from fault.verilog_target import VerilogTarget, verilog_name
 import fault.value_utils as value_utils
 import fault.verilator_utils as verilator_utils
@@ -12,6 +13,7 @@ from fault.wrapper import PortWrapper, InstanceWrapper
 import math
 from bit_vector import BitVector, SIntVector
 import subprocess
+from fault.random import random_bv
 
 
 src_tpl = """\
@@ -185,11 +187,11 @@ class VerilatorTarget(VerilogTarget):
                 f'{action.format_str}\\n", top->{name});']
 
     def make_assume(self, i, action):
-        self.assumptions.append((i, action))
+        self.assumptions.append(action)
         return ""
 
     def make_guarantee(self, i, action):
-        self.guarantees.append((i, action))
+        self.guarantees.append(action)
         return ""
 
     def make_expect(self, i, action):
@@ -255,7 +257,7 @@ class VerilatorTarget(VerilogTarget):
             code.append(f"top->{name} ^= 1;")
         return code
 
-    def generate_code(self, actions, verilator_includes):
+    def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default
             verilator_includes.insert(
@@ -277,6 +279,15 @@ class VerilatorTarget(VerilogTarget):
             for line in code:
                 main_body += f"  {line}\n"
 
+        for i in range(num_tests):
+            main_body += self.add_assumptions(circuit, actions, i)
+            code = self.make_eval(i, Eval())
+            for line in code:
+                main_body += f"  {line}\n"
+            main_body += self.add_guarantees(circuit, actions, i)
+
+
+
         includes += [f'"V{self.circuit_name}_{include}.h"' for include in
                      self.debug_includes]
 
@@ -292,10 +303,12 @@ class VerilatorTarget(VerilogTarget):
     def run_from_directory(self, cmd):
         return subprocess.call(cmd, cwd=self.directory, shell=True)
 
-    def run(self, actions, verilator_includes=[]):
+    def run(self, actions, verilator_includes=[], num_tests=0,
+            _circuit=None):
         driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
         # Write the verilator driver to file.
-        src = self.generate_code(actions, verilator_includes)
+        src = self.generate_code(actions, verilator_includes, num_tests,
+                                 _circuit)
         with open(driver_file, "w") as f:
             f.write(src)
         # Run a series of commands: run the Makefile output by verilator, and
@@ -304,3 +317,46 @@ class VerilatorTarget(VerilogTarget):
             self.circuit_name)
         assert not self.run_from_directory(verilator_make_cmd)
         assert not self.run_from_directory(f"./obj_dir/V{self.circuit_name}")
+
+    def add_assumptions(self, circuit, actions, i):
+        main_body = ""
+        for port in circuit.interface.ports.values():
+            if port.isoutput():
+                for assumption in self.assumptions:
+                    # TODO: Chained assumptions?
+                    assume_port = assumption.port
+                    if isinstance(assume_port, SelectPath):
+                        assume_port = assume_port[-1]
+                    if assume_port is port:
+                        pred = assumption.value
+                        while True:
+                            randval = random_bv(len(assume_port))
+                            if pred(randval):
+                                break
+                        code = self.make_poke(
+                            len(actions) + i, Poke(port, randval))
+                        for line in code:
+                            main_body += f"  {line}\n"
+                        break
+        return main_body
+
+    def add_guarantees(self, circuit, actions, i):
+        main_body = ""
+        for port in circuit.interface.ports.values():
+            if port.isinput():
+                for guarantee in self.guarantees:
+                    assume_port = guarantee.port
+                    if isinstance(assume_port, SelectPath):
+                        assume_port = assume_port[-1]
+                    if assume_port is port:
+                        pred = guarantee.value
+                        while True:
+                            randval = random_bv(len(assume_port))
+                            if pred(randval):
+                                break
+                        code = self.make_poke(
+                            len(actions) + i, Poke(port, randval))
+                        for line in code:
+                            main_body += f"  {line}\n"
+                        break
+        return main_body

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -342,21 +342,98 @@ class VerilatorTarget(VerilogTarget):
 
     def add_guarantees(self, circuit, actions, i):
         main_body = ""
-        for port in circuit.interface.ports.values():
+        for name, port in circuit.interface.ports.items():
             if port.isinput():
                 for guarantee in self.guarantees:
-                    assume_port = guarantee.port
-                    if isinstance(assume_port, SelectPath):
-                        assume_port = assume_port[-1]
-                    if assume_port is port:
-                        pred = guarantee.value
-                        while True:
-                            randval = random_bv(len(assume_port))
-                            if pred(randval):
-                                break
-                        code = self.make_poke(
-                            len(actions) + i, Poke(port, randval))
-                        for line in code:
-                            main_body += f"  {line}\n"
-                        break
+                    guarantee_port = guarantee.port
+                    if isinstance(guarantee_port, SelectPath):
+                        guarantee_port = guarantee_port[-1]
+                    if guarantee_port is port:
+                        # TODO: Support functions too
+                        code = get_short_lambda_body_text(guarantee.value)
+                        # TODO: More robust symbol replacer on AST
+                        print(name)
+                        code = code.replace(name, f"top->{name}")
+                        main_body += f"""\
+    if (!({code})) {{
+      std::cerr << std::endl;  // end the current line
+      std::cerr << \"Got      : 0x\" << std::hex << top->{name} << std::endl;
+      std::cerr << \"Expected : {code}" << std::endl;
+      std::cerr << \"i        : {i}\" << std::endl;
+      std::cerr << \"Port     : {name}\" << std::endl;
+      #if VM_TRACE
+        tracer->close();
+      #endif
+      exit(1);
+    }}
+"""
         return main_body
+
+
+import ast
+import inspect
+import os
+
+
+# From https://gist.github.com/Xion/617c1496ff45f3673a5692c3b0e3f75a
+def get_short_lambda_body_text(lambda_func):
+    """Return the source of a (short) lambda function.
+    If it's impossible to obtain, returns None.
+    """
+    try:
+        source_lines, _ = inspect.getsourcelines(lambda_func)
+    except (IOError, TypeError):
+        return None
+
+    # skip `def`-ed functions and long lambdas
+    if len(source_lines) != 1:
+        return None
+
+    source_text = os.linesep.join(source_lines).strip()
+
+    # find the AST node of a lambda definition
+    # so we can locate it in the source code
+    source_ast = ast.parse(source_text)
+    lambda_node = next((node for node in ast.walk(source_ast)
+                        if isinstance(node, ast.Lambda)), None)
+    if lambda_node is None:  # could be a single line `def fn(x): ...`
+        return None
+
+    # HACK: Since we can (and most likely will) get source lines
+    # where lambdas are just a part of bigger expressions, they will have
+    # some trailing junk after their definition.
+    #
+    # Unfortunately, AST nodes only keep their _starting_ offsets
+    # from the original source, so we have to determine the end ourselves.
+    # We do that by gradually shaving extra junk from after the definition.
+    lambda_text = source_text[lambda_node.col_offset:]
+    lambda_body_text = source_text[lambda_node.body.col_offset:]
+    min_length = len('lambda:_')  # shortest possible lambda expression
+    while len(lambda_text) > min_length:
+        try:
+            # What's annoying is that sometimes the junk even parses,
+            # but results in a *different* lambda. You'd probably have to
+            # be deliberately malicious to exploit it but here's one way:
+            #
+            #     bloop = lambda x: False, lambda x: True
+            #     get_short_lamnda_source(bloop[0])
+            #
+            # Ideally, we'd just keep shaving until we get the same code,
+            # but that most likely won't happen because we can't replicate
+            # the exact closure environment.
+            code = compile(lambda_body_text, '<unused filename>', 'eval')
+
+            # Thus the next best thing is to assume some divergence due
+            # to e.g. LOAD_GLOBAL in original code being LOAD_FAST in
+            # the one compiled above, or vice versa.
+            # But the resulting code should at least be the same *length*
+            # if otherwise the same operations are performed in it.
+            if len(code.co_code) == len(lambda_func.__code__.co_code):
+                # return lambda_text
+                return lambda_body_text
+        except SyntaxError:
+            pass
+        lambda_text = lambda_text[:-1]
+        lambda_body_text = lambda_body_text[:-1]
+    
+    return None

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -352,7 +352,6 @@ class VerilatorTarget(VerilogTarget):
                         # TODO: Support functions too
                         code = get_short_lambda_body_text(guarantee.value)
                         # TODO: More robust symbol replacer on AST
-                        print(name)
                         code = code.replace(name, f"top->{name}")
                         main_body += f"""\
     if (!({code})) {{

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -352,7 +352,9 @@ class VerilatorTarget(VerilogTarget):
                         # TODO: Support functions too
                         code = get_short_lambda_body_text(guarantee.value)
                         # TODO: More robust symbol replacer on AST
-                        code = code.replace(name, f"top->{name}")
+                        for port in circuit.interface.ports:
+                            code = code.replace("and", "&&")
+                            code = code.replace(port, f"top->{port}")
                         main_body += f"""\
     if (!({code})) {{
       std::cerr << std::endl;  // end the current line

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -104,6 +104,8 @@ class VerilatorTarget(VerilogTarget):
         # Need to check version since they changed how internal signal access
         # works
         self.verilator_version = float(verilator_version.split()[1])
+        self.assumptions = []
+        self.guarantees = []
 
     def make_poke(self, i, action):
         if self.verilator_version > 3.874:
@@ -181,6 +183,14 @@ class VerilatorTarget(VerilogTarget):
         name = verilog_name(action.port.name)
         return [f'printf("{action.port.debug_name} = '
                 f'{action.format_str}\\n", top->{name});']
+
+    def make_assume(self, i, action):
+        self.assumptions.append((i, action))
+        return ""
+
+    def make_guarantee(self, i, action):
+        self.guarantees.append((i, action))
+        return ""
 
     def make_expect(self, i, action):
         # For verilator, if an expect is "AnyValue" we don't need to

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -277,7 +277,6 @@ class VerilatorTarget(VerilogTarget):
                 main_body += f"  {line}\n"
             main_body += self.add_guarantees(circuit, actions, i)
 
-
         includes += [f'"V{self.circuit_name}_{include}.h"' for include in
                      self.debug_includes]
 

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -94,6 +94,10 @@ class VerilogTarget(Target):
             return self.make_eval(i, action)
         if isinstance(action, actions.Step):
             return self.make_step(i, action)
+        if isinstance(action, actions.Assume):
+            return self.make_assume(i, action)
+        if isinstance(action, actions.Guarantee):
+            return self.make_guarantee(i, action)
         raise NotImplementedError(action)
 
     @abstractmethod

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -6,18 +6,7 @@ import fault.actions as actions
 from fault.util import flatten
 import os
 from fault.select_path import SelectPath
-
-
-def verilog_name(name):
-    if isinstance(name, m.ref.DefnRef):
-        return str(name)
-    if isinstance(name, m.ref.ArrayRef):
-        array_name = verilog_name(name.array.name)
-        return f"{array_name}_{name.index}"
-    if isinstance(name, m.ref.TupleRef):
-        tuple_name = verilog_name(name.tuple.name)
-        return f"{tuple_name}_{name.index}"
-    raise NotImplementedError(name, type(name))
+from fault.verilog_utils import verilog_name
 
 
 class VerilogTarget(Target):

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -46,6 +46,17 @@ class VerilogTarget(Target):
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f"Compiling {self.circuit} failed")
 
+        self.assumptions = []
+        self.guarantees = []
+
+    def make_assume(self, i, action):
+        self.assumptions.append(action)
+        return ""
+
+    def make_guarantee(self, i, action):
+        self.guarantees.append(action)
+        return ""
+
     def generate_array_action_code(self, i, action):
         result = []
         port = action.port

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "fault",
     ],
     install_requires=[
-        "astor"
+        "astor",
+        "cosa"
     ],
     license='BSD License',
     url='https://github.com/leonardt/fault',

--- a/tests/common.py
+++ b/tests/common.py
@@ -65,4 +65,7 @@ class SimpleALU(m.Circuit):
     def definition(io):
         opcode = ConfigReg(name="config_reg")(io.config_data, CE=io.config_en)
         io.c <= mantle.mux(
-            [io.a + io.b, io.a - io.b, io.a * io.b, io.a / io.b], opcode)
+            # udiv not implemented
+            # [io.a + io.b, io.a - io.b, io.a * io.b, io.a / io.b], opcode)
+            # use arbitrary fourth op
+            [io.a + io.b, io.a - io.b, io.a * io.b, io.b - io.a], opcode)

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -1,18 +1,30 @@
 import common
 import tempfile
 from fault import SymbolicTester
+from bit_vector import BitVector
 
 
-def test_tester_magma_internal_signals_verilator():
+def pytest_generate_tests(metafunc):
+    if 'target' in metafunc.fixturenames:
+        metafunc.parametrize("target", ["verilator", "cosa"])
+
+
+def test_tester_magma_internal_signals_verilator(target):
     circ = common.SimpleALU
 
     tester = SymbolicTester(circ, circ.CLK, num_tests=100)
     tester.circuit.config_en = 1
     tester.circuit.config_data = 0
     tester.step(2)
+    # TODO: Handle case with only 1 step in cosa backend, then these would just
+    # become assumptions
+    tester.circuit.config_en = 0
+    tester.step(2)
     tester.circuit.config_reg.Q.expect(0)
-    tester.circuit.a.assume(lambda a: a < ((1 << 15)))
-    tester.circuit.b.assume(lambda b: b < ((1 << 15)))
+    tester.circuit.a.assume(lambda a: a < BitVector(32768, 16))
+    tester.circuit.b.assume(lambda b: b < BitVector(32768, 16))
+    # tester.circuit.b.assume(lambda b: b >= BitVector(32768, 16))
+
     # tester.circuit.a.assume(lambda a: a < ((1 << 16) - 1))
     # tester.circuit.b.assume(lambda b: b < ((1 << 16) - 1))
     # TODO: Dependent constraints, e.g.
@@ -21,6 +33,12 @@ def test_tester_magma_internal_signals_verilator():
     # tester.circuit.c.guarantee(lambda x: x > 0)
     tester.circuit.c.guarantee(lambda a, b, c: (c >= a) and (c >= b))
     with tempfile.TemporaryDirectory() as _dir:
-        tester.compile_and_run("verilator", directory=_dir,
-                               flags=["-Wno-fatal"],
-                               magma_opts={"verilator_debug": True})
+        _dir = "build"
+        kwargs = {}
+        if target == "verilator":
+            kwargs["flags"] = ["-Wno-fatal"]
+            kwargs["magma_opts"] = {"verilator_debug": True}
+        elif target == "cosa":
+            kwargs["magma_opts"] = {"passes": ["rungenerators", "flatten",
+                                               "cullgraph"]}
+        tester.compile_and_run(target, directory=_dir, **kwargs)

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -1,0 +1,27 @@
+import common
+import tempfile
+from fault import SymbolicTester
+
+
+def test_tester_magma_internal_signals():
+    circ = common.SimpleALU
+
+    tester = SymbolicTester(circ, circ.CLK, num_tests=100)
+    tester.circuit.config_en = 1
+    tester.circuit.config_data = 0
+    tester.step(2)
+    tester.circuit.config_reg.Q.expect(0)
+    tester.circuit.a.assume(lambda a: a < ((1 << 15)))
+    tester.circuit.b.assume(lambda b: b < ((1 << 15)))
+    # tester.circuit.a.assume(lambda a: a < ((1 << 16) - 1))
+    # tester.circuit.b.assume(lambda b: b < ((1 << 16) - 1))
+    # TODO: Dependent constraints, e.g.
+    # tester.ciruit.assume(lambda a, b: a > 0 and b > a)
+
+    # tester.circuit.c.guarantee(lambda x: x > 0)
+    tester.circuit.c.guarantee(lambda a, b, c: (c >= a) and (c >= b))
+    with tempfile.TemporaryDirectory() as _dir:
+        _dir = "build"
+        tester.compile_and_run("verilator", directory=_dir,
+                               flags=["-Wno-fatal"],
+                               magma_opts={"verilator_debug": True})

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -33,7 +33,6 @@ def test_tester_magma_internal_signals_verilator(target):
     # tester.circuit.c.guarantee(lambda x: x > 0)
     tester.circuit.c.guarantee(lambda a, b, c: (c >= a) and (c >= b))
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
         kwargs = {}
         if target == "verilator":
             kwargs["flags"] = ["-Wno-fatal"]

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -3,7 +3,7 @@ import tempfile
 from fault import SymbolicTester
 
 
-def test_tester_magma_internal_signals():
+def test_tester_magma_internal_signals_verilator():
     circ = common.SimpleALU
 
     tester = SymbolicTester(circ, circ.CLK, num_tests=100)
@@ -21,7 +21,6 @@ def test_tester_magma_internal_signals():
     # tester.circuit.c.guarantee(lambda x: x > 0)
     tester.circuit.c.guarantee(lambda a, b, c: (c >= a) and (c >= b))
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
         tester.compile_and_run("verilator", directory=_dir,
                                flags=["-Wno-fatal"],
                                magma_opts={"verilator_debug": True})


### PR DESCRIPTION
This adds minimum working support for the ability to specify constrained random tests and formal checks using the same interface.

The pattern is:
* Assumptions are specified on specific ports: `tester.circuit.<port>.assume(lambda <IO> : <smt_formula>)`
* Guarantees are specified on specific ports: `tester.circuit.<port>.guarantee(lambda <IO> : <smt_formula>)`

When using the `verilator` target, assumptions are used to filter input test vectors. Guarantees are emitted on every `Eval` action to assert that the property is true.

When using the `cosa` target, assumptions are mapped to the `assumptions` field in the problem file, and guarantees become `formula`s.

There's still quite a bit work to do here, a partial list is:
* Specify the supported language for formulas. This is identical to Peak, basically they should be valid SMT expressions
* Support assumptions/guarantees on joint ports. Right now you can only specify on a single port, but the user might want to guarantee something like `O0 + O1 < 4`.
* Generalize support for `poke` interface w/ `assume`/`guarantee`. Right now, you can use `poke` actions to create an initial `ets`, but in theory it should be possible to interleave `poke` and `assume`/`guarantee` invocations (e.g. make guarantees in certain states).
* Enable specification of assumptions and guarantees in circuit definitions (integration with magma)