### PR TITLE
Working with external verilog files

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -35,7 +35,8 @@ class SystemVerilogTarget(VerilogTarget):
                  skip_compile=False, magma_output="coreir-verilog",
                  magma_opts={}, include_verilog_libraries=[], simulator=None,
                  timescale="1ns/1ns", clock_step_delay=5, num_cycles=10000,
-                 dump_vcd=True, no_warning=False, sim_env=None):
+                 dump_vcd=True, no_warning=False, sim_env=None,
+                 ext_model_file=False):
         """
         circuit: a magma circuit
 
@@ -62,6 +63,11 @@ class SystemVerilogTarget(VerilogTarget):
         sim_env: Environment variable definitions to use when running the
                  simulator.  If not provided, the value from os.environ will
                  be used.
+
+        ext_model_file: If True, don't include the assumed model name in the
+                        list of Verilog sources.  The assumption is that the
+                        user has already taken care of this via
+                        include_verilog_libraries.
         """
         super().__init__(circuit, circuit_name, directory, skip_compile,
                          include_verilog_libraries, magma_output, magma_opts)
@@ -78,6 +84,7 @@ class SystemVerilogTarget(VerilogTarget):
         self.no_warning = no_warning
         self.declarations = []
         self.sim_env = sim_env if sim_env is not None else os.environ
+        self.ext_model_file = ext_model_file
 
     def make_name(self, port):
         if isinstance(port, SelectPath):
@@ -379,7 +386,7 @@ end;
         # assemble list of sources files
         vlog_srcs = []
         vlog_srcs += [test_bench_file]
-        if not self.skip_compile:
+        if not self.ext_model_file:
             vlog_srcs += [self.verilog_file]
 
         # generate simulator command

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -400,19 +400,20 @@ end;
         else:
             raise NotImplementedError(self.simulator)
 
+        cmd = ' '.join(cmd)
         logging.debug(f'Running command: {cmd}')
