### PR TITLE
Initial support for testing power domains

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,4 +1,5 @@
 from .tester import Tester
+from .power_tester import PowerTester
 from .value import Value, AnyValue, UnknownValue
 import fault.random
 from .symbolic_tester import SymbolicTester

--- a/fault/power_tester.py
+++ b/fault/power_tester.py
@@ -1,0 +1,27 @@
+import magma as m
+from fault import Tester
+
+
+class PowerTester(Tester):
+    def __init__(self, circuit: m.Circuit, clock: m.ClockType = None):
+        super().__init__(circuit, clock)
+        self.supply0s = []
+        self.supply1s = []
+        self.tris = []
+
+    def add_power(self, port):
+        self.supply1s.append(port.name.name)
+
+    def add_ground(self, port):
+        self.supply0s.append(port.name.name)
+
+    def add_tri(self, port):
+        self.tris.append(port.name.name)
+
+    def run(self, target="system-verilog"):
+        power_args = {
+            "supply0s": self.supply0s,
+            "supply1s": self.supply1s,
+            "tris": self.tris,
+        }
+        self.targets[target].run(self.actions, power_args)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -196,18 +196,18 @@ end;
             code.append(f"#5 {name} ^= 1;")
         return code
 
-    def generate_recursive_port_code(self, name, type_):
+    def generate_recursive_port_code(self, name, type_, power_args):
         port_list = []
         if isinstance(type_, m.ArrayKind):
             for j in range(type_.N):
                 result = self.generate_port_code(
-                    name + "_" + str(j), type_.T
+                    name + "_" + str(j), type_.T, power_args
                 )
                 port_list.extend(result)
         elif isinstance(type_, m.TupleKind):
             for k, t in zip(type_.Ks, type_.Ts):
                 result = self.generate_port_code(
-                    name + "_" + str(k), t
+                    name + "_" + str(k), t, power_args
                 )
                 port_list.extend(result)
         return port_list
@@ -216,7 +216,7 @@ end;
         is_array_of_bits = isinstance(type_, m.ArrayKind) and \
             not isinstance(type_.T, m.BitKind)
         if is_array_of_bits or isinstance(type_, m.TupleKind):
-            return self.generate_recursive_port_code(name, type_)
+            return self.generate_recursive_port_code(name, type_, power_args)
         else:
             width_str = ""
             if isinstance(type_, m.ArrayKind) and \

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -222,11 +222,11 @@ end;
             if isinstance(type_, m.ArrayKind) and \
                     isinstance(type_.T, m.BitKind):
                 width_str = f"[{len(type_) - 1}:0] "
-            if name in power_args["supply0s"]:
+            if name in power_args.get("supply0s", []):
                 t = "supply0"
-            elif name in power_args["supply1s"]:
+            elif name in power_args.get("supply1s", []):
                 t = "supply1"
-            elif name in power_args["tris"]:
+            elif name in power_args.get("tris", []):
                 t = "tri"
             elif type_.isoutput():
                 t = "wire"

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -1,7 +1,6 @@
 from fault.verilog_target import VerilogTarget, verilog_name
 import magma as m
 from pathlib import Path
-
 import fault.actions as actions
 from hwtypes import BitVector
 import fault.value_utils as value_utils

--- a/tests/test_power_domains.py
+++ b/tests/test_power_domains.py
@@ -52,5 +52,18 @@ def test_simple_alu_pd():
     tester.circuit.b = b
     tester.circuit.c.expect(a + b)
 
-    tester.compile_and_run(target="system-verilog", simulator="iverilog",
-                           directory="tests/build", skip_compile=True)
+    try:
+        tester.compile_and_run(target="system-verilog", simulator="ncsim",
+                               directory="tests/build", skip_compile=True)
+    except AssertionError:
+        # Won't run because we don't have concrete DUT or ncsim, but we check
+        # that the output has the right types for the special ports
+        with open("tests/build/simple_alu_pd_tb.sv", "r") as f:
+            for line in f.read().splitlines():
+                if "VDD_HIGH_TOP_VIRTUAL;" in line:
+                    assert line.lstrip().rstrip() == \
+                        "tri VDD_HIGH_TOP_VIRTUAL;"
+                elif "VDD_HIGH;" in line:
+                    assert line.lstrip().rstrip() == "supply1 VDD_HIGH;"
+                elif "VSS;" in line:
+                    assert line.lstrip().rstrip() == "supply0 VSS;"

--- a/tests/test_power_domains.py
+++ b/tests/test_power_domains.py
@@ -1,0 +1,56 @@
+import magma as m
+import mantle
+import fault
+from hwtypes import BitVector
+
+
+def test_simple_alu_pd():
+    type_map = {"CLK": m.In(m.Clock)}
+    circ = m.DefineFromVerilogFile("tests/verilog/simple_alu_pd.sv",
+                                   type_map=type_map)[0]
+    tester = fault.PowerTester(circ, circ.CLK)
+    tester.add_power(circ.VDD_HIGH)
+    tester.add_ground(circ.VSS)
+    tester.add_tri(circ.VDD_HIGH_TOP_VIRTUAL)
+
+    tester.circuit.CLK = 0
+
+    # Enable the power switch
+    tester.circuit.config_addr = 0x00080000
+    tester.circuit.config_data = 0xFFFFFFF0
+    tester.circuit.config_en = 1
+    tester.step(2)
+    tester.circuit.config_en = 0
+
+    # rest of test...
+    a, b = BitVector.random(16), BitVector.random(16)
+    tester.circuit.a = a
+    tester.circuit.b = b
+    tester.circuit.c.expect(a + b)
+
+    # Disable the power switch
+    tester.circuit.config_addr = 0x00080000
+    tester.circuit.config_data = 0xFFFFFFF0
+    tester.circuit.config_en = 1
+    tester.step(2)
+    tester.circuit.config_en = 0
+    # Stall global signal should be on when tile is off
+    tester.circuit.stall_out.expect(1)
+    # reset signal should be on when tile is off
+    tester.circuit.reset.expect(1)
+
+    # Enable the power switch
+    tester.circuit.config_addr = 0x00080000
+    tester.circuit.config_data = 0xFFFFFFF0
+    tester.circuit.config_en = 1
+    tester.step(2)
+    tester.circuit.config_en = 0
+
+    # rest of test...
+    a, b = BitVector.random(16), BitVector.random(16)
+    tester.circuit.a = a
+    tester.circuit.b = b
+    tester.circuit.c.expect(a + b)
+
+    tester.compile_and_run(target="system-verilog", simulator="iverilog",
+                           directory="tests/build", skip_compile=True)

--- a/tests/verilog/simple_alu_pd.sv
+++ b/tests/verilog/simple_alu_pd.sv
@@ -1,0 +1,9 @@
+module simple_alu_pd(input [15:0] a, input [15:0] b, output [15:0] c,
+		     input [15:0] config_data, input [15:0] config_en,
+		     input CLK, input VDD_HIGH, input VSS,
+		     input VDD_HIGH_TOP_VIRTUAL, output stall_out,
+		     output reset);
+
+   // stub to test support for reading in modules with supply1,
+   // supply0, and tri types
+endmodule


### PR DESCRIPTION
This adds a `PowerTester` class that adds the methods:
* `add_power` - marks a port to be generated as `supply1`
* `add_ground` - marks a port to be generated as `supply0`
* `add_tri` - marks a port to be generated as `tri`

When the `Tester` is compiled to a SV test bench, the marked ports are generated as the specified type (as opposed to the default behavior with `reg` for inputs and `wire` for outputs)