### PR TITLE
Timestamp edit

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -286,8 +286,8 @@ end;
         if check_timestamp:
             new_stat_result = os.stat(tb_file)
             new_times = (new_stat_result.st_atime, new_stat_result.st_mtime)
-            if new_times[1] - old_times[1] == 0:
-                new_times = (new_times[0] + 1, new_times[1] + 1)
+            if new_times[1] <= old_times[1]:
+                new_times = (new_times[0], old_times[1] + 1)
                 os.utime(tb_file, times=new_times)
         verilog_libraries = " ".join(str(x) for x in
                                      self.include_verilog_libraries)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -287,7 +287,7 @@ end;
             new_stat_result = os.stat(tb_file)
             new_times = (new_stat_result.st_atime, new_stat_result.st_mtime)
             if new_times[1] - old_times[1] == 0:
-                new_times = (new_times[0], new_times[1] + 1)
+                new_times = (new_times[0] + 1, new_times[1] + 1)
                 os.utime(tb_file, times=new_times)
         verilog_libraries = " ".join(str(x) for x in
                                      self.include_verilog_libraries)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -8,6 +8,7 @@ from fault.select_path import SelectPath
 import subprocess
 from fault.wrapper import PortWrapper
 import fault
+import os
 
 
 src_tpl = """\
@@ -269,8 +270,25 @@ end;
 
         # Write the verilator driver to file.
         src = self.generate_code(actions, power_args)
-        with open(self.directory / test_bench_file, "w") as f:
+        tb_file = self.directory / test_bench_file
+        # If there's an old test bench file, ncsim might not recompile based on
+        # the timestamp (1s granularity), see
+        # https://github.com/StanfordAHA/lassen/issues/111
+        # so we check if the new/old file have the same timestamp and edit them
+        # to force an ncsim recompile
+        check_timestamp = os.path.isfile(tb_file)
+        if check_timestamp:
+            check_timestamp = True
+            old_stat_result = os.stat(tb_file)
+            old_times = (old_stat_result.st_atime, old_stat_result.st_mtime)
+        with open(tb_file, "w") as f:
             f.write(src)
+        if check_timestamp:
+            new_stat_result = os.stat(tb_file)
+            new_times = (new_stat_result.st_atime, new_stat_result.st_mtime)
+            if new_times[1] - old_times[1] == 0:
+                new_times = (new_times[0], new_times[1] + 1)
+                os.utime(tb_file, times=new_times)
         verilog_libraries = " ".join(str(x) for x in
                                      self.include_verilog_libraries)
         cmd_file = Path(f"{self.circuit_name}_cmd.tcl")

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -286,8 +286,8 @@ end;
         if check_timestamp:
             new_stat_result = os.stat(tb_file)
             new_times = (new_stat_result.st_atime, new_stat_result.st_mtime)
-            if new_times[1] <= old_times[1]:
-                new_times = (new_times[0], old_times[1] + 1)
+            if old_times[0] <= new_times[0] or new_times[1] <= old_times[1]:
+                new_times = (old_times[0] + 1, old_times[1] + 1)
                 os.utime(tb_file, times=new_times)
         verilog_libraries = " ".join(str(x) for x in
                                      self.include_verilog_libraries)


### PR DESCRIPTION
Addresses issue where `ncsim` will not recompile a test bench if the new test bench file is generated within 1 second of the previous test bench file, see https://github.com/StanfordAHA/lassen/issues/111.

This forces fault to, by default, check whether the test bench exists, if so, diff the modification timestamp on the new file with the old file. if the new file is less than or equal (handling the case when this happens multiple times in a row), fault sets the new file to be "newer" than the old file.