-        result = subprocess.run(cmd, cwd=self.directory,
+        result = subprocess.run(cmd, cwd=self.directory, shell=True,
                                 capture_output=True, env=self.sim_env)
         self.display_subprocess_output(result)
         assert not result.returncode, "Error running system verilog simulator"
 
         if self.simulator == "vcs":
-            result = subprocess.run(['./simv'], cwd=self.directory,
+            result = subprocess.run('./simv', cwd=self.directory, shell=True,
                                     capture_output=True, env=self.sim_env)
         elif self.simulator == "iverilog":
-            result = subprocess.run(['vvp', '-N', f'{self.circuit_name}_tb'],
-                                    cwd=self.directory, capture_output=True,
-                                    env=self.sim_env)
+            result = subprocess.run(f'vvp -N {self.circuit_name}_tb',
+                                    shell=True, cwd=self.directory,
+                                    capture_output=True, env=self.sim_env)
         if self.simulator in {"vcs", "iverilog"}:
             # VCS and iverilog do not set the return code when a
             # simulation exits with an error, so we check the result

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -524,25 +524,7 @@ end;
         cmd += ['iverilog']
         cmd += ['-o', f'{self.circuit_name}_tb']
         cmd += [f'{src}' for src in sources]
-
-        # iverilog does not have a way to specify individual library files;
-        # only library directories are allowed and the user must specify
-        # which file extensions should be used.  hence, we need to gather
-        # up all of the unique library folders and file extensions from
-        # the provided library files
-
-        dirs = set()
-        exts = set()
         for lib in self.ext_libs:
-            lib_str = str(lib)  # convert to string -- might be a Path
-            dirs.add(os.path.dirname(lib_str))
-            exts.add(os.path.splitext(lib_str)[1])
-
-        # now add the options to specify all library directories and
-        # file extensions
-        for dir_ in dirs:
-            cmd += ['-y', f'{dir_}']
-        for ext in exts:
-            cmd += ['-Y', f'{ext}']
+            cmd += ['-v', f'{lib}']
 
         return cmd

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -48,5 +48,6 @@ def test_ext_vlog(target, simulator):
             directory=tmp_dir,
             include_verilog_libraries=[myinv_fname],
             sim_env=sim_env,
-            skip_compile=True
+            skip_compile=True,
+            ext_model_file=True
         )

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -21,7 +21,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_ext_vlog(target, simulator):
-    logging.getLogger().setLevel(logging.DEBUG)
+    # logging.getLogger().setLevel(logging.DEBUG)
 
     myinv_fname = pathlib.Path('tests/verilog/myinv.v').resolve()
     myinv = m.DeclareCircuit('myinv', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
@@ -46,7 +46,7 @@ def test_ext_vlog(target, simulator):
             target=target,
             simulator=simulator,
             directory=tmp_dir,
-            include_verilog_libraries=[myinv_fname],
+            ext_libs=[myinv_fname],
             sim_env=sim_env,
             skip_compile=True,
             ext_model_file=True

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -1,0 +1,52 @@
+import pathlib
+import tempfile
+import fault
+import magma as m
+import os
+import shutil
+import logging
+import mantle
+
+
+def pytest_generate_tests(metafunc):
+    if 'target' in metafunc.fixturenames:
+        targets = []
+        if shutil.which('vcs'):
+            targets.append(('system-verilog', 'vcs'))
+        if shutil.which('ncsim'):
+            targets.append(('system-verilog', 'ncsim'))
+        if shutil.which('iverilog'):
+            targets.append(('system-verilog', 'iverilog'))
+        metafunc.parametrize('target,simulator', targets)
+
+
+def test_ext_vlog(target, simulator):
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    myinv_fname = pathlib.Path('tests/verilog/myinv.v').resolve()
+    myinv = m.DeclareCircuit('myinv', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
+
+    tester = fault.Tester(myinv)
+
+    tester.poke(myinv.in_, 1)
+    tester.eval()
+    tester.expect(myinv.out, 0)
+
+    tester.poke(myinv.in_, 0)
+    tester.eval()
+    tester.expect(myinv.out, 1)
+
+    # make some modifications to the environment
+    sim_env = fault.util.remove_conda(os.environ)
+    sim_env['DISPLAY'] = sim_env.get('DISPLAY', '')
+
+    # run the test
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        tester.compile_and_run(
+            target=target,
+            simulator=simulator,
+            directory=tmp_dir,
+            include_verilog_libraries=[myinv_fname],
+            sim_env=sim_env,
+            skip_compile=True
+        )

--- a/tests/verilog/myinv.v
+++ b/tests/verilog/myinv.v
@@ -1,0 +1,8 @@
+module myinv(
+    input in_,
+    output out
+);
+
+    assign out = ~in_;
+
+endmodule


### PR DESCRIPTION
These commits span updates to the ncsim, vcs, and iverilog simulators in SystemVerilogTarget to make it easier to work with external files:
1. There is no file added to the source file list for the DUT itself when **ext_model_file=True**.  This, combined with the existing **ext_libs** option, gives the user an option to point to external verilog files rather than copying them over to the build directory outside of fault.  Perhaps in the future, when **skip_compile=True**, **ext_model_file** should default to **True** as well.  But I didn't want to break existing programs that depend on the current behavior.
2. The generation of commands for ncsim, vcs, and iverilog are moved into separate methods to make it easier to make simulator-specific updates in the future.
3. The files specified by the **ext_libs** argument are included as libraries ("-v" or "-y", depending on the simulator) rather than directly as source files.  This has the benefit of making their order unimportant.  The behavior of the **include_verilog_libraries** argument is unmodified, although it's worth noting that it really is including files as verilog sources, not libraries.  As an implementation note -- iverilog only supports libdirs, not lib files, so a set of unique directories is extracted from the ext_lib argument.
4. The use of subprocess to call the three simulators is pulled into the method subprocess_run to avoid code duplication for shell escaping, subprocess run options, and logging of outputs.  As a side note, it would be good to investigate why shell=True is needed -- test_power_domains fails without it on Travis but passes on my setup.  For now I left shell=True option in.
5. A new test, test_ext_vlog.py, exercises the above features.