### PR TITLE
Initial support for File IO

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -153,3 +153,53 @@ class Loop(Action):
         actions = [action.retarget(new_circuit, clock) for action in
                    self.actions]
         return Loop(self.n_iter, actions)
+
+class FileOpen(Action):
+    def __init__(self, file):
+        super().__init__()
+        self.file = file
+
+    def __str__(self):
+        return f"FileOpen({self.file})"
+
+    def retarget(self, new_circuit, clock):
+        return FileOpen(self.file)
+
+
+class FileRead(Action):
+    def __init__(self, file, n_char):
+        super().__init__()
+        self.file = file
+        self.n_char = n_char
+
+    def __str__(self):
+        return f"FileRead({self.file}, {self.n_char})"
+
+    def retarget(self, new_circuit, clock):
+        return FileRead(self.file)
+
+
+class FileWrite(Action):
+    def __init__(self, file, value, n_char):
+        super().__init__()
+        self.file = file
+        self.value = value
+        self.n_char = n_char
+
+    def __str__(self):
+        return f"FileWrite({self.file}, {self.value}, {self.n_char})"
+
+    def retarget(self, new_circuit, clock):
+        return FileWrite(self.file, self.value)
+
+
+class FileClose(Action):
+    def __init__(self, file):
+        super().__init__()
+        self.file = file
+
+    def __str__(self):
+        return f"FileClose({self.file})"
+
+    def retarget(self, new_circuit, clock):
+        return FileClose(self.file)

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -154,6 +154,7 @@ class Loop(Action):
                    self.actions]
         return Loop(self.n_iter, actions)
 
