### PR TITLE
Updates for magma sequential pe1

### DIFF
--- a/fault/magma_simulator_target.py
+++ b/fault/magma_simulator_target.py
@@ -1,4 +1,4 @@
-from bit_vector import BitVector
+from hwtypes import BitVector
 import magma as m
 from magma.simulator.python_simulator import PythonSimulator
 from magma.simulator.coreir_simulator import CoreIRSimulator

--- a/fault/random.py
+++ b/fault/random.py
@@ -1,5 +1,5 @@
 import random
-from bit_vector import BitVector
+from hwtypes import BitVector
 
 
 def random_bv(width):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -2,7 +2,7 @@ from fault.verilog_target import VerilogTarget, verilog_name
 import magma as m
 from pathlib import Path
 import fault.actions as actions
-from bit_vector import BitVector
+from hwtypes import BitVector
 import fault.value_utils as value_utils
 from fault.select_path import SelectPath
 import subprocess

--- a/fault/test_vector_generator.py
+++ b/fault/test_vector_generator.py
@@ -1,7 +1,7 @@
 import fault
 from fault.random import random_bv, random_bit
 import magma as m
-from bit_vector import BitVector
+from hwtypes import BitVector
 from fault.common import get_renamed_port
 
 

--- a/fault/test_vectors.py
+++ b/fault/test_vectors.py
@@ -82,14 +82,14 @@ def generate_function_test_vectors(circuit, func, input_ranges=None,
                                             2**(num_bits - 1))
                     else:
                         input_range = input_ranges[i]
