### PR TITLE
Preliminary Verilog-AMS support

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -3,6 +3,7 @@ from .power_tester import PowerTester
 from .value import Value, AnyValue, UnknownValue
 import fault.random
 from .symbolic_tester import SymbolicTester
+from .verilogams import VAMSWrap, AnalogIn, AnalogOut
 
 
 class WrappedVerilogInternalPort:

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -3,7 +3,8 @@ from .power_tester import PowerTester
 from .value import Value, AnyValue, UnknownValue
 import fault.random
 from .symbolic_tester import SymbolicTester
-from .verilogams import VAMSWrap, AnalogIn, AnalogOut
+from .extra_types import ElectIn, ElectOut, RealIn, RealOut
+from .verilogams import VAMSWrap
 
 
 class WrappedVerilogInternalPort:

--- a/fault/extra_types.py
+++ b/fault/extra_types.py
@@ -1,0 +1,12 @@
+import magma as m
+from magma.bit import MakeBit
+from magma.port import INPUT, OUTPUT
+
+# Hacky definition of analog types.  A more fully-fledged
+# version should probably be moved to magma at some point
+
+ElectIn = MakeBit(direction=INPUT)
+ElectOut = MakeBit(direction=OUTPUT)
+
+RealIn = MakeBit(direction=INPUT)
+RealOut = MakeBit(direction=OUTPUT)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -7,6 +7,7 @@ from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
 from fault.system_verilog_target import SystemVerilogTarget
+from fault.verilogams_target import VerilogAMSTarget
 from fault.actions import Poke, Expect, Step, Print, Loop, While, If
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
@@ -71,7 +72,7 @@ class Tester:
         corresponding target object.
 
         Supported values of target: "verilator", "coreir", "python",
