### PR TITLE
Add support for both endian modes

### DIFF
--- a/fault/file.py
+++ b/fault/file.py
@@ -3,7 +3,7 @@ import os
 
 
 class File:
-    def __init__(self, name, tester, mode, chunk_size):
+    def __init__(self, name, tester, mode, chunk_size, endianness):
         self.name = name
         self.tester = tester
         self.mode = mode
@@ -12,6 +12,7 @@ class File:
         filename = os.path.splitext(basename)[0]
         filename = filename.replace(".", "_")
         self.name_without_ext = filename
+        self.endianness = endianness
 
     def __str__(self):
         return f'File<"{self.name}">'

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -190,7 +190,6 @@ if (!{name}_file) $error("Could not open file {action.file.name}: %0d", {name}_f
             loop_expr = f"__i = {action.file.chunk_size - 1}; __i >= 0; __i--"
         else:
             loop_expr = f"__i = 0; __i < {action.file.chunk_size}; __i++"
-        # notice that this is little endian
         code = f"""\
 {action.file.name_without_ext}_in = 0;
 for ({loop_expr}) begin
@@ -209,7 +208,6 @@ end
             loop_expr = f"__i = {action.file.chunk_size - 1}; __i >= 0; __i--"
         else:
             loop_expr = f"__i = 0; __i < {action.file.chunk_size}; __i++"
-        # this is little endian as well
         code = f"""\
 for ({loop_expr}) begin
     $fwrite({action.file.name_without_ext}_file, \"%c\", ({value} >> (8 * __i)) & {mask_size}'hFF);

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -186,10 +186,14 @@ if (!{name}_file) $error("Could not open file {action.file.name}: %0d", {name}_f
         decl = f"integer __i;"
         if decl not in self.declarations:
             self.declarations.append(decl)
+        if action.file.endianness == "big":
+            loop_expr = f"__i = {action.file.chunk_size - 1}; __i >= 0; __i--"
+        else:
+            loop_expr = f"__i = 0; __i < {action.file.chunk_size}; __i++"
         # notice that this is little endian
         code = f"""\
 {action.file.name_without_ext}_in = 0;
-for (__i = {action.file.chunk_size - 1}; __i >= 0; __i--) begin
+for ({loop_expr}) begin
     {action.file.name_without_ext}_in |= $fgetc({action.file.name_without_ext}_file) << (8 * __i);
 end
 """  # noqa
@@ -201,9 +205,13 @@ end
         decl = f"integer __i;"
         if decl not in self.declarations:
             self.declarations.append(decl)
+        if action.file.endianness == "big":
+            loop_expr = f"__i = {action.file.chunk_size - 1}; __i >= 0; __i--"
+        else:
+            loop_expr = f"__i = 0; __i < {action.file.chunk_size}; __i++"
         # this is little endian as well
         code = f"""\
-for (__i = {action.file.chunk_size - 1}; __i >= 0; __i--) begin
+for ({loop_expr}) begin
     $fwrite({action.file.name_without_ext}_file, \"%c\", ({value} >> (8 * __i)) & {mask_size}'hFF);
 end
 """  # noqa

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -268,12 +268,12 @@ class Tester:
                                  loop_tester.actions))
         return loop_tester
 
-    def file_open(self, file_name, mode="r", chunk_size=1):
+    def file_open(self, file_name, mode="r", chunk_size=1, endianness="little"):
         """
         mode : "r" for read, "w" for write
         chunk_size : number of bytes per read/write
         """
-        file = File(file_name, self, mode, chunk_size)
+        file = File(file_name, self, mode, chunk_size, endianness)
         self.actions.append(actions.FileOpen(file))
         return file
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -344,8 +344,12 @@ if ({name}_file == NULL) {{
 
     def make_file_write(self, i, action):
         value = f"top->{verilog_name(action.value.name)}"
+        if action.file.endianness == "big":
+            loop_expr = f"int i = {action.file.chunk_size - 1}; i >= 0; i--"
+        else:
+            loop_expr = f"int i = 0; i < {action.file.chunk_size}; i++"
         code = f"""\
-for (int i = {action.file.chunk_size - 1}; i >= 0; i--) {{
+for ({loop_expr}) {{
     int result = fputc(({value} >> (i * 8)) & 0xFF,
                        {action.file.name_without_ext}_file);
     if (result == EOF) {{
@@ -358,8 +362,12 @@ for (int i = {action.file.chunk_size - 1}; i >= 0; i--) {{
         return code.splitlines()
 
     def make_file_read(self, i, action):
+        if action.file.endianness == "big":
+            loop_expr = f"int i = {action.file.chunk_size - 1}; i >= 0; i--"
+        else:
+            loop_expr = f"int i = 0; i < {action.file.chunk_size}; i++"
         code = f"""\
-for (int i = 0; i < {action.file.chunk_size}; i++) {{
+for ({loop_expr}) {{
     int result =  fgetc({action.file.name_without_ext}_file);
     if (result == EOF) {{
         std::cout << "Reached end of file {action.file.name_without_ext}"

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -18,7 +18,7 @@ def test_action_strs():
     assert str(Loop(12, index, [Peek(circ.O), Poke(circ.I, 1)])) == \
         f'Loop(12, {index}, ' \
         f'[Peek(BasicClkCircuit.O), Poke(BasicClkCircuit.I, 1)])'
-    file = File("my_file", Tester(circ), "r", 1)
+    file = File("my_file", Tester(circ), "r", 1, "little")
     assert str(FileOpen(file)) == 'FileOpen(File<"my_file">)'
     assert str(FileRead(file)) == 'FileRead(File<"my_file">)'
     assert str(FileWrite(file, 3)) == 'FileWrite(File<"my_file">, 3)'

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -376,13 +376,13 @@ def test_tester_file_io(target, simulator):
             assert file.read(8) == expected
 
 
-def test_tester_file_io_chunk_size_4(target, simulator):
+def test_tester_file_io_chunk_size_4_big_endian(target, simulator):
     circ = common.TestUInt32Circuit
     tester = fault.Tester(circ)
     tester.zero_inputs()
-    file_in = tester.file_open("test_file_in.raw", "r", chunk_size=4)
+    file_in = tester.file_open("test_file_in.raw", "r", chunk_size=4, endianness="big")
     out_file = "test_file_out.raw"
-    file_out = tester.file_open(out_file, "w", chunk_size=4)
+    file_out = tester.file_open(out_file, "w", chunk_size=4, endianness="big")
     loop = tester.loop(8)
     value = loop.file_read(file_in)
     loop.poke(circ.I, value)
@@ -412,6 +412,44 @@ def test_tester_file_io_chunk_size_4(target, simulator):
                     assert file.read(1) == bytes([i])
                 else:
                     assert file.read(4) == bytes([0, 0, 0, i])
+
+
+def test_tester_file_io_chunk_size_4_little_endian(target, simulator):
+    circ = common.TestUInt32Circuit
+    tester = fault.Tester(circ)
+    tester.zero_inputs()
+    file_in = tester.file_open("test_file_in.raw", "r", chunk_size=4)
+    out_file = "test_file_out.raw"
+    file_out = tester.file_open(out_file, "w", chunk_size=4)
+    loop = tester.loop(8)
+    value = loop.file_read(file_in)
+    loop.poke(circ.I, value)
+    loop.eval()
+    loop.expect(circ.O, loop.index)
+    loop.file_write(file_out, circ.O)
+    tester.file_close(file_in)
+    tester.file_close(file_out)
+    with tempfile.TemporaryDirectory() as _dir:
+        if os.path.exists(_dir + "/" + out_file):
+            os.remove(_dir + "/" + out_file)
+        with open(_dir + "/test_file_in.raw", "wb") as file:
+            for i in range(8):
+                file.write(bytes([i, 0, 0, 0]))
+        if target == "verilator":
+            tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
+        else:
+            tester.compile_and_run(target, directory=_dir, simulator=simulator)
+        with open(_dir + "/test_file_out.raw", "rb") as file:
+            expected = bytes([i for i in range(8 * 32)])
+            for i in range(8):
+                if simulator == "iverilog":
+                    # iverilog doesn't support writing a NULL byte out using
+                    # %c, so this first values are skipped
+                    if i == 0:
+                        continue
+                    assert file.read(1) == bytes([i])
+                else:
+                    assert file.read(4) == bytes([i, 0, 0, 0])
 
 
 def test_tester_while(target, simulator):
@@ -485,6 +523,8 @@ def test_tester_if(target, simulator):
 
 
 def test_tester_file_scanf(target, simulator):
+    if simulator == "iverilog":
+        pytest.skip("iverilog does not support scanf")
     circ = common.TestUInt32Circuit
     tester = fault.Tester(circ)
     tester.zero_inputs()

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -380,7 +380,8 @@ def test_tester_file_io_chunk_size_4_big_endian(target, simulator):
     circ = common.TestUInt32Circuit
     tester = fault.Tester(circ)
     tester.zero_inputs()
-    file_in = tester.file_open("test_file_in.raw", "r", chunk_size=4, endianness="big")
+    file_in = tester.file_open("test_file_in.raw", "r", chunk_size=4,
+                               endianness="big")
     out_file = "test_file_out.raw"
     file_out = tester.file_open(out_file, "w", chunk_size=4, endianness="big")
     loop = tester.loop(8)


### PR DESCRIPTION
Reverts default file IO behavior to be little endian (the semantics got mixed up because Pythons `file.write` method is weird and caused some semantic mismatch in the expected behavior and actual behavior) and adds a parameter to file open to select endianness.