### PR TITLE
Define variables and wait_until_(high|low|posedge|negedge)

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -430,7 +430,7 @@ end;
         if bin_cmd is not None:
             bin_res = self.subprocess_run(bin_cmd)
             assert not bin_res.returncode, f'Running {self.simulator} binary failed'  # noqa
-            assert err_str not in str(bin_res.stdout), f'"{error_str}" found in stdout of {self.simulator} run'  # noqa
+            assert err_str not in str(bin_res.stdout), f'"{err_str}" found in stdout of {self.simulator} run'  # noqa
 
     @staticmethod
     def shlex_join(args):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -154,6 +154,10 @@ class SystemVerilogTarget(VerilogTarget):
             right = self.compile_expression(value.right)
             op = value.op_str
             return f"{left} {op} {right}"
+        elif isinstance(value, expression.UnaryOp):
+            operand = self.compile_expression(value.operand)
+            op = value.op_str
+            return f"{op} {operand}"
         elif isinstance(value, PortWrapper):
             return f"dut.{value.select_path.system_verilog_path}"
         elif isinstance(value, actions.Peek):

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -315,6 +315,40 @@ class Tester:
         self.actions.append(var)
         return var
 
+    def wait_on(self, cond):
+        loop = self._while(cond)
+        loop.step()
+
+    def wait_until_low(self, signal):
+        self.wait_on(self.peek(signal))
+
+    def wait_until_high(self, signal):
+        self.wait_on(~self.peek(signal))
+
+    def wait_until_negedge(self, signal):
+        self.wait_until_high(signal)
+        self.wait_until_low(signal)
+
+    def wait_until_posedge(self, signal, steps_per_iter=1):
+        self.wait_until_low(signal)
+        self.wait_until_high(signal)
+
+    def pulse_high(self, signal):
+        # first make sure the signal is actually low to begin with
+        self.expect(signal, 0)
+
+        # first set the signal high, then bring it low again
+        self.poke(signal, 1)
+        self.poke(signal, 0)
+
+    def pulse_low(self, signal):
+        # first make sure the signal is actually high to begin with
+        self.expect(signal, 1)
+
+        # first set the signal low, then bring it high again
+        self.poke(signal, 0)
+        self.poke(signal, 1)
+
 
 class LoopIndex:
     def __init__(self, name):

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -1,0 +1,54 @@
+import pathlib
+import tempfile
+import fault
+import magma as m
+import os
+import shutil
+import logging
+import mantle
+
+
+def pytest_generate_tests(metafunc):
+    if 'target' in metafunc.fixturenames:
+        targets = []
+        if shutil.which('vcs'):
+            targets.append(('system-verilog', 'vcs'))
+        if shutil.which('ncsim'):
+            targets.append(('system-verilog', 'ncsim'))
+        if shutil.which('iverilog'):
+            targets.append(('system-verilog', 'iverilog'))
+        metafunc.parametrize('target,simulator', targets)
+
+
+def test_def_vlog(target, simulator, n_bits=8, b_val=42):
+    # logging.getLogger().setLevel(logging.DEBUG)
+
+    defadd_fname = pathlib.Path('tests/verilog/defadd.sv').resolve()
+    defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]), 
+                              'c_val', m.Out(m.Bits[n_bits]))
+
+    tester = fault.Tester(defadd)
+
+    tester.poke(defadd.a_val, 12)
+    tester.eval()
+    tester.expect(defadd.c_val, 54)
+
+    tester.poke(defadd.a_val, 34)
+    tester.eval()
+    tester.expect(defadd.c_val, 76)
+
+    # make some modifications to the environment
+    sim_env = fault.util.remove_conda(os.environ)
+
+    # run the test
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        tester.compile_and_run(
+            target=target,
+            simulator=simulator,
+            directory=tmp_dir,
+            ext_libs=[defadd_fname],
+            sim_env=sim_env,
+            skip_compile=True,
+            ext_model_file=True,
+            defines={'N_BITS': n_bits, 'B_VAL': b_val}
+        )

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -24,7 +24,7 @@ def test_def_vlog(target, simulator, n_bits=8, b_val=42):
     # logging.getLogger().setLevel(logging.DEBUG)
 
     defadd_fname = pathlib.Path('tests/verilog/defadd.sv').resolve()
