### PR TITLE
Add basic support for poke/expect X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ addons:
   apt:
     packages:
     - verilator
+    - iverilog
 # python managed by conda until 3.7 available
 # python:
 # - '3.6'

--- a/tests/common.py
+++ b/tests/common.py
@@ -70,3 +70,11 @@ class SimpleALU(m.Circuit):
             # [io.a + io.b, io.a - io.b, io.a * io.b, io.a / io.b], opcode)
             # use arbitrary fourth op
             [io.a + io.b, io.a - io.b, io.a * io.b, io.b - io.a], opcode)
+
+
+class AndCircuit(m.Circuit):
+    IO = ["I0", m.In(m.Bit), "I1", m.In(m.Bit), "O", m.Out(m.Bit)]
+
+    @classmethod
+    def definition(io):
+        io.O <= io.I0 & io.I1


### PR DESCRIPTION
From what I understand, verilator does not support X (see https://www.veripool.org/projects/verilator/wiki/Manual-verilator#Unknown-states)

This add support for poking/expecting with `fault.UnknownValue` for the `system-verilog` targets (compiled by translating to a Verilog `'X`).