### PR TITLE
Explicitly set integer literal size in SV backend

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -90,7 +90,7 @@ class SystemVerilogTarget(VerilogTarget):
         elif isinstance(port, m.SIntType) and value < 0:
             port_len = len(port)
             value = BitVector(value, port_len).as_uint()
-            value = f"{port_len}'d{value.as_uint()}"
+            value = f"{port_len}'d{value}"
         elif value is fault.UnknownValue:
             value = "'X"
         elif isinstance(value, actions.Peek):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -85,11 +85,12 @@ class SystemVerilogTarget(VerilogTarget):
         return name
 
     def process_value(self, port, value):
-        if isinstance(port, m.SIntType) and value < 0:
-            # Handle sign extension for verilator since it expects and
-            # unsigned c type
+        if isinstance(value, BitVector):
+            value = f"{len(value)}'d{value.as_uint()}"
+        elif isinstance(port, m.SIntType) and value < 0:
             port_len = len(port)
             value = BitVector(value, port_len).as_uint()
+            value = f"{port_len}'d{value.as_uint()}"
         elif value is fault.UnknownValue:
             value = "'X"
         elif isinstance(value, actions.Peek):


### PR DESCRIPTION
Fixes issue introduced in https://github.com/StanfordAHA/lassen/pull/95 where a 66 bit constant value was generated in system verilog and ncsim complained with: 

```
inst = 21040819108348690454;
--
  | \|
  | ncvlog: *W,INTOVF (WrappedPE_tb.sv,37\|34): bit overflow during conversion from text [2.5(IEEE)] (32 bits).
```

This changes the system verilog backend to always emit the size of the integer literal using the `<size>'d<value>` syntax.