### PR TITLE
Add basic support for expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - source activate test-env
 - conda install pip
 # End install conda
-- pip install python-coveralls
+# - pip install python-coveralls
 - pip install pytest-cov pytest-codestyle
 - pip install mantle  # for tests.common
 - pip install -e .
@@ -37,8 +37,8 @@ install:
 
 script:
 - pytest --cov fault --codestyle fault -v --cov-report term-missing tests
-after_success:
-- coveralls
+# after_success:
+# - coveralls
 deploy:
   provider: script
   script: /bin/bash .travis/deploy.sh

--- a/fault/expression.py
+++ b/fault/expression.py
@@ -1,0 +1,12 @@
+class Expression:
+    pass
+
+
+class BinaryOp(Expression):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+
+class And(BinaryOp):
+    pass

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -108,7 +108,7 @@ class SystemVerilogTarget(VerilogTarget):
                 new_value += "[0]"
             value = new_value
         elif isinstance(value, expression.Expression):
-            value = self.compile_expression(port, value)
+            value = f"({self.compile_expression(port, value)})"
         return value
 
     def compile_expression(self, port, value):

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -10,6 +10,7 @@ from fault.actions import Poke, Expect, Step, Print, Loop
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
 from fault.file import File
+import fault.expression as expression
 import copy
 import os
 import inspect
@@ -113,7 +114,8 @@ class Tester:
         """
         Expect the current value of `port` to be `value`
         """
-        if not isinstance(value, (actions.Peek, PortWrapper, LoopIndex)):
+        if not isinstance(value, (actions.Peek, PortWrapper,
+                                  LoopIndex, expression.Expression)):
             value = make_value(port, value)
         self.actions.append(actions.Expect(port, value))
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -120,7 +120,7 @@ class VerilatorTarget(VerilogTarget):
             return self.process_signed_values(port, value)
         elif isinstance(value, (int, BitVector)):
             return value
-        raise NotImplementedError(value, type(value))
+        return value
 
     def process_signed_values(self, port, value):
         # Handle sign extension for verilator since it expects and unsigned

--- a/fault/wrapper.py
+++ b/fault/wrapper.py
@@ -1,5 +1,6 @@
 import fault
 from fault.select_path import SelectPath
+import fault.expression as expression
 import magma as m
 
 
@@ -102,6 +103,9 @@ class PortWrapper:
             parent = parent.parent
         select_path.tester = parent
         return select_path
+
+    def __and__(self, other):
+        return expression.And(self, other)
 
 
 class InstanceWrapper(Wrapper):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -45,7 +45,7 @@ def test_and_two_signals(target, simulator):
         def definition(io):
             io.I0_out <= io.I0
             io.I1_out <= io.I1
-            io.O <= io.I0 & io.I1 
+            io.O <= io.I0 & io.I1
 
     tester = fault.Tester(ANDCircuit)
     for _ in range(5):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,63 @@
+"""
+Test the construction of expression trees from Peeked values
+"""
+import shutil
+import tempfile
+
+import fault
+import magma as m
+import mantle
+import hwtypes
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Parametrize tests over targets
+    """
+    if "target" in metafunc.fixturenames:
+        targets = [("verilator", None)]
+        if shutil.which("irun"):
+            targets.append(
+                ("system-verilog", "ncsim"))
+        if shutil.which("vcs"):
+            targets.append(
+                ("system-verilog", "vcs"))
+        if shutil.which("iverilog"):
+            targets.append(
+                ("system-verilog", "iverilog"))
+        metafunc.parametrize("target,simulator", targets)
+
+
+def test_and_two_signals(target, simulator):
+    class ANDCircuit(m.Circuit):
+        """
+        Pass through I0 and I1 as outputs so we can assert a function
+        of I0 and I1 as the result
+        """
+        IO = ["I0", m.In(m.Bits[5]), "I1", m.In(m.Bits[5]),
+              "I0_out", m.Out(m.Bits[5]), "I1_out", m.Out(m.Bits[5]),
+              "O", m.Out(m.Bits[5])]
+
+        @classmethod
+        def definition(io):
+            io.I0_out <= io.I0
+            io.I1_out <= io.I1
+            io.O <= io.I0 & io.I1 
+
+
+    tester = fault.Tester(ANDCircuit)
+    for _ in range(5):
+        tester.circuit.I0 = hwtypes.BitVector.random(5)
+        tester.circuit.I1 = hwtypes.BitVector.random(5)
+        tester.eval()
+        tester.circuit.O.expect(tester.circuit.I0_out &
+                                tester.circuit.I1_out)
+    
+    with tempfile.TemporaryDirectory() as _dir:
+        kwargs = {
+            "target": target,
+            "directory": _dir,
+        }
+        if target == "system-verilog":
+            kwargs["simulator"] = simulator
+        tester.compile_and_run(**kwargs)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -29,6 +29,9 @@ def pytest_generate_tests(metafunc):
 
 
 def test_and_two_signals(target, simulator):
+    """
+    Test that we can and two output signals for an expect
+    """
     class ANDCircuit(m.Circuit):
         """
         Pass through I0 and I1 as outputs so we can assert a function
@@ -44,15 +47,13 @@ def test_and_two_signals(target, simulator):
             io.I1_out <= io.I1
             io.O <= io.I0 & io.I1 
 
-
     tester = fault.Tester(ANDCircuit)
     for _ in range(5):
         tester.circuit.I0 = hwtypes.BitVector.random(5)
         tester.circuit.I1 = hwtypes.BitVector.random(5)
         tester.eval()
-        tester.circuit.O.expect(tester.circuit.I0_out &
-                                tester.circuit.I1_out)
-    
+        tester.circuit.O.expect(tester.circuit.I0_out & tester.circuit.I1_out)
+
     with tempfile.TemporaryDirectory() as _dir:
         kwargs = {
             "target": target,


### PR DESCRIPTION
This allows you to expect that an output is a function (expression) of inputs. This adds support for just the And expression, but shows the required extensions to support this in the targets. Will continue to work on filling out the supported operators as well as integrating with while loops (loop until a condition expression).