-    defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]), 
+    defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]),
                               'c_val', m.Out(m.Bits[n_bits]))
 
     tester = fault.Tester(defadd)

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -1,0 +1,87 @@
+import pathlib
+import tempfile
+import fault
+import magma as m
+import os
+import shutil
+import logging
+import mantle
+
+
+def pytest_generate_tests(metafunc):
+    if 'target' in metafunc.fixturenames:
+        targets = []
+        if shutil.which('vcs'):
+            targets.append(('system-verilog', 'vcs'))
+        if shutil.which('ncsim'):
+            targets.append(('system-verilog', 'ncsim'))
+        if shutil.which('iverilog'):
+            targets.append(('system-verilog', 'iverilog'))
+        metafunc.parametrize('target,simulator', targets)
+
+
+def debug_print(tester, dut):
+    to_display = {
+            'dut.n_done': dut.n_done,
+            'dut.count': dut.count
+    }
+
+    args = []
+    fmt = []
+    for key, val in to_display.items():
+        args.append(val)
+        fmt.append(f'{key}: %0d')
+
+    tester.print(', '.join(fmt) + '\n', *args)
+
+
+def test_def_vlog(target, simulator, n_cyc=3, n_bits=8):
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    dut_fname = pathlib.Path('tests/verilog/clkdelay.sv').resolve()
+    dut = m.DeclareCircuit('clkdelay', 
+                           'clk', m.In(m.Clock),
+                           'rst', m.In(m.Bit),
+                           'count', m.Out(m.Bits[n_bits]),
+                           'n_done', m.Out(m.Bit))
+
+    tester = fault.Tester(dut, dut.clk)
+
+    # reset
+    tester.poke(dut.rst, 1)
+    tester.poke(dut.clk, 0)
+    tester.step()
+    tester.step()
+
+    # check initial state
+    tester.expect(dut.n_done, 1)
+    tester.expect(dut.count, 0)
+
+    # wait for the loop to complete
+    tester.poke(dut.rst, 0)
+    loop = tester._while(dut.n_done)
+    debug_print(loop, dut)
+    loop.step()
+    loop.step()
+
+    debug_print(tester, dut)
+
+    # check final state
+    tester.expect(dut.count, n_cyc-1)
+    tester.expect(dut.n_done, 0)
+
+    # make some modifications to the environment
+    sim_env = fault.util.remove_conda(os.environ)
+
+    # run the test
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        tester.compile_and_run(
+            target=target,
+            simulator=simulator,
+            directory=tmp_dir,
+            ext_libs=[dut_fname],
+            sim_env=sim_env,
+            skip_compile=True,
+            ext_model_file=True,
+            defines={'N_CYC': n_cyc, 'N_BITS': n_bits}
+        )

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -21,10 +21,7 @@ def pytest_generate_tests(metafunc):
 
 
 def debug_print(tester, dut):
-    to_display = {
-            'dut.n_done': dut.n_done,
-            'dut.count': dut.count
-    }
+    to_display = {'dut.n_done': dut.n_done, 'dut.count': dut.count}
 
     args = []
     fmt = []
@@ -39,7 +36,7 @@ def test_def_vlog(target, simulator, n_cyc=3, n_bits=8):
     logging.getLogger().setLevel(logging.DEBUG)
 
     dut_fname = pathlib.Path('tests/verilog/clkdelay.sv').resolve()
-    dut = m.DeclareCircuit('clkdelay', 
+    dut = m.DeclareCircuit('clkdelay',
                            'clk', m.In(m.Clock),
                            'rst', m.In(m.Bit),
                            'count', m.Out(m.Bits[n_bits]),
@@ -67,7 +64,7 @@ def test_def_vlog(target, simulator, n_cyc=3, n_bits=8):
     debug_print(tester, dut)
 
     # check final state
-    tester.expect(dut.count, n_cyc-1)
+    tester.expect(dut.count, n_cyc - 1)
     tester.expect(dut.n_done, 0)
 
     # make some modifications to the environment

--- a/tests/verilog/clkdelay.sv
+++ b/tests/verilog/clkdelay.sv
@@ -1,0 +1,24 @@
+module clkdelay #(
+    parameter integer n_cyc=`N_CYC,
+    parameter integer n_bits=`N_BITS
+) (
+    input wire logic clk,
+    input wire logic rst,
+    output reg [n_bits-1:0] count,
+    output reg n_done
+);
+
+    always @(posedge clk) begin
+        if (rst == 1'b1) begin
+            count <= 0;
+            n_done <= 1;
+        end else if (count >= n_cyc-1) begin
+            count <= count;
+            n_done <= 0;
+        end else begin
+            count <= count + 1;
+            n_done <= 1;
+        end
+    end
+
+endmodule

--- a/tests/verilog/defadd.sv
+++ b/tests/verilog/defadd.sv
@@ -1,0 +1,11 @@
+module defadd #(
+    parameter integer n_bits=`N_BITS,
+    parameter integer b_val=`B_VAL
+) (
+    input wire logic [n_bits-1:0] a_val,
+    output wire logic [n_bits-1:0] c_val
+);
+
+    assign c_val = a_val + b_val;
+
+endmodule


### PR DESCRIPTION
Depends on pull request #139 

1. Define variables can now be specified to a SystemVerilogTarget via the **defines** argument.  This can be a convenient manner to pass arguments into existing verilog code.
2. Added a test for the while loop functionality in fault (tests/test_while_loop.py)
3. Added support for UnaryOp to SystemVerilogTarget.
4. Added wait_until_high/wait_until_low/wait_until_posedge/wait_until_negedge into the Tester.  These are not implemented as actions but instead are built from the _while() and step() commands.