-                    args.append([SIntVector(x, num_bits=num_bits)
+                    args.append([SIntVector[num_bits](x)
                                  for x in input_range])
                 else:
                     if input_ranges is None:
                         input_range = range(1 << num_bits)
                     else:
                         input_range = input_ranges[i]
-                    args.append([BitVector(x, num_bits=num_bits)
+                    args.append([BitVector[num_bits](x)
                                  for x in input_range])
             else:
                 raise NotImplementedError(type(port))
@@ -131,14 +131,14 @@ def generate_simulator_test_vectors(circuit, input_ranges=None,
                         input_range = range(start, end)
                     else:
                         input_range = input_ranges[i]
-                    args.append([SIntVector(x, num_bits=num_bits)
+                    args.append([SIntVector[num_bits](x)
                                  for x in input_range])
                 else:
                     if input_ranges is None:
                         input_range = range(1 << num_bits)
                     else:
                         input_range = input_ranges[i]
-                    args.append([BitVector(x, num_bits=num_bits)
+                    args.append([BitVector[num_bits](x)
                                  for x in input_range])
             else:
                 assert True, "can't test Tuples"

--- a/fault/test_vectors.py
+++ b/fault/test_vectors.py
@@ -1,6 +1,6 @@
 from magma import BitKind, ArrayKind, SIntKind, UIntKind, BitsKind
 from magma.simulator.python_simulator import PythonSimulator
-from bit_vector import BitVector, SIntVector, UIntVector
+from hwtypes import BitVector, SIntVector, UIntVector
 from inspect import signature
 from itertools import product
 import pytest

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -10,7 +10,6 @@ from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 import copy
-from dataclasses import fields, is_dataclass
 
 
 class Tester:
@@ -88,9 +87,8 @@ class Tester:
         Set `port` to be `value`
         """
         if isinstance(port, m.TupleType):
-            assert is_dataclass(value), "Expected dataclass when setting tuple"
-            for p, f in zip(port, fields(value)):
-                self.poke(p, getattr(value, f.name))
+            for p, v in zip(port, value):
+                self.poke(p, v)
         else:
             value = make_value(port, value)
             self.actions.append(actions.Poke(port, value))

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -10,6 +10,7 @@ from fault.actions import Poke, Expect, Step, Print
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 import copy
+from dataclasses import fields, is_dataclass
 
 
 class Tester:
@@ -86,8 +87,13 @@ class Tester:
         """
         Set `port` to be `value`
         """
-        value = make_value(port, value)
-        self.actions.append(actions.Poke(port, value))
+        if isinstance(port, m.TupleType):
+            assert is_dataclass(value), "Expected dataclass when setting tuple"
+            for p, f in zip(port, fields(value)):
+                self.poke(p, getattr(value, f.name))
+        else:
+            value = make_value(port, value)
+            self.actions.append(actions.Poke(port, value))
 
     def peek(self, port):
         """

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -1,9 +1,11 @@
 import fault
 import magma
-from bit_vector import BitVector
+from hwtypes import BitVector, Bit
 from fault.value import AnyValue, UnknownValue
 from fault.array import Array
+from fault.tuple import Tuple
 from fault.select_path import SelectPath
+from enum import Enum
 
 
 def make_value(port, value):
@@ -16,12 +18,14 @@ def make_value(port, value):
         return make_bit(value)
     if isinstance(switch, (magma.ArrayType, magma.ArrayKind)):
         return make_array(switch.T, switch.N, value)
+    if isinstance(switch, (magma.TupleType, magma.TupleKind)):
+        raise NotImplementedError()
     raise NotImplementedError(switch, value)
 
 
 def make_bit(value):
     # TODO(rsetaluri): Use bit_vector.Bit when implemented.
-    if isinstance(value, BitVector) and value.num_bits == 1:
+    if isinstance(value, BitVector) and len(value) == 1:
         return value
     if value == 0 or value == 1:
         return BitVector(value, 1)
@@ -44,13 +48,19 @@ def make_array(T, N, value):
 
 def make_bit_vector(N, value):
     assert isinstance(N, int)
-    if isinstance(value, BitVector) and N == value.num_bits:
+    if isinstance(value, BitVector[N]):
         return value
+    if isinstance(value, BitVector) and len(value) < N or \
+            isinstance(value, Bit):
+        return BitVector[N](value)
     if isinstance(value, int):
-        return BitVector(value, N)
+        return BitVector[N](value)
     if value is AnyValue or value is UnknownValue:
         return value
-    raise NotImplementedError(N, value)
+    if isinstance(value, Enum):
+        N = type(value).bit_length()
+        return BitVector[N](value.value)
+    raise NotImplementedError(N, value, type(value))
 
 
 def is_any(value):

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -3,7 +3,6 @@ import magma
 from hwtypes import BitVector, Bit
 from fault.value import AnyValue, UnknownValue
 from fault.array import Array
-from fault.tuple import Tuple
 from fault.select_path import SelectPath
 from enum import Enum
 

--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -28,7 +28,7 @@ def make_bit(value):
     if isinstance(value, BitVector) and len(value) == 1:
         return value
     if value == 0 or value == 1:
-        return BitVector(value, 1)
+        return BitVector[1](value)
     if value is AnyValue or value is UnknownValue:
         return value
     raise NotImplementedError(value)

--- a/fault/vector_builder.py
+++ b/fault/vector_builder.py
@@ -1,4 +1,4 @@
-from bit_vector import BitVector
+from hwtypes import BitVector
 import magma
 import fault.actions as actions
 from fault.value_utils import make_value

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -11,7 +11,7 @@ import fault.verilator_utils as verilator_utils
 from fault.select_path import SelectPath
 from fault.wrapper import PortWrapper, InstanceWrapper
 import math
-from bit_vector import BitVector, SIntVector
+from hwtypes import BitVector, SIntVector
 import subprocess
 from fault.random import random_bv
 import fault.utils as utils

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ A Python package for testing hardware (part of the magma ecosystem)\
 
 setup(
     name='fault',
-    version='1.0.8',
+    version='2.0.0',
     description=description,
     scripts=[],
     packages=[
@@ -18,7 +18,7 @@ setup(
     ],
     install_requires=[
         "astor",
-        "coreir==1.0.2",
+        "coreir==2.0.0",
         "cosa"
     ],
     license='BSD License',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     install_requires=[
         "astor",
         "coreir==2.0.0",
-        "cosa"
+        "cosa",
+        "hwtypes>=1.0.*"
     ],
     license='BSD License',
     url='https://github.com/leonardt/fault',

--- a/tests/test_functional_tester.py
+++ b/tests/test_functional_tester.py
@@ -1,5 +1,5 @@
 import fault
-from bit_vector import BitVector
+from hwtypes import BitVector
 from fault.functional_tester import FunctionalTester
 import magma as m
 import mantle

--- a/tests/test_magma_simulator_target.py
+++ b/tests/test_magma_simulator_target.py
@@ -1,4 +1,4 @@
-from bit_vector import BitVector
+from hwtypes import BitVector
 import common
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 from fault.magma_simulator_target import MagmaSimulatorTarget

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -1,7 +1,7 @@
 import common
 import tempfile
 from fault import SymbolicTester
-from bit_vector import BitVector
+from hwtypes import BitVector
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/test_test_vectors.py
+++ b/tests/test_test_vectors.py
@@ -1,7 +1,7 @@
 from itertools import product
 import pytest
 import tempfile
-from bit_vector import BitVector
+from hwtypes import BitVector
 import magma as m
 import mantle
 from common import TestBasicCircuit, TestArrayCircuit, TestSIntCircuit

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,6 +1,6 @@
 import magma as m
 import random
-from bit_vector import BitVector
+from hwtypes import BitVector
 import fault
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek
 import common

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -206,9 +206,9 @@ def test_print_arrays(capsys):
     out, err = capsys.readouterr()
     assert "\n".join(out.splitlines()[1:]) == """\
 Actions:
-    0: Poke(DoubleNestedArraysCircuit.I, Array([Array([BitVector(0, 4), BitVector(1, 4), BitVector(2, 4)], 3), Array([BitVector(3, 4), BitVector(4, 4), BitVector(5, 4)], 3)], 2))
+    0: Poke(DoubleNestedArraysCircuit.I, Array([Array([BitVector[4](0), BitVector[4](1), BitVector[4](2)], 3), Array([BitVector[4](3), BitVector[4](4), BitVector[4](5)], 3)], 2))
     1: Eval()
-    2: Expect(DoubleNestedArraysCircuit.O, Array([Array([BitVector(0, 4), BitVector(1, 4), BitVector(2, 4)], 3), Array([BitVector(3, 4), BitVector(4, 4), BitVector(5, 4)], 3)], 2))
+    2: Expect(DoubleNestedArraysCircuit.O, Array([Array([BitVector[4](0), BitVector[4](1), BitVector[4](2)], 3), Array([BitVector[4](3), BitVector[4](4), BitVector[4](5)], 3)], 2))
     3: Print(DoubleNestedArraysCircuit.O, "%08x")
 """  # nopep8
 

--- a/tests/test_value_utils.py
+++ b/tests/test_value_utils.py
@@ -1,6 +1,6 @@
 import pytest
 import magma as m
-from bit_vector import BitVector
+from hwtypes import BitVector
 from fault.array import Array
 from fault.value_utils import make_value
 from fault.value import AnyValue, UnknownValue

--- a/tests/test_vector_builder.py
+++ b/tests/test_vector_builder.py
@@ -1,5 +1,5 @@
 import random
-from bit_vector import BitVector
+from hwtypes import BitVector
 import fault
 import common
 from fault.actions import Poke, Expect, Eval, Step, Print

--- a/tests/test_verilator_target.py
+++ b/tests/test_verilator_target.py
@@ -1,7 +1,7 @@
 import tempfile
 import magma as m
 import fault
-from bit_vector import BitVector
+from hwtypes import BitVector
 import common
 import random
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -1,7 +1,7 @@
 import tempfile
 import magma as m
 import fault
-from bit_vector import BitVector
+from hwtypes import BitVector
 import common
 import random
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek


### PR DESCRIPTION
Initial migration to `hwtypes`, adds support for poking tuples