### PR TITLE
Add debug_name property to SelectPath

### DIFF
--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -36,5 +36,9 @@ class SelectPath:
     def verilator_path(self):
         return self.make_path("->")
 
+    @property
+    def debug_name(self):
+        return self.make_path('.')
+
     def __len__(self):
         return len(self.path)


### PR DESCRIPTION
This is a very simple change which adds a `debug_name` property to the SelectPath class. This is for debug printing. Currently, if we try to print a test object with `Expect` actions, we get the following error:
```
  File "./test_exercise_1.py", line 31, in <module>
    main()
  File "./test_exercise_1.py", line 28, in main
    test_v1()
  File "./test_exercise_1.py", line 23, in test_v1
    print(simple_alu_tester)
  File "/home/makai/repos/fault/fault/tester.py", line 219, in __str__
    s += f"    {i}: {action}\n"
  File "/home/makai/repos/fault/fault/actions.py", line 23, in __str__
    return f"{type_name}({self.port.debug_name}, {self.value})"
AttributeError: 'SelectPath' object has no attribute 'debug_name'
```

This change just ensures that there's a `debug_name`. Let me know if there's a better way to do this and I can make the change!