### PR TITLE
fix input values due to the change for signed values

### DIFF
--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -178,7 +178,8 @@ class VerilatorTarget(VerilogTarget):
         else:
             value = action.value
             if isinstance(value, actions.FileRead):
-                value = f"*{value.file.name_without_ext}_in"
+                mask = "FF" * value.file.chunk_size
+                value = f"(*{value.file.name_without_ext}_in) & 0x{mask}"
             value = self.process_signed_values(action.port, value)
             result = [f"top->{name} = {value};"]
             # Hack to support verilator's semantics, need to set the register


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6099149/58065362-4952e600-7b3a-11e9-946a-b607713e0b9c.png)

Whenever the high bit for the input is high, i.e. when the value is larger than `0x80`, the current fault will pad 1's to make an negative number. This patch use masks to mask them off.

That's the cause that why `verilator` failed in `GarnetFlow` but `ncsim` works: https://github.com/StanfordAHA/GarnetFlow/commits/master

EDIT:
Travis version is working with this fix: https://travis-ci.com/StanfordAHA/GarnetFlow/builds/112535673