### PR TITLE
Determine max_bits from architecture

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -8,6 +8,7 @@ from fault.select_path import SelectPath
 import subprocess
 from fault.wrapper import PortWrapper
 import fault
+import platform
 
 
 src_tpl = """\
@@ -84,8 +85,9 @@ class SystemVerilogTarget(VerilogTarget):
             name = f"dut.{action.port.path}"
         else:
             name = verilog_name(action.port.name)
+        max_bits = 64 if platform.architecture()[0] == "64bit" else 32
         if isinstance(action.value, BitVector) and \
-                action.value.num_bits > 32:
+                action.value.num_bits > max_bits:
             raise NotImplementedError()
         else:
             value = action.value

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -8,7 +8,6 @@ from fault.select_path import SelectPath
 import subprocess
 from fault.wrapper import PortWrapper
 import fault
-import platform
 
 
 src_tpl = """\
@@ -85,18 +84,14 @@ class SystemVerilogTarget(VerilogTarget):
             name = f"dut.{action.port.path}"
         else:
             name = verilog_name(action.port.name)
-        max_bits = 64 if platform.architecture()[0] == "64bit" else 32
-        if isinstance(action.value, BitVector) and \
-                action.value.num_bits > max_bits:
-            raise NotImplementedError()
-        else:
-            value = action.value
-            if isinstance(action.port, m.SIntType) and value < 0:
-                # Handle sign extension for verilator since it expects and
-                # unsigned c type
-                port_len = len(action.port)
-                value = BitVector(value, port_len).as_uint()
-            return [f"{name} = {value};", f"#{self.clock_step_delay}"]
+        # For now we assume that verilog can handle big ints
+        value = action.value
+        if isinstance(action.port, m.SIntType) and value < 0:
+            # Handle sign extension for verilator since it expects and
+            # unsigned c type
+            port_len = len(action.port)
+            value = BitVector(value, port_len).as_uint()
+        return [f"{name} = {value};", f"#{self.clock_step_delay}"]
 
     def make_print(self, i, action):
         name = verilog_name(action.port.name)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -15,6 +15,7 @@ from hwtypes import BitVector, SIntVector
 import subprocess
 from fault.random import random_bv
 import fault.utils as utils
+import platform
 
 
 src_tpl = """\
@@ -149,12 +150,13 @@ class VerilatorTarget(VerilogTarget):
             isinstance(action.port[-1], fault.WrappedVerilogInternalPort) \
             and action.port[-1].path == "outReg"
 
+        max_bits = 64 if platform.architecture()[0] == "64bit" else 32
         if isinstance(action.value, BitVector) and \
-                action.value.num_bits > 32:
+                action.value.num_bits > max_bits:
             asserts = []
-            for i in range(math.ceil(action.value.num_bits / 32)):
-                value = action.value[i * 32:min(
-                    (i + 1) * 32, action.value.num_bits)]
+            for i in range(math.ceil(action.value.num_bits / max_bits)):
+                value = action.value[i * max_bits:min(
+                    (i + 1) * max_bits, action.value.num_bits)]
                 asserts += [f"top->{name}[{i}] = {value};"]
             if is_reg_poke:
                 raise NotImplementedError()


### PR DESCRIPTION
Old code assumed that 32 bits was the max size for an integer, this code now chooses 64 versus 32 depending `platform.architecture()`