### PR TITLE
Allow more control of env and debug printing in the system-verilog target

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -437,7 +437,7 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
     def display_subprocess_output(result):
         # display both standard output and standard error as INFO, since
         # since some useful debugging info is included in standard error
-        
+
         to_display = {
             'STDOUT': result.stdout.decode(),
             'STDERR': result.stderr.decode()
@@ -447,4 +447,3 @@ vcs -sverilog -full64 +v2k -timescale={self.timescale} -LDFLAGS -Wl,--no-as-need
             if val != '':
                 logging.info(f'*** {name} ***')
                 logging.info(val)
-

--- a/fault/util.py
+++ b/fault/util.py
@@ -2,17 +2,27 @@ import os
 import os.path
 from pathlib import Path
 
+
 def flatten(l):
     return [item for sublist in l for item in sublist]
 
+
 def remove_conda(env):
-    '''Returns a copy of the current environment with conda directories removed from the path.'''
+    '''Returns a copy of the current environment with conda directories
+       removed from the path.'''
 
     # copy the environment
     env = os.environ.copy()
 
     # find the location of the conda installation
-    conda_prefix = env['CONDA_PREFIX']
+    # if the variable is not found, then just
+    # return the original environment
+    try:
+        conda_prefix = env['CONDA_PREFIX']
+    except KeyError:
+        return env
+
+    # convert to Path object
     conda_prefix = os.path.realpath(os.path.expanduser(conda_prefix))
     conda_prefix = Path(conda_prefix)
 
@@ -20,7 +30,8 @@ def remove_conda(env):
     # those starting with the CONDA_PREFIX
     path_entries = env['PATH'].split(os.pathsep)
     path_entries = [Path(entry) for entry in path_entries]
-    path_entries = [entry for entry in path_entries if conda_prefix not in entry.parents]
+    path_entries = [entry for entry in path_entries
+                    if conda_prefix not in entry.parents]
 
     # update the PATH variable
     env['PATH'] = os.pathsep.join(str(entry) for entry in path_entries)

--- a/fault/util.py
+++ b/fault/util.py
@@ -1,2 +1,28 @@
+import os
+import os.path
+from pathlib import Path
+
 def flatten(l):
     return [item for sublist in l for item in sublist]
+
+def remove_conda(env):
+    '''Returns a copy of the current environment with conda directories removed from the path.'''
+
+    # copy the environment
+    env = os.environ.copy()
+
+    # find the location of the conda installation
+    conda_prefix = env['CONDA_PREFIX']
+    conda_prefix = os.path.realpath(os.path.expanduser(conda_prefix))
+    conda_prefix = Path(conda_prefix)
+
+    # split up the path into individual entries, then filter out
+    # those starting with the CONDA_PREFIX
+    path_entries = env['PATH'].split(os.pathsep)
+    path_entries = [Path(entry) for entry in path_entries]
+    path_entries = [entry for entry in path_entries if conda_prefix not in entry.parents]
+
+    # update the PATH variable
+    env['PATH'] = os.pathsep.join(str(entry) for entry in path_entries)
+
+    return env

--- a/tests/test_env_mod.py
+++ b/tests/test_env_mod.py
@@ -1,0 +1,47 @@
+import pathlib
+import tempfile
+import fault
+import magma as m
+import os
+import shutil
+import logging
+import mantle
+
+def pytest_generate_tests(metafunc):
+    if "target" in metafunc.fixturenames:
+        targets = []
+        if shutil.which("vcs"):
+            targets.append(("system-verilog", "vcs"))
+        if shutil.which("ncsim"):
+            targets.append(("system-verilog", "ncsim"))
+        metafunc.parametrize("target,simulator", targets)
+
+def test_env_mod(target, simulator):
+    #logging.getLogger().setLevel(logging.DEBUG)
+
+    myinv = m.DefineCircuit('myinv', 'a', m.In(m.Bit), 'y', m.Out(m.Bit))
+    m.wire(~myinv.a, myinv.y)
+    m.EndDefine()
+
+    tester = fault.Tester(myinv)
+
+    tester.poke(myinv.a, 1)
+    tester.eval()
+    tester.expect(myinv.y, 0)
+    tester.poke(myinv.a, 0)
+    tester.eval()
+    tester.expect(myinv.y, 1)
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        # make some modifications to the environment
+        sim_env = fault.util.remove_conda(os.environ)
+        sim_env['DISPLAY'] = sim_env.get('DISPLAY', '')
+
+        # run the test
+        tester.compile_and_run(
+            target=target,
+            simulator=simulator,
+            directory=tmp_dir,
+            sim_env=sim_env
+        )
+

--- a/tests/test_env_mod.py
+++ b/tests/test_env_mod.py
@@ -7,6 +7,7 @@ import shutil
 import logging
 import mantle
 
+
 def pytest_generate_tests(metafunc):
     if "target" in metafunc.fixturenames:
         targets = []
@@ -16,8 +17,9 @@ def pytest_generate_tests(metafunc):
             targets.append(("system-verilog", "ncsim"))
         metafunc.parametrize("target,simulator", targets)
 
+
 def test_env_mod(target, simulator):
-    #logging.getLogger().setLevel(logging.DEBUG)
+    # logging.getLogger().setLevel(logging.DEBUG)
 
     myinv = m.DefineCircuit('myinv', 'a', m.In(m.Bit), 'y', m.Out(m.Bit))
     m.wire(~myinv.a, myinv.y)
@@ -44,4 +46,3 @@ def test_env_mod(target, simulator):
             directory=tmp_dir,
             sim_env=sim_env
         )
-


### PR DESCRIPTION
Added a few features to address issues encountered in a specific CAD system:
1) The SystemVerilogTarget now has an optional "sim_env" argument that allows the user to specify a custom environment for running the simulation command.  This is needed for example if CAD tools are using scripts that except "python" to point to a Python2 install, but the user is running fault from a Python3 conda env.
2) The SystemVerilogTarget now writes STDERR to the logging.INFO level in addition to STDOUT.  This is helpful for debugging because ncsim writes certain license errors to STDERR, not STDOUT.
3) Added remove_conda() to fault/util.py.  This utility function removes path entries (if any) that start with the CONDA_PREFIX.
4) Added a new test "test_env_mod" to test out these features.  It passes within my specific CAD system.