+
 class FileOpen(Action):
     def __init__(self, file):
         """

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -156,6 +156,9 @@ class Loop(Action):
 
 class FileOpen(Action):
     def __init__(self, file):
+        """
+        mode: "r" or "w" for read/write permissions
+        """
         super().__init__()
         self.file = file
 
@@ -167,27 +170,25 @@ class FileOpen(Action):
 
 
 class FileRead(Action):
-    def __init__(self, file, n_char):
+    def __init__(self, file):
         super().__init__()
         self.file = file
-        self.n_char = n_char
 
     def __str__(self):
-        return f"FileRead({self.file}, {self.n_char})"
+        return f"FileRead({self.file})"
 
     def retarget(self, new_circuit, clock):
         return FileRead(self.file)
 
 
 class FileWrite(Action):
-    def __init__(self, file, value, n_char):
+    def __init__(self, file, value):
         super().__init__()
         self.file = file
         self.value = value
-        self.n_char = n_char
 
     def __str__(self):
-        return f"FileWrite({self.file}, {self.value}, {self.n_char})"
+        return f"FileWrite({self.file}, {self.value})"
 
     def retarget(self, new_circuit, clock):
         return FileWrite(self.file, self.value)

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -69,6 +69,18 @@ class CoSATarget(VerilogTarget):
     def make_loop(self, i, action):
         raise NotImplementedError()
 
+    def make_file_open(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_close(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_read(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_write(self, i, action):
+        raise NotImplementedError()
+
     def make_step(self, i, action):
         self.step_offset += action.steps
         if self.step_offset % 2 == 0:

--- a/fault/file.py
+++ b/fault/file.py
@@ -12,9 +12,3 @@ class File:
 
     def __str__(self):
         return f'File<"{self.name}">'
-
-#     def read(self, n_char=1):
-#         return actions.FileRead(self, n_char)
-
-#     def write(self, value, n_char=1):
-#         self.tester.actions.append(actions.FileWrite(self, value, n_char))

--- a/fault/file.py
+++ b/fault/file.py
@@ -1,16 +1,20 @@
 import fault.actions as actions
+import os
 
 
 class File:
-    def __init__(self, file_name, tester):
-        self.file_name = file_name
+    def __init__(self, name, tester, mode, chunk_size):
+        self.name = name
         self.tester = tester
+        self.mode = mode
+        self.chunk_size = chunk_size
+        self.name_without_ext = os.path.splitext(self.name)[0]
 
     def __str__(self):
-        return f'File<"{self.file_name}">'
+        return f'File<"{self.name}">'
 
-    def read(self, n_char=1):
-        return actions.FileRead(self, n_char)
+#     def read(self, n_char=1):
+#         return actions.FileRead(self, n_char)
 
-    def write(self, value, n_char=1):
-        self.tester.actions.append(actions.FileWrite(self, value, n_char))
+#     def write(self, value, n_char=1):
+#         self.tester.actions.append(actions.FileWrite(self, value, n_char))

--- a/fault/file.py
+++ b/fault/file.py
@@ -1,0 +1,16 @@
+import fault.actions as actions
+
+
+class File:
+    def __init__(self, file_name, tester):
+        self.file_name = file_name
+        self.tester = tester
+
+    def __str__(self):
+        return f'File<"{self.file_name}">'
+
+    def read(self, n_char=1):
+        return actions.FileRead(self, n_char)
+
+    def write(self, value, n_char=1):
+        self.tester.actions.append(actions.FileWrite(self, value, n_char))

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -112,6 +112,18 @@ class SystemVerilogTarget(VerilogTarget):
         code.append("end")
         return code
 
+    def make_file_open(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_close(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_read(self, i, action):
+        raise NotImplementedError()
+
+    def make_file_write(self, i, action):
+        raise NotImplementedError()
+
     def make_expect(self, i, action):
         if value_utils.is_any(action.value):
             return []

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -9,6 +9,7 @@ from fault.system_verilog_target import SystemVerilogTarget
 from fault.actions import Poke, Expect, Step, Print, Loop
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
+from fault.file import File
 import copy
 
 
@@ -90,7 +91,7 @@ class Tester:
             for p, v in zip(port, value):
                 self.poke(p, v)
         else:
-            if not isinstance(value, LoopIndex):
+            if not isinstance(value, (LoopIndex, actions.FileRead)):
                 value = make_value(port, value)
             self.actions.append(actions.Poke(port, value))
 
@@ -237,13 +238,25 @@ class Tester:
                                  loop_tester.actions))
         return loop_tester
 
-    def file_open(self, file_name):
-        file = File(file_name, self)
+    def file_open(self, file_name, mode="r", chunk_size=1):
+        """
+        mode : "r" for read, "w" for write
+        chunk_size : number of bytes per read/write
+        """
+        file = File(file_name, self, mode, chunk_size)
         self.actions.append(actions.FileOpen(file))
         return file
 
     def file_close(self, file):
         self.actions.append(actions.FileClose(file))
+
+    def file_read(self, file):
+        read_action = actions.FileRead(file)
+        self.actions.append(read_action)
+        return read_action
+
+    def file_write(self, file, value):
+        self.actions.append(actions.FileWrite(file, value))
 
 
 class LoopIndex:

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -237,6 +237,14 @@ class Tester:
                                  loop_tester.actions))
         return loop_tester
 
+    def file_open(self, file_name):
+        file = File(file_name, self)
+        self.actions.append(actions.FileOpen(file))
+        return file
+
+    def file_close(self, file):
+        self.actions.append(actions.FileClose(file))
+
 
 class LoopIndex:
     def __init__(self, name):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -282,7 +282,8 @@ class VerilatorTarget(VerilogTarget):
             mode = "out"
         code = f"""\
 char {name}_in[{action.file.chunk_size}] = {{0}};
