### PR TITLE
Loop action

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -11,6 +11,9 @@ class Action(ABC):
         """
         raise NotImplementedError()
 
+    def __repr__(self):
+        return str(self)
+
 
 class PortAction(Action):
     def __init__(self, port, value):
@@ -133,3 +136,19 @@ class Step(Action):
 
     def retarget(self, new_circuit, clock):
         return Step(clock, self.steps)
+
+
+class Loop(Action):
+    def __init__(self, n_iter, actions):
+        self.n_iter = n_iter
+        self.actions = actions
+
+    def __str__(self):
+        # TODO: Might be nice to format this print output over multiple lines
+        # for actions
+        return f"Loop({self.n_iter}, {self.actions})"
+
+    def retarget(self, new_circuit, clock):
+        actions = [action.retarget(new_circuit, clock) for action in
+                   self.actions]
+        return Loop(self.n_iter, actions)

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -139,9 +139,10 @@ class Step(Action):
 
 
 class Loop(Action):
-    def __init__(self, n_iter, actions):
+    def __init__(self, n_iter, loop_var, actions):
         self.n_iter = n_iter
         self.actions = actions
+        self.loop_var = loop_var
 
     def __str__(self):
         # TODO: Might be nice to format this print output over multiple lines

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -147,7 +147,7 @@ class Loop(Action):
     def __str__(self):
         # TODO: Might be nice to format this print output over multiple lines
         # for actions
-        return f"Loop({self.n_iter}, {self.actions})"
+        return f"Loop({self.n_iter}, {self.loop_var}, {self.actions})"
 
     def retarget(self, new_circuit, clock):
         actions = [action.retarget(new_circuit, clock) for action in

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -49,10 +49,10 @@ class CoSATarget(VerilogTarget):
         self.solver = solver
 
     def make_eval(self, i, action):
-        return
+        raise NotImplementedError()
 
     def make_expect(self, i, action):
-        return
+        raise NotImplementedError()
 
     def make_poke(self, i, action):
         name = verilog_name(action.port.name)
@@ -64,7 +64,10 @@ class CoSATarget(VerilogTarget):
             f"self.{name} = {value}_{width}")
 
     def make_print(self, i, action):
-        return
+        raise NotImplementedError()
+
+    def make_loop(self, i, action):
+        raise NotImplementedError()
 
     def make_step(self, i, action):
         self.step_offset += action.steps

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -98,6 +98,20 @@ class SystemVerilogTarget(VerilogTarget):
         return [f'$display("{action.port.debug_name} = '
                 f'{action.format_str}", {name});']
 
+    def make_loop(self, i, action):
+        code = []
+        code.append(f"for (int {action.loop_var} = 0;"
+                    f" {action.loop_var} < {action.n_iter};"
+                    f" {action.loop_var}++) begin")
+
+        for inner_action in action.actions:
+            # TODO: Handle relative offset of sub-actions
+            inner_code = self.generate_action_code(i, inner_action)
+            code += ["    " + x for x in inner_code]
+
+        code.append("end")
+        return code
+
     def make_expect(self, i, action):
         if value_utils.is_any(action.value):
             return []

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -227,7 +227,9 @@ class Tester:
 
     def loop(self, n_iter):
         """
