### PR TITLE
Use is instead of == for port equality

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -110,7 +110,7 @@ class Peek(Action):
         return cls(new_port)
 
     def __eq__(self, other):
-        return self.port == other.port
+        return self.port is other.port
 
     def __str__(self):
         return f"Peek({self.port.debug_name})"


### PR DESCRIPTION
`==` corresponds to instancing a `mantle.EQ` circuit for magma circuit ports.  For the actions `__eq__` method we want to check equality for testing purposes (e.g. compare a generated action sequence versus a manually crafted expected action sequence), so it should be using `is` instead of `==` to check object equality (versus just creating an EQ circuit).