### PR TITLE
Fix logic for signed expect/poke

### DIFF
--- a/fault/random.py
+++ b/fault/random.py
@@ -1,8 +1,9 @@
+
 import typing as tp
 import random
 import itertools as it
 from hwtypes import AbstractBitVector, AbstractBit
-from hwtypes import BitVector, Bit
+from hwtypes import BitVector, Bit, SIntVector
 from hwtypes import z3BitVector, z3Bit
 from collections.abc import Mapping
 import z3

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -286,14 +286,14 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
                                     capture_output=True)
         elif self.simulator == "iverilog":
             result = subprocess.run(f"vvp -N {self.circuit_name}_tb",
-                                    cwd=self.directory, shell=True)
+                                    cwd=self.directory, shell=True,
+                                    capture_output=True)
         if self.simulator in {"vcs", "iverilog"}:
-            assert not result.returncode, \
-                f"Running {self.simulator} binary failed"
             # VCS and iverilog do not set the return code when a
             # simulation exits with an error, so we check the result
             # of stdout to see if "Error" is present
-            if result.stdout:
-                print(result.stdout.decode())
-                assert "Error" not in str(result.stdout), \
-                    f"\"Error\" found during {self.simulator} run"
+            print(result.stdout.decode())
+            assert not result.returncode, \
+                f"Running {self.simulator} binary failed"
+            assert "Error" not in str(result.stdout), \
+                f"\"Error\" found in stdout of {self.simulator} run"

--- a/tests/common.py
+++ b/tests/common.py
@@ -20,7 +20,7 @@ def define_simple_circuit(T, circ_name, has_clk=False):
 TestBasicCircuit = define_simple_circuit(m.Bit, "BasicCircuit")
 TestArrayCircuit = define_simple_circuit(m.Array[3, m.Bit], "ArrayCircuit")
 TestByteCircuit = define_simple_circuit(m.Bits[8], "ByteCircuit")
-TestSIntCircuit = define_simple_circuit(m.SInt[3], "SIntCircuit")
+TestSIntCircuit = define_simple_circuit(m.SInt[4], "SIntCircuit")
 TestNestedArraysCircuit = define_simple_circuit(m.Array[3, m.Bits[4]],
                                                 "NestedArraysCircuit")
 TestDoubleNestedArraysCircuit = define_simple_circuit(

--- a/tests/test_constrained_random.py
+++ b/tests/test_constrained_random.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 from fault.random import ConstrainedRandomGenerator
 
 N = 8
@@ -6,6 +7,7 @@ WIDTH = 8
 
 
 def test_constrained_random():
+    random.seed(0)
     v = dict(x=WIDTH, y=WIDTH, z=WIDTH)
 
     def pred(x, y, z):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -351,16 +351,16 @@ def test_sint_circuit(target, simulator):
     circ = common.TestSIntCircuit
     tester = fault.Tester(circ)
 
-    inputs = [hwtypes.SIntVector.random(3) for _ in range(10)]
+    inputs = [hwtypes.SIntVector.random(4) for _ in range(10)]
 
     # have at least a few negative tests
     while sum(bool(x < 0) for x in inputs) < 3:
-        inputs = [hwtypes.SIntVector.random(3) for _ in range(10)]
+        inputs = [hwtypes.SIntVector.random(4) for _ in range(10)]
 
     for i in range(10):
-        tester.circuit.I = inputs[i]
+        tester.circuit.I = int(inputs[i])
         tester.eval()
-        tester.circuit.O.expect(inputs[i])
+        tester.circuit.O.expect(int(inputs[i]))
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {"target": target, "directory": _dir}
         if target == "system-verilog":


### PR DESCRIPTION
(based on patch-pipefail)

Fixes the logic for compiling signed values to verilator. Basically, verilator always uses the unsigned representation as a C data type, so we need to convert all negative values into their unsigned bits representation. The logic already existed, but was too conservative (it only checked if the port was type as a signed value, but there are cases where expect a signed value on an unsigned port, such as in the case of the signed mode of the PE)  