-        Returns a new tester with a special
+        Returns a new tester to record actions inside the loop.  The created
+        loop action object maintains a references to the return Tester's
+        `actions` list.
         """
         loop_tester = LoopTester(self.circuit, self.clock,
                                  self.default_print_format_str)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -6,7 +6,7 @@ from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
 from fault.system_verilog_target import SystemVerilogTarget
-from fault.actions import Poke, Expect, Step, Print
+from fault.actions import Poke, Expect, Step, Print, Loop
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 import copy
@@ -90,7 +90,8 @@ class Tester:
             for p, v in zip(port, value):
                 self.poke(p, v)
         else:
-            value = make_value(port, value)
+            if not isinstance(value, LoopIndex):
+                value = make_value(port, value)
             self.actions.append(actions.Poke(port, value))
 
     def peek(self, port):
@@ -114,9 +115,7 @@ class Tester:
         """
         Expect the current value of `port` to be `value`
         """
-        is_peek = isinstance(value, actions.Peek)
-        is_port_wrapper = isinstance(value, PortWrapper)
-        if not (is_peek or is_port_wrapper):
+        if not isinstance(value, (actions.Peek, PortWrapper, LoopIndex)):
             value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 
@@ -225,3 +224,32 @@ class Tester:
     @property
     def circuit(self):
         return CircuitWrapper(self._circuit, self)
+
+
+    def loop(self, n_iter):
+        """
+        Returns a new tester with a special
+        """
+        loop_tester = LoopTester(self.circuit, self.clock,
+                             self.default_print_format_str)
+        self.actions.append(Loop(n_iter, loop_tester.index,
+                                 loop_tester.actions))
+        return loop_tester
+
+
+class LoopIndex:
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
+
+class LoopTester(Tester):
+    __unique_index_id = -1
+    def __init__(self, circuit: m.Circuit, clock: m.ClockType = None,
+                 default_print_format_str: str = "%x"):
+        super().__init__(circuit, clock, default_print_format_str)
+        LoopTester.__unique_index_id += 1
+        self.index = LoopIndex(
+            f"__fault_loop_var_action_{LoopTester.__unique_index_id}")

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -225,13 +225,12 @@ class Tester:
     def circuit(self):
         return CircuitWrapper(self._circuit, self)
 
-
     def loop(self, n_iter):
         """
         Returns a new tester with a special
         """
         loop_tester = LoopTester(self.circuit, self.clock,
-                             self.default_print_format_str)
+                                 self.default_print_format_str)
         self.actions.append(Loop(n_iter, loop_tester.index,
                                  loop_tester.actions))
         return loop_tester
@@ -247,6 +246,7 @@ class LoopIndex:
 
 class LoopTester(Tester):
     __unique_index_id = -1
+
     def __init__(self, circuit: m.Circuit, clock: m.ClockType = None,
                  default_print_format_str: str = "%x"):
         super().__init__(circuit, clock, default_print_format_str)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -258,6 +258,20 @@ class VerilatorTarget(VerilogTarget):
             code.append("#endif")
         return code
 
+    def make_loop(self, i, action):
+        code = []
+        code.append(f"for (int {action.loop_var} = 0;"
+                    f" {action.loop_var} < {action.n_iter};"
+                    f" {action.loop_var}++) {{")
+
+        for inner_action in action.actions:
+            # TODO: Handle relative offset of sub-actions
+            inner_code = self.generate_action_code(i, inner_action)
+            code += ["    " + x for x in inner_code]
+
+        code.append("}")
+        return code
+
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -99,6 +99,8 @@ class VerilogTarget(Target):
             return self.make_assume(i, action)
         if isinstance(action, actions.Guarantee):
             return self.make_guarantee(i, action)
+        if isinstance(action, actions.Loop):
+            return self.make_loop(i, action)
         raise NotImplementedError(action)
 
     @abstractmethod
@@ -119,4 +121,8 @@ class VerilogTarget(Target):
 
     @abstractmethod
     def make_step(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_loop(self, i, action):
         pass

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,4 @@
-from fault.actions import Poke, Expect, Eval, Step, Print, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek, Loop
 import common
 
 
@@ -10,3 +10,5 @@ def test_action_strs():
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
     assert str(Print(circ.O, "%08x")) == 'Print(BasicClkCircuit.O, "%08x")'
     assert str(Peek(circ.O)) == 'Peek(BasicClkCircuit.O)'
+    assert str(Loop(12, [Peek(circ.O), Poke(circ.I, 1)])) == \
+        'Loop(12, [Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -10,5 +10,7 @@ def test_action_strs():
     assert str(Step(circ.CLK, 1)) == 'Step(BasicClkCircuit.CLK, steps=1)'
     assert str(Print(circ.O, "%08x")) == 'Print(BasicClkCircuit.O, "%08x")'
     assert str(Peek(circ.O)) == 'Peek(BasicClkCircuit.O)'
-    assert str(Loop(12, [Peek(circ.O), Poke(circ.I, 1)])) == \
-        'Loop(12, [Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'
+    index = f"__fault_loop_var_action_0"
+    assert str(Loop(12, index, [Peek(circ.O), Poke(circ.I, 1)])) == \
+        f'Loop(12, {index}, ' \
+        f'[Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -10,6 +10,9 @@ def pytest_generate_tests(metafunc):
 
 
 def test_tester_magma_internal_signals_verilator(target):
+    if target == "cosa":
+        import pytest
+        pytest.skip("Regression introduced by latest cosa version")
     circ = common.SimpleALU
 
     tester = SymbolicTester(circ, circ.CLK, num_tests=100)

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -20,7 +20,9 @@ def test_tester_magma_internal_signals_verilator(target):
     # become assumptions
     tester.circuit.config_en = 0
     tester.step(2)
-    tester.circuit.config_reg.Q.expect(0)
+    if target == "verilator":
+        # TODO: We could turn this expect into a CoSA assert
+        tester.circuit.config_reg.Q.expect(0)
     tester.circuit.a.assume(lambda a: a < BitVector(32768, 16))
     tester.circuit.b.assume(lambda b: b < BitVector(32768, 16))
     # tester.circuit.b.assume(lambda b: b >= BitVector(32768, 16))

--- a/tests/test_symbolic_tester.py
+++ b/tests/test_symbolic_tester.py
@@ -10,9 +10,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_tester_magma_internal_signals_verilator(target):
-    if target == "cosa":
-        import pytest
-        pytest.skip("Regression introduced by latest cosa version")
     circ = common.SimpleALU
 
     tester = SymbolicTester(circ, circ.CLK, num_tests=100)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -287,7 +287,6 @@ def test_tester_loop(target, simulator):
                                  Expect(circ.O, loop.index)]):
         check(actual, expected)
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
         if target == "verilator":
             tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
         else:

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -273,7 +273,7 @@ def test_tester_verilog_wrapped(target, simulator):
 
 
 def test_tester_loop(target, simulator):
-    circ = common.TestBasicCircuit
+    circ = common.TestArrayCircuit
     tester = fault.Tester(circ)
     tester.zero_inputs()
     loop = tester.loop(7)

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -4,7 +4,7 @@ import fault
 from hwtypes import BitVector
 import common
 import random
-from fault.actions import Poke, Expect, Eval, Step, Print, Peek
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek, Loop
 from fault.random import random_bv
 import copy
 import os.path


### PR DESCRIPTION
Initial implementation of loop action for TBG, only tested on verilator.

Here's the generated `main` for `test_tester_loop`

```cpp
 int main(int argc, char **argv) {
  Verilated::commandArgs(argc, argv);
  VArrayCircuit* top = new VArrayCircuit;

#if VM_TRACE
  Verilated::traceEverOn(true);
  tracer = new VerilatedVcdC;
  top->trace(tracer, 99);
  mkdir("logs", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
  tracer->open("logs/ArrayCircuit.vcd");
#endif

  top->I = 0;
  for (int __fault_loop_var_action_0 = 0; __fault_loop_var_action_0 < 7; __fault_loop_var_action_0++) {
      top->I = __fault_loop_var_action_0;
      top->eval();
      main_time++;
      #if VM_TRACE
      tracer->dump(main_time);
      #endif
      my_assert(top->O, __fault_loop_var_action_0, 1, "ArrayCircuit.O");
  }


#if VM_TRACE
  tracer->close();
#endif
}
```