-            "system-verilog"
+            "system-verilog", "verilog-ams"
         """
         if target == "verilator":
             return VerilatorTarget(self._circuit, **kwargs)
@@ -83,6 +84,8 @@ class Tester:
                                         backend='python', **kwargs)
         elif target == "system-verilog":
             return SystemVerilogTarget(self._circuit, **kwargs)
+        elif target == "verilog-ams":
+            return VerilogAMSTarget(self._circuit, **kwargs)
         raise NotImplementedError(target)
 
     def poke(self, port, value):

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -5,106 +5,62 @@ from magma.port import INPUT, OUTPUT
 # Very preliminary implementation of analog types
 # This should probably be moved to magma at some point
 
+
 class AnalogKind(BitKind):
     pass
+
 
 class AnalogType(BitType):
     pass
 
+
 def MakeAnalog(**kwargs):
     return AnalogKind('Analog', (AnalogType,), kwargs)
+
 
 Analog = MakeAnalog()
 AnalogIn = MakeAnalog(direction=INPUT)
 AnalogOut = MakeAnalog(direction=OUTPUT)
 
-# Class that can wrap an existing magma circuit in a Verilog-AMS shell
-# In the future, various special measurement and stimulus features
-# might be added here.
 
-class VerilogAMSWrapper:
-    def __init__(self, circuit, wrap_name=None, inst_name=None):
-        self.circuit = circuit
-        self.wrap_name = (wrap_name if wrap_name is not None
-                             else f'{self.circ_name}_wrap')
-        self.inst_name = (inst_name if inst_name is not None
-                          else f'{self.circ_name}_inst')
+def vams_io_entry(name, type_):
+    # returns the port list declaration for the given port
 
-    @property
-    def circ_name(self):
-        # returns the name of the circuit being wrapped
+    retval = ''
 
-        return self.circuit.name
+    if type_.isinput():
+        retval += 'input'
+    elif type_.isoutput():
+        retval += 'output'
+    else:
+        raise Exception(f'Only inputs and outputs are supported.')
 
-    @staticmethod
-    def io_entry(name, type_):
-        # returns the port list declaration for the given port
+    retval += f' {name}'
 
-        retval = ''
+    return retval
 
-        if type_.isinput():
-            retval += 'input'
-        elif type_.isoutput():
-            retval += 'output'
-        else:
-            raise Exception(f'Only inputs and outputs are supported.')
 
-        retval += f' {name}'
+def vams_type_entry(name, type_):
+    # return the type declaration string for the given port
 
-        return retval
+    if isinstance(type_, AnalogKind):
+        return f'electrical {name};'
+    else:
+        return f'wire [{type_.size()-1}:0] {name};'
 
-    @staticmethod
-    def type_entry(name, type_):
-        # return the type declaration string
-        # for the given port
 
-        if isinstance(type_, AnalogKind):
-            return f'electrical {name};'
-        else:
-            return f'wire [{type_.size()-1}:0] {name};'
+def wrap_circ(circ, wrap_name):
+    # Returns a magma circuit representing the wrapped circuit.
 
-    def generate_code(self, tab='    ', nl='\n'):
-        # Returns a string containing the VerilogAMS implementation 
-        # of the wrapper.
+    args = []
+    for name, type_ in circ.IO.ports.items():
+        args += [name, type_]
 
-        # generate port list declarations
-        port_io = [nl + tab + self.io_entry(name=name, type_=type_) 
-                   for name, type_ in self.circuit.IO.ports.items()]
-        port_io = ','.join(port_io)
+    return m.DeclareCircuit(f'{wrap_name}', *args)
 
-        # generate type declarations
-        port_types = [tab + self.type_entry(name=name, type_=type_)
-                      for name, type_ in self.circuit.IO.ports.items()]
-        port_types = '\n'.join(port_types)
 
-        # generate wiring withing the module instantiation
-        inst_wiring = [f'{nl}{2*tab}.{name}({name})'
-                       for name in self.circuit.IO.ports.keys()]
-        inst_wiring = ','.join(inst_wiring)
-
-        # render the text template
-        src = self.src_tpl.format(
-            wrap_name=self.wrap_name,
-            port_io=port_io,
-            port_types=port_types,
-            circ_name=self.circ_name,
-            inst_name=self.inst_name,
-            inst_wiring=inst_wiring
-        )
-
-        return src
-
-    def make_wrap_circ(self):
-        # Returns a magma circuit representing the wrapped circuit.
-
-        args = []
-        for name, type_ in self.circuit.IO.ports.items():
-            args += [name, type_]
-
-        return m.DeclareCircuit(f'{self.wrap_name}', *args)
-    
-    # Template used for generating the VerilogAMS implementation
-    src_tpl = '''\
+# Template used for generating the VerilogAMS implementation
+src_tpl = '''\
 `include "disciplines.vams"
 
 module {wrap_name} ({port_io}
@@ -116,3 +72,45 @@ module {wrap_name} ({port_io}
     );
 
 endmodule'''
+
+
+def vams_wrap(circ, wrap_name=None, inst_name=None, tab='    ', nl='\n'):
+    # Set defaults
+    wrap_name = (wrap_name if wrap_name is not None
+                 else f'{circ.name}_wrap')
+    inst_name = (inst_name if inst_name is not None
+                 else f'{circ.name}_inst')
+
+    # Generate port list declarations
+    port_io = [nl + tab + vams_io_entry(name=name, type_=type_)
+               for name, type_ in circ.IO.ports.items()]
+    port_io = ','.join(port_io)
+
+    # Generate type declarations
+    port_types = [tab + vams_type_entry(name=name, type_=type_)
+                  for name, type_ in circ.IO.ports.items()]
+    port_types = '\n'.join(port_types)
+
+    # Generate wiring withing the module instantiation
+    inst_wiring = [f'{nl}{2*tab}.{name}({name})'
+                   for name in circ.IO.ports.keys()]
+    inst_wiring = ','.join(inst_wiring)
+
+    # Render the text template
+    vams_code = src_tpl.format(
+        wrap_name=wrap_name,
+        port_io=port_io,
+        port_types=port_types,
+        circ_name=circ.name,
+        inst_name=inst_name,
+        inst_wiring=inst_wiring
+    )
+
+    # Create magma circuit for wrapper
+    retval = wrap_circ(circ=circ, wrap_name=wrap_name)
+
+    # Poke the VerilogAMS code into the magma circuit
+    retval.vams_code = vams_code
+
+    # Return the magma circuit
+    return retval

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -1,0 +1,127 @@
+import magma as m
+
+src_tpl = '''\
+`include "disciplines.vams"
+
+module {wrapper_name} ({port_io}
+);
+
+{port_types}
+
+    {mod_name} {inst_name} ({inst_wiring}
+    );
+
+endmodule'''
+
+
+class VAMSPort:
+    def __init__(self, name, type_, dir_):
+        # input validation to catch typos
+        assert dir_.lower() in ['input', 'output']
+
+        # save settings
+        self.name = name
+        self.type_ = type_
+        self.dir_ = dir_
+
+    def io_entry(self):
+        return f'{self.dir_} {self.name}'
+
+    def type_entry(self):
+        return f'{self.type_} {self.name};'
+
+    def is_analog(self):
+        return self.type_.lower() == 'analog'
+
+    def is_digital(self):
+        return self.type_.lower() == 'digital'
+
+    def magma_io(self):
+        if self.dir_.lower() == 'input':
+            return m.In(self.magma_type())
+        elif self.dir_.lower() == 'output':
+            return m.Out(self.magma_type())
+        else:
+            raise Exception(f'Unsupported I/O direction: {self.dir_}')
+
+    def magma_type(self):
+        raise NotImplementedError
+
+
+class AnalogVAMSPort(VAMSPort):
+    def __init__(self, name, dir_):
+        super().__init__(name=name, type_='electrical', dir_=dir_)
+
+    def magma_type(self):
+        return m.Bit
+
+
+class DigitalVAMSPort(VAMSPort):
+    def __init__(self, name, dir_, width=1, bus=None):
+        # the user doesn't have to set the 'bus' argument unless they
+        # really want a 1-bit bus.  this flexibility seems to be
+        # useful, however because some simulators exhibit minor differences
+        # between a single bit ('wire a') and a 1-bit bus ('wire [0:0] a'])
+        if bus is None:
+            bus = width > 1
+        elif width > 1:
+            assert bus, 'Multi-bit signals must be declared as a bus.'
+
+        # save settings
+        self.width = width
+        self.bus = bus
+
+        # determine the string representation of the wire type
+        type_ = 'wire'
+        if bus:
+            type_ += f' [{width-1}:0]'
+
+        # call the super constructor
+        super().__init__(name=name, type_=type_, dir_=dir_)
+
+    def magma_type(self):
+        if self.bus:
+            return m.Bits[self.width]
+        else:
+            return m.Bit
+
+
+class VerilogAMSWrapper:
+    def __init__(self, mod_name, ports=None, wrapper_name=None, inst_name=None):
+        self.mod_name = mod_name
+        self.ports = ports if ports is not None else []
+        self.wrapper_name = (wrapper_name if wrapper_name is not None
+                             else f'{self.mod_name}_wrapper')
+        self.inst_name = (inst_name if inst_name is not None
+                          else f'{self.mod_name}_inst')
+
+    def generate_code(self, tab='    ', nl='\n'):
+        port_io = [nl + tab + port.io_entry() for port in self.ports]
+        port_io = ','.join(port_io)
+
+        port_types = [tab + port.type_entry() for port in self.ports]
+        port_types = '\n'.join(port_types)
+
+        inst_wiring = [f'{nl}{2*tab}.{port.name}({port.name})'
+                       for port in self.ports]
+        inst_wiring = ','.join(inst_wiring)
+
+        src = src_tpl.format(
+            wrapper_name=self.wrapper_name,
+            port_io=port_io,
+            port_types=port_types,
+            mod_name=self.mod_name,
+            inst_name=self.inst_name,
+            inst_wiring=inst_wiring
+        )
+
+        return src
+
+    def declare_circuit(self):
+        args = []
+        for port in self.ports:
+            args += [port.name, port.magma_io()]
+
+        print(args)
+
+        return m.DeclareCircuit(f'{self.wrapper_name}', *args)

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -1,12 +1,5 @@
 import magma as m
-from magma.bit import MakeBit
-from magma.port import INPUT, OUTPUT
-
-# Hacky definition of analog types.  A more fully-fledged
-# version should probably be moved to magma at some point
-
-AnalogIn = MakeBit(direction=INPUT)
-AnalogOut = MakeBit(direction=OUTPUT)
+from fault.extra_types import ElectIn, ElectOut, RealIn, RealOut
 
 
 def vams_io_entry(name, type_):
@@ -29,8 +22,10 @@ def vams_io_entry(name, type_):
 def vams_type_entry(name, type_):
     # return the type declaration string for the given port
 
-    if type_ is AnalogIn or type_ is AnalogOut:
+    if type_ is ElectIn or type_ is ElectOut:
         return f'electrical {name};'
+    elif type_ is RealIn or type_ is RealOut:
+        return f'real {name};'
     else:
         return f'wire [{type_.size()-1}:0] {name};'
 

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -2,6 +2,9 @@ import magma as m
 from magma.bit import BitKind, BitType
 from magma.port import INPUT, OUTPUT
 
+# Very preliminary implementation of analog types
+# This should probably be moved to magma at some point
+
 class AnalogKind(BitKind):
     pass
 
@@ -15,18 +18,9 @@ Analog = MakeAnalog()
 AnalogIn = MakeAnalog(direction=INPUT)
 AnalogOut = MakeAnalog(direction=OUTPUT)
 
-src_tpl = '''\
-`include "disciplines.vams"
-
-module {wrap_name} ({port_io}
-);
-
-{port_types}
-
-    {circ_name} {inst_name} ({inst_wiring}
-    );
-
-endmodule'''
+# Class that can wrap an existing magma circuit in a Verilog-AMS shell
+# In the future, various special measurement and stimulus features
+# might be added here.
 
 class VerilogAMSWrapper:
     def __init__(self, circuit, wrap_name=None, inst_name=None):
@@ -38,10 +32,14 @@ class VerilogAMSWrapper:
 
     @property
     def circ_name(self):
+        # returns the name of the circuit being wrapped
+
         return self.circuit.name
 
     @staticmethod
     def io_entry(name, type_):
+        # returns the port list declaration for the given port
+
         retval = ''
 
         if type_.isinput():
@@ -57,25 +55,35 @@ class VerilogAMSWrapper:
 
     @staticmethod
     def type_entry(name, type_):
+        # return the type declaration string
+        # for the given port
+
         if isinstance(type_, AnalogKind):
             return f'electrical {name};'
         else:
             return f'wire [{type_.size()-1}:0] {name};'
 
     def generate_code(self, tab='    ', nl='\n'):
+        # Returns a string containing the VerilogAMS implementation 
+        # of the wrapper.
+
+        # generate port list declarations
         port_io = [nl + tab + self.io_entry(name=name, type_=type_) 
                    for name, type_ in self.circuit.IO.ports.items()]
         port_io = ','.join(port_io)
 
+        # generate type declarations
         port_types = [tab + self.type_entry(name=name, type_=type_)
                       for name, type_ in self.circuit.IO.ports.items()]
         port_types = '\n'.join(port_types)
 
+        # generate wiring withing the module instantiation
         inst_wiring = [f'{nl}{2*tab}.{name}({name})'
                        for name in self.circuit.IO.ports.keys()]
         inst_wiring = ','.join(inst_wiring)
 
-        src = src_tpl.format(
+        # render the text template
+        src = self.src_tpl.format(
             wrap_name=self.wrap_name,
             port_io=port_io,
             port_types=port_types,
@@ -86,9 +94,25 @@ class VerilogAMSWrapper:
 
         return src
 
-    def declare_circuit(self):
+    def make_wrap_circ(self):
+        # Returns a magma circuit representing the wrapped circuit.
+
         args = []
-        for port in self.ports:
-            args += [port.name, port.magma_io()]
+        for name, type_ in self.circuit.IO.ports.items():
+            args += [name, type_]
 
         return m.DeclareCircuit(f'{self.wrap_name}', *args)
+    
+    # Template used for generating the VerilogAMS implementation
+    src_tpl = '''\
+`include "disciplines.vams"
+
+module {wrap_name} ({port_io}
+);
+
+{port_types}
+
+    {circ_name} {inst_name} ({inst_wiring}
+    );
+
+endmodule'''

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -1,116 +1,85 @@
 import magma as m
+from magma.bit import BitKind, BitType
+from magma.port import INPUT, OUTPUT
+
+class AnalogKind(BitKind):
+    pass
+
+class AnalogType(BitType):
+    pass
+
+def MakeAnalog(**kwargs):
+    return AnalogKind('Analog', (AnalogType,), kwargs)
+
+Analog = MakeAnalog()
+AnalogIn = MakeAnalog(direction=INPUT)
+AnalogOut = MakeAnalog(direction=OUTPUT)
 
 src_tpl = '''\
 `include "disciplines.vams"
 
-module {wrapper_name} ({port_io}
+module {wrap_name} ({port_io}
 );
 
 {port_types}
 
-    {mod_name} {inst_name} ({inst_wiring}
+    {circ_name} {inst_name} ({inst_wiring}
     );
 
 endmodule'''
 
-
-class VAMSPort:
-    def __init__(self, name, type_, dir_):
-        # input validation to catch typos
-        assert dir_.lower() in ['input', 'output']
-
-        # save settings
-        self.name = name
-        self.type_ = type_
-        self.dir_ = dir_
-
-    def io_entry(self):
-        return f'{self.dir_} {self.name}'
-
-    def type_entry(self):
-        return f'{self.type_} {self.name};'
-
-    def is_analog(self):
-        return self.type_.lower() == 'analog'
-
-    def is_digital(self):
-        return self.type_.lower() == 'digital'
-
-    def magma_io(self):
-        if self.dir_.lower() == 'input':
-            return m.In(self.magma_type())
-        elif self.dir_.lower() == 'output':
-            return m.Out(self.magma_type())
-        else:
-            raise Exception(f'Unsupported I/O direction: {self.dir_}')
-
-    def magma_type(self):
-        raise NotImplementedError
-
-
-class AnalogVAMSPort(VAMSPort):
-    def __init__(self, name, dir_):
-        super().__init__(name=name, type_='electrical', dir_=dir_)
-
-    def magma_type(self):
-        return m.Bit
-
-
-class DigitalVAMSPort(VAMSPort):
-    def __init__(self, name, dir_, width=1, bus=None):
-        # the user doesn't have to set the 'bus' argument unless they
-        # really want a 1-bit bus.  this flexibility seems to be
-        # useful, however because some simulators exhibit minor differences
-        # between a single bit ('wire a') and a 1-bit bus ('wire [0:0] a'])
-        if bus is None:
-            bus = width > 1
-        elif width > 1:
-            assert bus, 'Multi-bit signals must be declared as a bus.'
-
-        # save settings
-        self.width = width
-        self.bus = bus
-
-        # determine the string representation of the wire type
-        type_ = 'wire'
-        if bus:
-            type_ += f' [{width-1}:0]'
-
-        # call the super constructor
-        super().__init__(name=name, type_=type_, dir_=dir_)
-
-    def magma_type(self):
-        if self.bus:
-            return m.Bits[self.width]
-        else:
-            return m.Bit
-
-
 class VerilogAMSWrapper:
-    def __init__(self, mod_name, ports=None, wrapper_name=None, inst_name=None):
-        self.mod_name = mod_name
-        self.ports = ports if ports is not None else []
-        self.wrapper_name = (wrapper_name if wrapper_name is not None
-                             else f'{self.mod_name}_wrapper')
+    def __init__(self, circuit, wrap_name=None, inst_name=None):
+        self.circuit = circuit
+        self.wrap_name = (wrap_name if wrap_name is not None
+                             else f'{self.circ_name}_wrap')
         self.inst_name = (inst_name if inst_name is not None
-                          else f'{self.mod_name}_inst')
+                          else f'{self.circ_name}_inst')
+
+    @property
+    def circ_name(self):
+        return self.circuit.name
+
+    @staticmethod
+    def io_entry(name, type_):
+        retval = ''
+
+        if type_.isinput():
+            retval += 'input'
+        elif type_.isoutput():
+            retval += 'output'
+        else:
+            raise Exception(f'Only inputs and outputs are supported.')
+
+        retval += f' {name}'
+
+        return retval
+
+    @staticmethod
+    def type_entry(name, type_):
+        if isinstance(type_, AnalogKind):
+            return f'electrical {name};'
+        else:
+            return f'wire [{type_.size()-1}:0] {name};'
 
     def generate_code(self, tab='    ', nl='\n'):
-        port_io = [nl + tab + port.io_entry() for port in self.ports]
+        port_io = [nl + tab + self.io_entry(name=name, type_=type_) 
+                   for name, type_ in self.circuit.IO.ports.items()]
         port_io = ','.join(port_io)
 
-        port_types = [tab + port.type_entry() for port in self.ports]
+        port_types = [tab + self.type_entry(name=name, type_=type_)
+                      for name, type_ in self.circuit.IO.ports.items()]
         port_types = '\n'.join(port_types)
 
-        inst_wiring = [f'{nl}{2*tab}.{port.name}({port.name})'
-                       for port in self.ports]
+        inst_wiring = [f'{nl}{2*tab}.{name}({name})'
+                       for name in self.circuit.IO.ports.keys()]
         inst_wiring = ','.join(inst_wiring)
 
         src = src_tpl.format(
-            wrapper_name=self.wrapper_name,
+            wrap_name=self.wrap_name,
             port_io=port_io,
             port_types=port_types,
-            mod_name=self.mod_name,
+            circ_name=self.circ_name,
             inst_name=self.inst_name,
             inst_wiring=inst_wiring
         )
@@ -122,6 +91,4 @@ class VerilogAMSWrapper:
         for port in self.ports:
             args += [port.name, port.magma_io()]
 
-        print(args)
-
-        return m.DeclareCircuit(f'{self.wrapper_name}', *args)
+        return m.DeclareCircuit(f'{self.wrap_name}', *args)

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -1,26 +1,12 @@
 import magma as m
-from magma.bit import BitKind, BitType
+from magma.bit import MakeBit
 from magma.port import INPUT, OUTPUT
 
-# Very preliminary implementation of analog types
-# This should probably be moved to magma at some point
+# Hacky definition of analog types.  A more fully-fledged
+# version should probably be moved to magma at some point
 
-
-class AnalogKind(BitKind):
-    pass
-
-
-class AnalogType(BitType):
-    pass
-
-
-def MakeAnalog(**kwargs):
-    return AnalogKind('Analog', (AnalogType,), kwargs)
-
-
-Analog = MakeAnalog()
-AnalogIn = MakeAnalog(direction=INPUT)
-AnalogOut = MakeAnalog(direction=OUTPUT)
+AnalogIn = MakeBit(direction=INPUT)
+AnalogOut = MakeBit(direction=OUTPUT)
 
 
 def vams_io_entry(name, type_):
@@ -43,7 +29,7 @@ def vams_io_entry(name, type_):
 def vams_type_entry(name, type_):
     # return the type declaration string for the given port
 
-    if isinstance(type_, AnalogKind):
+    if type_ is AnalogIn or type_ is AnalogOut:
         return f'electrical {name};'
     else:
         return f'wire [{type_.size()-1}:0] {name};'

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -74,7 +74,7 @@ module {wrap_name} ({port_io}
 endmodule'''
 
 
-def vams_wrap(circ, wrap_name=None, inst_name=None, tab='    ', nl='\n'):
+def VAMSWrap(circ, wrap_name=None, inst_name=None, tab='    ', nl='\n'):
     # Set defaults
     wrap_name = (wrap_name if wrap_name is not None
                  else f'{circ.name}_wrap')

--- a/fault/verilogams_target.py
+++ b/fault/verilogams_target.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+from .system_verilog_target import SystemVerilogTarget
+
+
+class VerilogAMSTarget(SystemVerilogTarget):
+    def __init__(self, circuit, simulator='ncsim', directory='build/',
+                 model_paths=None, stop_time=1, vsup=1.0, rout=1, flags=None,
+                 include_verilog_libraries=None, **kwargs):
+        """
+        simulator: Name of the simulator to be used for simulation.
+        model_paths: paths to SPICE/Spectre files used in the simulation
+        stop_time: simulation time passed to the analog solver.  must be
+        longer than the mixed-signal simulation duration, or simulation will
+        end before encountering $finish.
+        vsup: supply voltage assumed for D/A and A/D conversions
+        rout: output resistance assumed for D/A conversions
+        flags: Additional flags to be passed to the simulator.  Certain
+        additional flags will be tacked onto this before passing to the
+        SystemVerilogTarget.
+        include_verilog_libraries: Additional source files to be compiled
+        when building this simulation.
+        """
+
+        # save settings
+        self.stop_time = stop_time
+        self.vsup = vsup
+        self.rout = rout
+
+        # save file names that will be written
+        self.amscf = 'amscf.scs'
+
+        # update simulator argument
+        assert simulator == 'ncsim', 'Only the ncsim simulator is allowed at this time.'  # noqa
+
+        # update flags argument
+        flags = flags if flags is not None else []
+        model_paths = model_paths if model_paths is not None else []
+        for path in model_paths:
+            flags += ['-modelpath', f'{path}']
+
+        # update include_verilog_libraries
+        include_verilog_libraries = (include_verilog_libraries
+                                     if include_verilog_libraries is not None
+                                     else [])
+        include_verilog_libraries += [self.amscf]
+
+        # call the superconstructor
+        super().__init__(circuit=circuit, simulator=simulator, flags=flags,
+                         include_verilog_libraries=include_verilog_libraries,
+                         directory=directory, **kwargs)
+
+    def run(self, *args, **kwargs):
+        # write the AMS control file
+        self.write_amscf()
+
+        # then call the super constructor
+        super().run(*args, **kwargs)
+
+    def gen_amscf(self):
+        return f'''
+tranSweep tran stop={self.stop_time}s
+amsd {{
+    ie vsup={self.vsup} rout={self.rout}
+}}'''
+
+    def write_amscf(self):
+        with open(self.directory / Path(self.amscf), 'w') as f:
+            f.write(self.gen_amscf())

--- a/tests/spice/myinv.sp
+++ b/tests/spice/myinv.sp
@@ -1,0 +1,12 @@
+* Inverter example modified from:
+* https://people.rit.edu/lffeee/SPICE_Examples.pdf
+
+.model EENMOS NMOS (VTO=0.4 KP=432E-6 GAMMA=0.2 PHI=.88)
+.model EEPMOS PMOS (VTO=-0.4 KP=122E-6 GAMMA=0.2 PHI=.88)
+
+.subckt myinv in_ out vdd vss
+
+MP0 out in_ vdd vdd EEPMOS w=0.7u l=0.1u
+MN0 out in_ vss vss EENMOS w=0.4u l=0.1u
+
+.ends

--- a/tests/test_vams_sim.py
+++ b/tests/test_vams_sim.py
@@ -17,7 +17,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_vams_sim(target, simulator, n_trials=100, vsup=1.5):
-    logging.getLogger().setLevel(logging.DEBUG)
+    # logging.getLogger().setLevel(logging.DEBUG)
 
     myinv_fname = pathlib.Path('tests/spice/myinv.sp').resolve()
 

--- a/tests/test_vams_sim.py
+++ b/tests/test_vams_sim.py
@@ -1,5 +1,6 @@
 import os
 import random
+import tempfile
 import logging
 import pathlib
 import magma as m
@@ -40,15 +41,18 @@ def test_vams_sim(n_trials=100, vsup=1.5):
     sim_env = fault.util.remove_conda(os.environ)
     sim_env['DISPLAY'] = sim_env.get('DISPLAY', '')
 
-    # write the Verilog-AMS wrapper
-    vamsf = os.path.realpath(os.path.expanduser('myinv_wrap.vams'))
-    open(vamsf, 'w').write(dut.vams_code)
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        # Write the Verilog-AMS model
+        vamsf = os.path.join(tmp_dir, 'myinv_wrap.vams')
+        vamsf = os.path.realpath(os.path.expanduser(vamsf))
+        open(vamsf, 'w').write(dut.vams_code)
 
-    # run the simulation
-    tester.compile_and_run(target='verilog-ams',
-                           model_paths=[myinv_fname],
-                           ext_libs=[vamsf],
-                           sim_env=sim_env,
-                           skip_compile=True,
-                           ext_model_file=True,
-                           vsup=vsup)
+        # Run the simulation
+        tester.compile_and_run(target='verilog-ams',
+                               directory=tmp_dir,
+                               model_paths=[myinv_fname],
+                               ext_libs=[vamsf],
+                               sim_env=sim_env,
+                               skip_compile=True,
+                               ext_model_file=True,
+                               vsup=vsup)

--- a/tests/test_vams_sim.py
+++ b/tests/test_vams_sim.py
@@ -22,10 +22,10 @@ def test_vams_sim(target, simulator, n_trials=100, vsup=1.5):
     myinv_fname = pathlib.Path('tests/spice/myinv.sp').resolve()
 
     myinv = m.DeclareCircuit('myinv',
-                             'in_', fault.AnalogIn,
-                             'out', fault.AnalogOut,
-                             'vdd', fault.AnalogIn,
-                             'vss', fault.AnalogIn)
+                             'in_', m.In(m.Bit),
+                             'out', m.Out(m.Bit),
+                             'vdd', m.In(m.Bit),
+                             'vss', m.In(m.Bit))
 
     dut = fault.VAMSWrap(myinv)
 

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -1,5 +1,5 @@
 import magma as m
-from fault.verilogams import vams_wrap, AnalogIn, AnalogOut
+from fault.verilogams import VAMSWrap, AnalogIn, AnalogOut
 
 
 def test_vams_wrap():
@@ -8,7 +8,7 @@ def test_vams_wrap():
                              'b', AnalogOut,
                              'c', m.In(m.Bit),
                              'd', m.Out(m.Bits[2]))
-    wrap_circ = vams_wrap(myblk)
+    wrap_circ = VAMSWrap(myblk)
 
     # check magma representation of wrapped circuit
     assert wrap_circ.IO.ports['a'] is AnalogIn

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -1,18 +1,18 @@
 import magma as m
-from fault.verilogams import VAMSWrap, AnalogIn, AnalogOut
+from fault.verilogams import VAMSWrap, ElectIn, ElectOut
 
 
 def test_vams_wrap():
     myblk = m.DeclareCircuit('myblk',
-                             'a', AnalogIn,
-                             'b', AnalogOut,
+                             'a', ElectIn,
+                             'b', ElectOut,
                              'c', m.In(m.Bit),
                              'd', m.Out(m.Bits[2]))
     wrap_circ = VAMSWrap(myblk)
 
     # check magma representation of wrapped circuit
-    assert wrap_circ.IO.ports['a'] is AnalogIn
-    assert wrap_circ.IO.ports['b'] is AnalogOut
+    assert wrap_circ.IO.ports['a'] is ElectIn
+    assert wrap_circ.IO.ports['b'] is ElectOut
     assert wrap_circ.IO.ports['c'] is m.In(m.Bit)
     assert wrap_circ.IO.ports['d'] is m.Out(m.Bits[2])
 

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -1,5 +1,5 @@
 import magma as m
-from fault.verilogams import VerilogAMSWrapper, AnalogIn, AnalogOut
+from fault.verilogams import vams_wrap, AnalogIn, AnalogOut
 
 
 def test_vams_wrap():
@@ -8,17 +8,16 @@ def test_vams_wrap():
                              'b', AnalogOut,
                              'c', m.In(m.Bit),
                              'd', m.Out(m.Bits[2]))
-    wrapper = VerilogAMSWrapper(myblk)
+    wrap_circ = vams_wrap(myblk)
 
     # check magma representation of wrapped circuit
-    wrap_circ = wrapper.make_wrap_circ()
     assert wrap_circ.IO.ports['a'] is AnalogIn
     assert wrap_circ.IO.ports['b'] is AnalogOut
     assert wrap_circ.IO.ports['c'] is m.In(m.Bit)
     assert wrap_circ.IO.ports['d'] is m.Out(m.Bits[2])
 
     # check Verilog-AMS code itself
-    assert wrapper.generate_code() == '''\
+    assert wrap_circ.vams_code == '''\
 `include "disciplines.vams"
 
 module myblk_wrap (

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -1,0 +1,35 @@
+from fault.verilogams import (VerilogAMSWrapper,
+                              AnalogVAMSPort,
+                              DigitalVAMSPort)
+
+
+def test_vams_wrap():
+    ports = [AnalogVAMSPort('a', 'input'),
+             AnalogVAMSPort('b', 'output'),
+             DigitalVAMSPort('c', 'input'),
+             DigitalVAMSPort('d', 'output', width=2)]
+    wrapper = VerilogAMSWrapper(mod_name='myblk', ports=ports)
+
+    assert wrapper.generate_code() == '''\
+`include "disciplines.vams"
+
+module myblk_wrapper (
+    input a,
+    output b,
+    input c,
+    output d
+);
+
+    electrical a;
+    electrical b;
+    wire c;
+    wire [1:0] d;
+
+    myblk myblk_inst (
+        .a(a),
+        .b(b),
+        .c(c),
+        .d(d)
+    );
+
+endmodule'''

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -10,6 +10,14 @@ def test_vams_wrap():
                              'd', m.Out(m.Bits[2]))
     wrapper = VerilogAMSWrapper(myblk)
 
+    # check magma representation of wrapped circuit
+    wrap_circ = wrapper.make_wrap_circ()
+    assert wrap_circ.IO.ports['a'] is AnalogIn
+    assert wrap_circ.IO.ports['b'] is AnalogOut
+    assert wrap_circ.IO.ports['c'] is m.In(m.Bit)
+    assert wrap_circ.IO.ports['d'] is m.Out(m.Bits[2])
+
+    # check Verilog-AMS code itself
     assert wrapper.generate_code() == '''\
 `include "disciplines.vams"
 

--- a/tests/test_vams_wrap.py
+++ b/tests/test_vams_wrap.py
@@ -1,19 +1,19 @@
-from fault.verilogams import (VerilogAMSWrapper,
-                              AnalogVAMSPort,
-                              DigitalVAMSPort)
+import magma as m
+from fault.verilogams import VerilogAMSWrapper, AnalogIn, AnalogOut
 
 
 def test_vams_wrap():
-    ports = [AnalogVAMSPort('a', 'input'),
-             AnalogVAMSPort('b', 'output'),
-             DigitalVAMSPort('c', 'input'),
-             DigitalVAMSPort('d', 'output', width=2)]
-    wrapper = VerilogAMSWrapper(mod_name='myblk', ports=ports)
+    myblk = m.DeclareCircuit('myblk',
+                             'a', AnalogIn,
+                             'b', AnalogOut,
+                             'c', m.In(m.Bit),
+                             'd', m.Out(m.Bits[2]))
+    wrapper = VerilogAMSWrapper(myblk)
 
     assert wrapper.generate_code() == '''\
 `include "disciplines.vams"
 
-module myblk_wrapper (
+module myblk_wrap (
     input a,
     output b,
     input c,
@@ -22,7 +22,7 @@ module myblk_wrapper (
 
     electrical a;
     electrical b;
-    wire c;
+    wire [0:0] c;
     wire [1:0] d;
 
     myblk myblk_inst (


### PR DESCRIPTION
This pull request adds support for mixed-signal simulation via VerilogAMSTarget, which inherits from SystemVerilogTarget.  The following features are supported:
1. Generate a VerilogAMS wrapper for a SPICE/Spectre netlist, which itself is a magma circuit that can be provided as the argument to a Tester instantiation.  This is done using the VAMSWrap command.
2. AnalogIn and AnalogOut are added as port types that may be used in a magma DeclareCircuit command.  This probably should be moved to magma at some point.
3. The new VerilogAMSTarget allows the user to specify locations of SPICE/Spectre files (via **model_paths**) and the voltage+resistance used for D2A and A2D conversions (via **vsup** and **rout**).
4. VerilogAMSTarget automatically generates the AMS control file needed for mixed-signal simulation as part of the run() function, similar to how TCL files are generated in the run() command of SystemVerilogTarget.
5. tests/test_vams_sim.py illustrates these features by instantiating a SPICE-level CMOS inverter (tests/spice/myinv.sp) and then checking its behavior in response to a randomized binary stimulus.
6. tests/test_vams_wrap.py is a more low-level test of the generation of a Verilog-AMS wrapper for a mixed-signal circuit.