-std::fstream {name}_file("{action.file.name}", std::ios::{mode} | std::ios::binary);
+std::fstream {name}_file("{action.file.name}", std::ios::{mode} |
+                                               std::ios::binary);
 if (!{name}_file.is_open()) {{
     std::cout << "Could not open file {action.file.name}" << std::endl;
     return 1;
@@ -295,15 +296,18 @@ if (!{name}_file.is_open()) {{
     def make_file_write(self, i, action):
         value = f"top->{verilog_name(action.value.name)}"
         code = f"""\
-{action.file.name_without_ext}_file.write((char *)&{value}, {action.file.chunk_size});
+{action.file.name_without_ext}_file.write((char *)&{value},
+                                          {action.file.chunk_size});
 """
         return [code]
 
     def make_file_read(self, i, action):
         code = f"""\
-{action.file.name_without_ext}_file.read({action.file.name_without_ext}_in, {action.file.chunk_size});
+{action.file.name_without_ext}_file.read({action.file.name_without_ext}_in,
+                                         {action.file.chunk_size});
 if ({action.file.name_without_ext}_file.eof()) {{
-    std::cout << "Reached end of file {action.file.name_without_ext}" << std::endl;
+    std::cout << "Reached end of file {action.file.name_without_ext}"
+              << std::endl;
     break;
 }}
 """

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -165,6 +165,8 @@ class VerilatorTarget(VerilogTarget):
             return asserts
         else:
             value = action.value
+            if isinstance(value, actions.FileRead):
+                value = f"*{value.file.name_without_ext}_in"
             if isinstance(action.port, m.SIntType) and value < 0:
                 # Handle sign extension for verilator since it expects and
                 # unsigned c type
@@ -272,6 +274,41 @@ class VerilatorTarget(VerilogTarget):
         code.append("}")
         return code
 
+    def make_file_open(self, i, action):
+        name = action.file.name_without_ext
+        if action.file.mode == "r":
+            mode = "in"
+        else:
+            mode = "out"
+        code = f"""\
+char {name}_in[{action.file.chunk_size}] = {{0}};
+std::fstream {name}_file("{action.file.name}", std::ios::{mode} | std::ios::binary);
+if (!{name}_file.is_open()) {{
+    std::cout << "Could not open file {action.file.name}" << std::endl;
+    return 1;
+}}"""
+        return code.splitlines()
+
+    def make_file_close(self, i, action):
+        return [f"{action.file.name_without_ext}_file.close();"]
+
+    def make_file_write(self, i, action):
+        value = f"top->{verilog_name(action.value.name)}"
+        code = f"""\
+{action.file.name_without_ext}_file.write((char *)&{value}, {action.file.chunk_size});
+"""
+        return [code]
+
+    def make_file_read(self, i, action):
+        code = f"""\
+{action.file.name_without_ext}_file.read({action.file.name_without_ext}_in, {action.file.chunk_size});
+if ({action.file.name_without_ext}_file.eof()) {{
+    std::cout << "Reached end of file {action.file.name_without_ext}" << std::endl;
+    break;
+}}
+"""
+        return code.splitlines()
+
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default
@@ -283,6 +320,7 @@ class VerilatorTarget(VerilogTarget):
              verilator_includes] + [
             '"verilated.h"',
             '<iostream>',
+            '<fstream>',
             '<verilated_vcd_c.h>',
             '<sys/types.h>',
             '<sys/stat.h>',

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -101,6 +101,14 @@ class VerilogTarget(Target):
             return self.make_guarantee(i, action)
         if isinstance(action, actions.Loop):
             return self.make_loop(i, action)
+        if isinstance(action, actions.FileOpen):
+            return self.make_file_open(i, action)
+        if isinstance(action, actions.FileWrite):
+            return self.make_file_write(i, action)
+        if isinstance(action, actions.FileRead):
+            return self.make_file_read(i, action)
+        if isinstance(action, actions.FileClose):
+            return self.make_file_close(i, action)
         raise NotImplementedError(action)
 
     @abstractmethod
@@ -125,4 +133,20 @@ class VerilogTarget(Target):
 
     @abstractmethod
     def make_loop(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_file_open(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_file_close(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_file_read(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_file_write(self, i, action):
         pass

--- a/tests/common.py
+++ b/tests/common.py
@@ -19,6 +19,7 @@ def define_simple_circuit(T, circ_name, has_clk=False):
 
 TestBasicCircuit = define_simple_circuit(m.Bit, "BasicCircuit")
 TestArrayCircuit = define_simple_circuit(m.Array[3, m.Bit], "ArrayCircuit")
+TestByteCircuit = define_simple_circuit(m.Bits[8], "ByteCircuit")
 TestSIntCircuit = define_simple_circuit(m.SInt[3], "SIntCircuit")
 TestNestedArraysCircuit = define_simple_circuit(m.Array[3, m.Bits[4]],
                                                 "NestedArraysCircuit")

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -18,8 +18,8 @@ def test_action_strs():
     assert str(Loop(12, index, [Peek(circ.O), Poke(circ.I, 1)])) == \
         f'Loop(12, {index}, ' \
         f'[Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'
-    file = File("my_file", Tester(circ))
+    file = File("my_file", Tester(circ), "r", 1)
     assert str(FileOpen(file)) == 'FileOpen(File<"my_file">)'
-    assert str(FileRead(file, 1)) == 'FileRead(File<"my_file">, 1)'
-    assert str(FileWrite(file, 3, 1)) == 'FileWrite(File<"my_file">, 3, 1)'
+    assert str(FileRead(file)) == 'FileRead(File<"my_file">)'
+    assert str(FileWrite(file, 3)) == 'FileWrite(File<"my_file">, 3)'
     assert str(FileClose(file)) == 'FileClose(File<"my_file">)'

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,4 +1,8 @@
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek, Loop
+from fault import Tester
+from fault.actions import Poke, Expect, Eval, Step, Print, Peek, FileOpen, \
+    FileRead, FileWrite, FileClose, Loop
+from fault.file import File
 import common
 
 
@@ -14,3 +18,8 @@ def test_action_strs():
     assert str(Loop(12, index, [Peek(circ.O), Poke(circ.I, 1)])) == \
         f'Loop(12, {index}, ' \
         f'[Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'
+    file = File("my_file", Tester(circ))
+    assert str(FileOpen(file)) == 'FileOpen(File<"my_file">)'
+    assert str(FileRead(file, 1)) == 'FileRead(File<"my_file">, 1)'
+    assert str(FileWrite(file, 3, 1)) == 'FileWrite(File<"my_file">, 3, 1)'
+    assert str(FileClose(file)) == 'FileClose(File<"my_file">)'

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -294,6 +294,9 @@ def test_tester_loop(target, simulator):
 
 
 def test_tester_file_io(target, simulator):
+    if target == "system-verilog":
+        import pytest
+        pytest.skip("File IO not yet implemented for system-verilog target")
     circ = common.TestByteCircuit
     tester = fault.Tester(circ)
     tester.zero_inputs()

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -308,7 +308,6 @@ def test_tester_file_io(target, simulator):
     tester.file_close(file_in)
     tester.file_close(file_out)
     with tempfile.TemporaryDirectory() as _dir:
-        _dir = "build"
         with open(_dir + "/test_file_in.raw", "wb") as file:
             file.write(bytes([i for i in range(8)]))
         if target == "verilator":

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -294,7 +294,7 @@ def test_tester_loop(target, simulator):
 
 
 def test_tester_file_io(target, simulator):
-    circ = common.TestArrayCircuit
+    circ = common.TestByteCircuit
     tester = fault.Tester(circ)
     tester.zero_inputs()
     file_in = tester.file_open("test_file_in.raw", "r")

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -291,3 +291,29 @@ def test_tester_loop(target, simulator):
             tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
         else:
             tester.compile_and_run(target, directory=_dir, simulator=simulator)
+
+
+def test_tester_file_io(target, simulator):
+    circ = common.TestArrayCircuit
+    tester = fault.Tester(circ)
+    tester.zero_inputs()
+    file_in = tester.file_open("test_file_in.raw", "r")
+    file_out = tester.file_open("test_file_out.raw", "w")
+    loop = tester.loop(8)
+    value = loop.file_read(file_in)
+    loop.poke(circ.I, value)
+    loop.eval()
+    loop.expect(circ.O, loop.index)
+    loop.file_write(file_out, circ.O)
+    tester.file_close(file_in)
+    tester.file_close(file_out)
+    with tempfile.TemporaryDirectory() as _dir:
+        _dir = "build"
+        with open(_dir + "/test_file_in.raw", "wb") as file:
+            file.write(bytes([i for i in range(8)]))
+        if target == "verilator":
+            tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
+        else:
+            tester.compile_and_run(target, directory=_dir, simulator=simulator)
+        with open(_dir + "/test_file_out.raw", "rb") as file:
+            assert file.read(8) == bytes([i for i in range(8)])


### PR DESCRIPTION
We should do a design review on the interface and clean it up, but this should be sufficient for implementing TBG.

Right now it assumes that files are read with a fixed chunk size (number of bytes) specified when a file is open. Reading a file is done using the `file_read` method, however this reads into a singleton, pre-declared buffer (based on a fixed chunk size). So two calls to read will write to the same buffer (right now the interface gives an illusion that the old read value could be stored). We could remedy this by generating a new buffer for each read, but this would cause space consumption to grow linearly with number of independent reads (We could leverage some analysis at the python level to determine the lifetime of read values, but this would be complex and I suspect fraught with edge cases). Another option is to redesign the interface to make it more clear that only one value can be read out of a file at a time (e.g. `file_inst.curr_read_value`).