### PR TITLE
Allow Printing To Logs That Can Be Parsed By External Programs

### DIFF
--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -187,7 +187,7 @@ class VerilatorTarget(VerilogTarget):
 
     def make_print(self, i, action):
         name = verilog_name(action.port.name)
-        if action.format_str.__contains__("%x"):
+        if action.format_str.__contains__("%x") or action.format_str.__contains__("%d"):
             return [f'printf("'
                     f'{action.format_str}", top->{name});']
         else:

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -194,9 +194,6 @@ class VerilatorTarget(VerilogTarget):
             return [f'printf("'
                     f'{action.format_str}");']
 
-        #return [f'printf("{action.port.debug_name} = '
-        #        f'{action.format_str}\\n", top->{name});']
-
     def make_expect(self, i, action):
         # For verilator, if an expect is "AnyValue" we don't need to
         # perform the expect.

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -187,8 +187,15 @@ class VerilatorTarget(VerilogTarget):
 
     def make_print(self, i, action):
         name = verilog_name(action.port.name)
-        return [f'printf("{action.port.debug_name} = '
-                f'{action.format_str}\\n", top->{name});']
+        if action.format_str.__contains__("%x"):
+            return [f'printf("'
+                    f'{action.format_str}", top->{name});']
+        else:
+            return [f'printf("'
+                    f'{action.format_str}");']
+
+        #return [f'printf("{action.port.debug_name} = '
+        #        f'{action.format_str}\\n", top->{name});']
 
     def make_expect(self, i, action):
         # For verilator, if an expect is "AnyValue" we don't need to
@@ -315,7 +322,7 @@ class VerilatorTarget(VerilogTarget):
         verilator_make_cmd = verilator_utils.verilator_make_cmd(
             self.circuit_name)
         assert not self.run_from_directory(verilator_make_cmd)
-        assert not self.run_from_directory(f"./obj_dir/V{self.circuit_name}")
+        assert not self.run_from_directory(f"./obj_dir/V{self.circuit_name} > ./obj_dir/{self.circuit_name}.log")
 
     def add_assumptions(self, circuit, actions, i):
         main_body = ""


### PR DESCRIPTION
These changes make the verilator backend:
1. Not print the standard prefix to each line
2. Write the output to a file
3. Print lines with no value

These changes are inconsistent with the other backends. I presume better changes will be consistent across all backends.