### PR TITLE
Working with external testbenches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build
 dist
 fault.egg-info
+vnc_logs

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -632,7 +632,7 @@ end;
         cmd += ['-LDFLAGS']
         cmd += ['-Wl,--no-as-needed']
         if self.dump_vcd:
-            cmd += ['-debug_access+all']
+            cmd += ['+vcs+vcdpluson', '-debug_pp']
 
         # return arg list and binary file location
         return cmd, './simv'

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -631,6 +631,8 @@ end;
         cmd += ['+v2k']
         cmd += ['-LDFLAGS']
         cmd += ['-Wl,--no-as-needed']
+        if self.dump_vcd:
+            cmd += ['-debug_access+all']
 
         # return arg list and binary file location
         return cmd, './simv'

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -32,11 +32,13 @@ endmodule
 
 class SystemVerilogTarget(VerilogTarget):
     def __init__(self, circuit, circuit_name=None, directory="build/",
-                 skip_compile=False, magma_output="coreir-verilog",
-                 magma_opts={}, include_verilog_libraries=[], simulator=None,
-                 timescale="1ns/1ns", clock_step_delay=5, num_cycles=10000,
-                 dump_vcd=True, no_warning=False, sim_env=None,
-                 ext_model_file=False, ext_libs=None, defines=None, flags=None):
+                 skip_compile=None, magma_output="coreir-verilog",
+                 magma_opts=None, include_verilog_libraries=None,
+                 simulator=None, timescale="1ns/1ns", clock_step_delay=5,
+                 num_cycles=10000, dump_vcd=True, no_warning=False,
+                 sim_env=None, ext_model_file=None, ext_libs=None,
+                 defines=None, flags=None, inc_dirs=None,
+                 ext_test_bench=False, top_module=None, ext_srcs=None):
         """
         circuit: a magma circuit
 
@@ -79,14 +81,62 @@ class SystemVerilogTarget(VerilogTarget):
 
         flags: List of additional arguments that should be passed to the
                simulator.
+
+        inc_dirs: List of "include directories" to search for the `include
+                  statement.
+
+        ext_test_bench: If True, do not compile testbench actions into a
+                        SystemVerilog testbench and instead simply run a
+                        simulation of an existing (presumably manually
+                        created) testbench.  Can be used to get started
+                        integrating legacy testbenches into the fault
+                        framework.
+
+        top_module: Name of the top module in the design.  If the value is
+                    None and ext_test_bench is False, then top_module will
+                    automatically be filled with the name of the module
+                    containing the generated testbench code.
+
+        ext_srcs: Shorter alias for "include_verilog_libraries" argument.
+                  It is illegal to specify both "include_verilog_libraries"
+                  and "ext_srcs".
         """
+        # set default for list of external sources
+        if include_verilog_libraries is None:
+            if ext_srcs is None:
+                include_verilog_libraries = []
+            else:
+                include_verilog_libraries = ext_srcs
+        else:
+            if ext_srcs is None:
+                pass
+            else:
+                raise ValueError('Cannot specify both "include_verilog_libraries" and "ext_srcs".')  # noqa
+
+        # set default for there being an external model file
+        if ext_model_file is None:
+            ext_model_file = ext_test_bench
+
+        # set default for whether magma compilation should happen
+        if skip_compile is None:
+            skip_compile = ext_model_file
+
+        # set default for magma compilation options
+        magma_opts = magma_opts if magma_opts is not None else {}
+
+        # call the super constructor
         super().__init__(circuit, circuit_name, directory, skip_compile,
-                         include_verilog_libraries, magma_output, magma_opts)
+                         include_verilog_libraries, magma_output,
+                         magma_opts)
+
+        # sanity check
         if simulator is None:
             raise ValueError("Must specify simulator when using system-verilog"
                              " target")
         if simulator not in {"vcs", "ncsim", "iverilog"}:
             raise ValueError(f"Unsupported simulator {simulator}")
+
+        # save settings
         self.simulator = simulator
         self.timescale = timescale
         self.clock_step_delay = clock_step_delay
@@ -99,6 +149,9 @@ class SystemVerilogTarget(VerilogTarget):
         self.ext_libs = ext_libs if ext_libs is not None else []
         self.defines = defines if defines is not None else {}
         self.flags = flags if flags is not None else []
+        self.inc_dirs = inc_dirs if inc_dirs is not None else []
+        self.ext_test_bench = ext_test_bench
+        self.top_module = top_module
 
     def make_name(self, port):
         if isinstance(port, SelectPath):
@@ -376,12 +429,55 @@ end;
 
         return src
 
-    def run(self, actions, power_args={}):
-        test_bench_file = Path(f"{self.circuit_name}_tb.sv")
+    def run(self, actions, power_args=None):
+        # set defaults
+        power_args = power_args if power_args is not None else {}
 
-        # Write the verilator driver to file.
+        # assemble list of sources files
+        vlog_srcs = []
+        if not self.ext_test_bench:
+            tb_file = self.write_test_bench(actions=actions,
+                                            power_args=power_args)
+            vlog_srcs += [tb_file]
+        if not self.ext_model_file:
+            vlog_srcs += [self.verilog_file]
+        vlog_srcs += self.include_verilog_libraries
+
+        # generate simulator commands
+        if self.simulator == 'ncsim':
+            sim_cmd = self.ncsim_cmd(sources=vlog_srcs,
+                                     cmd_file=self.write_ncsim_tcl())
+            bin_cmd = None
+            err_str = None
+        elif self.simulator == 'vcs':
+            sim_cmd, bin_file = self.vcs_cmd(sources=vlog_srcs)
+            bin_cmd = [bin_file]
+            err_str = 'Error'
+        elif self.simulator == 'iverilog':
+            sim_cmd, bin_file = self.iverilog_cmd(sources=vlog_srcs)
+            bin_cmd = ['vvp', '-N', bin_file]
+            err_str = 'ERROR'
+        else:
+            raise NotImplementedError(self.simulator)
+
+        # compile the simulation
+        sim_res = self.subprocess_run(sim_cmd + self.flags)
+        assert not sim_res.returncode, 'Error running system verilog simulator'
+
+        # run the simulation binary (if applicable)
+        if bin_cmd is not None:
+            bin_res = self.subprocess_run(bin_cmd)
+            assert not bin_res.returncode, f'Running {self.simulator} binary failed'  # noqa
+            assert err_str not in str(bin_res.stdout), f'"{err_str}" found in stdout of {self.simulator} run'  # noqa
+
+    def write_test_bench(self, actions, power_args):
+        # determine the path of the testbench file
+        tb_file = self.directory / Path(f'{self.circuit_name}_tb.sv')
+        tb_file = tb_file.absolute()
+
+        # generate source code of test bench
         src = self.generate_code(actions, power_args)
-        tb_file = self.directory / test_bench_file
+
         # If there's an old test bench file, ncsim might not recompile based on
         # the timestamp (1s granularity), see
         # https://github.com/StanfordAHA/lassen/issues/111
@@ -401,43 +497,8 @@ end;
                 new_times = (old_times[0] + 1, old_times[1] + 1)
                 os.utime(tb_file, times=new_times)
 
-        # assemble list of sources files
-
-        vlog_srcs = []
-        vlog_srcs += [test_bench_file]
-        if not self.ext_model_file:
-            vlog_srcs += [self.verilog_file]
-        vlog_srcs += self.include_verilog_libraries
-
-        # generate simulator commands
-
-        if self.simulator == 'ncsim':
-            sim_cmd = self.ncsim_cmd(sources=vlog_srcs,
-                                     cmd_file=self.write_ncsim_tcl())
-            bin_cmd = None
-            err_str = None
-        elif self.simulator == 'vcs':
-            sim_cmd, bin_file = self.vcs_cmd(sources=vlog_srcs)
-            bin_cmd = [bin_file]
-            err_str = 'Error'
-        elif self.simulator == 'iverilog':
-            sim_cmd, bin_file = self.iverilog_cmd(sources=vlog_srcs)
-            bin_cmd = ['vvp', '-N', bin_file]
-            err_str = 'ERROR'
-        else:
-            raise NotImplementedError(self.simulator)
-
-        # compile the simulation
-
-        sim_res = self.subprocess_run(sim_cmd + self.flags)
-        assert not sim_res.returncode, 'Error running system verilog simulator'
-
-        # run the simulation binary (if applicable)
-
-        if bin_cmd is not None:
-            bin_res = self.subprocess_run(bin_cmd)
-            assert not bin_res.returncode, f'Running {self.simulator} binary failed'  # noqa
-            assert err_str not in str(bin_res.stdout), f'"{err_str}" found in stdout of {self.simulator} run'  # noqa
+        # return the path to the testbench location
+        return tb_file
 
     @staticmethod
     def display_subprocess_output(result):
@@ -459,6 +520,8 @@ end;
         # the user-specified environment.  shell=True is used for
         # now which is why the list of arguments must be combined
         # into a single string before passing to subprocess.run
+
+        logging.info(f'Running command: {args}')
 
         result = subprocess.run(args, cwd=self.directory,
                                 capture_output=True, env=self.sim_env)
@@ -500,8 +563,15 @@ end;
         # binary name
         cmd += ['irun']
 
-        # top module
-        cmd += ['-top', f'{self.circuit_name}_tb']
+        # determine the name of the top module
+        if self.top_module is None and not self.ext_test_bench:
+            top = f'{self.circuit_name}_tb'
+        else:
+            top = self.top_module
+
+        # send name of top module to the simulator
+        if top is not None:
+            cmd += ['-top', f'{top}']
 
         # timescale
         cmd += ['-timescale', f'{self.timescale}']
@@ -515,6 +585,10 @@ end;
         # library files
         for lib in self.ext_libs:
             cmd += ['-v', f'{lib}']
+
+        # include directory search path
+        for dir_ in self.inc_dirs:
+            cmd += ['-incdir', f'{dir_}']
 
         # define variables
         cmd += self.def_args(prefix='+define+')
@@ -543,6 +617,10 @@ end;
         # library files
         for lib in self.ext_libs:
             cmd += ['-v', f'{lib}']
+
+        # include directory search path
+        for dir_ in self.inc_dirs:
+            cmd += [f'+incdir+{dir_}']
 
         # define variables
         cmd += self.def_args(prefix='+define+')
@@ -573,6 +651,10 @@ end;
         # library files
         for lib in self.ext_libs:
             cmd += ['-v', f'{lib}']
+
+        # include directory search path
+        for dir_ in self.inc_dirs:
+            cmd += [f'-I{dir_}']
 
         # define variables
         cmd += self.def_args(prefix='-D')

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -20,9 +20,8 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('target,simulator', targets)
 
 
-def test_def_vlog(target, simulator, n_bits=8, b_val=42, debug=False):
-    if debug:
-        logging.getLogger().setLevel(logging.DEBUG)
+def test_def_vlog(target, simulator, n_bits=8, b_val=42):
+    # logging.getLogger().setLevel(logging.DEBUG)
 
     defadd_fname = pathlib.Path('tests/verilog/defadd.sv').resolve()
     defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]),
@@ -52,8 +51,3 @@ def test_def_vlog(target, simulator, n_bits=8, b_val=42, debug=False):
             defines={'N_BITS': n_bits, 'B_VAL': b_val},
             ext_model_file=True
         )
-
-
-if __name__ == '__main__':
-    for simulator in ['vcs', 'ncsim', 'iverilog']:
-        test_def_vlog('system-verilog', simulator, debug=True)

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -4,7 +4,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 import mantle
 
 
@@ -21,8 +20,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_def_vlog(target, simulator, n_bits=8, b_val=42):
-    # logging.getLogger().setLevel(logging.DEBUG)
-
     defadd_fname = pathlib.Path('tests/verilog/defadd.sv').resolve()
     defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]),
                               'c_val', m.Out(m.Bits[n_bits]))

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -20,8 +20,9 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('target,simulator', targets)
 
 
-def test_def_vlog(target, simulator, n_bits=8, b_val=42):
-    # logging.getLogger().setLevel(logging.DEBUG)
+def test_def_vlog(target, simulator, n_bits=8, b_val=42, debug=False):
+    if debug:
+        logging.getLogger().setLevel(logging.DEBUG)
 
     defadd_fname = pathlib.Path('tests/verilog/defadd.sv').resolve()
     defadd = m.DeclareCircuit('defadd', 'a_val', m.In(m.Bits[n_bits]),
@@ -48,7 +49,11 @@ def test_def_vlog(target, simulator, n_bits=8, b_val=42):
             directory=tmp_dir,
             ext_libs=[defadd_fname],
             sim_env=sim_env,
-            skip_compile=True,
-            ext_model_file=True,
-            defines={'N_BITS': n_bits, 'B_VAL': b_val}
+            defines={'N_BITS': n_bits, 'B_VAL': b_val},
+            ext_model_file=True
         )
+
+
+if __name__ == '__main__':
+    for simulator in ['vcs', 'ncsim', 'iverilog']:
+        test_def_vlog('system-verilog', simulator, debug=True)

--- a/tests/test_env_mod.py
+++ b/tests/test_env_mod.py
@@ -4,7 +4,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 import mantle
 
 
@@ -19,8 +18,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_env_mod(target, simulator):
-    # logging.getLogger().setLevel(logging.DEBUG)
-
     myinv = m.DefineCircuit('myinv', 'a', m.In(m.Bit), 'y', m.Out(m.Bit))
     m.wire(~myinv.a, myinv.y)
     m.EndDefine()

--- a/tests/test_ext_tb.py
+++ b/tests/test_ext_tb.py
@@ -4,7 +4,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 
 
 def pytest_generate_tests(metafunc):
@@ -20,8 +19,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_ext_vlog(target, simulator):
-    # logging.getLogger().setLevel(logging.DEBUG)
-
     mytb_fname = pathlib.Path('tests/verilog/mytb.sv').resolve()
     tester = fault.Tester(m.DeclareCircuit('mytb'))
 

--- a/tests/test_ext_tb.py
+++ b/tests/test_ext_tb.py
@@ -19,9 +19,8 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('target,simulator', targets)
 
 
-def test_ext_vlog(target, simulator, debug=False):
-    if debug:
-        logging.getLogger().setLevel(logging.DEBUG)
+def test_ext_vlog(target, simulator):
+    # logging.getLogger().setLevel(logging.DEBUG)
 
     mytb_fname = pathlib.Path('tests/verilog/mytb.sv').resolve()
     tester = fault.Tester(m.DeclareCircuit('mytb'))
@@ -40,8 +39,3 @@ def test_ext_vlog(target, simulator, debug=False):
             sim_env=sim_env,
             ext_test_bench=True
         )
-
-
-if __name__ == '__main__':
-    for simulator in ['vcs', 'ncsim', 'iverilog']:
-        test_ext_vlog('system-verilog', simulator, debug=True)

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -4,7 +4,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 import mantle
 
 
@@ -21,8 +20,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_ext_vlog(target, simulator):
-    # logging.getLogger().setLevel(logging.DEBUG)
-
     myinv_fname = pathlib.Path('tests/verilog/myinv.v').resolve()
     myinv = m.DeclareCircuit('myinv', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
 

--- a/tests/test_inc_dir.py
+++ b/tests/test_inc_dir.py
@@ -3,7 +3,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 import mantle
 from pathlib import Path
 
@@ -21,8 +20,6 @@ def pytest_generate_tests(metafunc):
 
 
 def test_ext_vlog(target, simulator):
-    # logging.getLogger().setLevel(logging.DEBUG)
-
     mybuf_fname = Path('tests/verilog/mybuf.v').resolve()
     mybuf = m.DeclareCircuit('mybuf', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
 

--- a/tests/test_inc_dir.py
+++ b/tests/test_inc_dir.py
@@ -1,4 +1,3 @@
-import pathlib
 import tempfile
 import fault
 import magma as m
@@ -6,6 +5,7 @@ import os
 import shutil
 import logging
 import mantle
+from pathlib import Path
 
 
 def pytest_generate_tests(metafunc):
@@ -23,18 +23,18 @@ def pytest_generate_tests(metafunc):
 def test_ext_vlog(target, simulator):
     # logging.getLogger().setLevel(logging.DEBUG)
 
-    myinv_fname = pathlib.Path('tests/verilog/myinv.v').resolve()
-    myinv = m.DeclareCircuit('myinv', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
+    mybuf_fname = Path('tests/verilog/mybuf.v').resolve()
+    mybuf = m.DeclareCircuit('mybuf', 'in_', m.In(m.Bit), 'out', m.Out(m.Bit))
 
-    tester = fault.Tester(myinv)
+    tester = fault.Tester(mybuf)
 
-    tester.poke(myinv.in_, 1)
+    tester.poke(mybuf.in_, 1)
     tester.eval()
-    tester.expect(myinv.out, 0)
+    tester.expect(mybuf.out, 1)
 
-    tester.poke(myinv.in_, 0)
+    tester.poke(mybuf.in_, 0)
     tester.eval()
-    tester.expect(myinv.out, 1)
+    tester.expect(mybuf.out, 0)
 
     # make some modifications to the environment
     sim_env = fault.util.remove_conda(os.environ)
@@ -46,7 +46,8 @@ def test_ext_vlog(target, simulator):
             target=target,
             simulator=simulator,
             directory=tmp_dir,
-            ext_libs=[myinv_fname],
+            ext_libs=[mybuf_fname],
+            inc_dirs=[Path('tests/verilog').resolve()],
             sim_env=sim_env,
             ext_model_file=True
         )

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -78,7 +78,6 @@ def test_def_vlog(target, simulator, n_cyc=3, n_bits=8):
             directory=tmp_dir,
             ext_libs=[dut_fname],
             sim_env=sim_env,
-            skip_compile=True,
-            ext_model_file=True,
-            defines={'N_CYC': n_cyc, 'N_BITS': n_bits}
+            defines={'N_CYC': n_cyc, 'N_BITS': n_bits},
+            ext_model_file=True
         )

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -4,7 +4,6 @@ import fault
 import magma as m
 import os
 import shutil
-import logging
 import mantle
 
 
@@ -32,9 +31,7 @@ def debug_print(tester, dut):
     tester.print(', '.join(fmt) + '\n', *args)
 
 
-def test_def_vlog(target, simulator, n_cyc=3, n_bits=8):
-    logging.getLogger().setLevel(logging.DEBUG)
-
+def test_while_loop(target, simulator, n_cyc=3, n_bits=8):
     dut_fname = pathlib.Path('tests/verilog/clkdelay.sv').resolve()
     dut = m.DeclareCircuit('clkdelay',
                            'clk', m.In(m.Clock),

--- a/tests/verilog/mybuf.v
+++ b/tests/verilog/mybuf.v
@@ -1,0 +1,13 @@
+`include "myinv.v"
+
+module mybuf(
+    input in_,
+    output out
+);
+
+    wire out_n;
+
+    myinv myinv_0 (.in_(in_), .out(out_n));
+    myinv myinv_1 (.in_(out_n), .out(out));
+
+endmodule

--- a/tests/verilog/mytb.sv
+++ b/tests/verilog/mytb.sv
@@ -1,0 +1,20 @@
+module mytb;
+    reg in_;
+    wire out;
+
+    assign out = ~in_;
+
+    task check(input stim, input expct); begin
+        in_ = stim;
+        #1;
+        if (out !== expct) begin
+            $error("Expected %0b, got %0b", expct, out);
+        end
+    end endtask
+
+    initial begin
+        check(1'b0, 1'b1);
+        check(1'b1, 1'b0);
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
This PR allows a user to run an existing (presumably hand-written) SystemVerilog testbench using **fault**.  In this case, **fault** is essentially being using for its capability to abstract simulator commands over ncsim, vcs, and iverilog.  However, this is still a useful capability in its own right, and might be a stepping stone for the user to get started creating their own testbenches using the full power of **fault**.

The following features are included:
1.  Added an argument "ext_test_bench" to SystemVerilogTarget.  If True, no testbench file will be written for fault and the simulator won't be instructed to look for it.
2. Added an argument "inc_dirs" to SystemVerilogTarget.  This is the search path used by the simulator for "`include" statements.
3.  Added an argument "top_module" to SystemVerilogTarget.  Generally this can be left at its default value (None), and it will be filled automatically if needed.  This addition was needed because the ncsim command used to always include "-top {circuit.name}_tb", which isn't necessarily correct in the case of an external test bench.
4. Added an argument "ext_srcs" to SystemVerilogTarget.  It is an alias for the longer argument name "include_verilog_libraries".  A conservative approach is taken to avoid confusion: it is deemed illegal to specify both.
5. Updated the default-picking scheme for "skip_compile", "ext_model_file", and "ext_test_bench": if ext_model_file isn't specified, it defaults to "ext_test_bench".  Similarly, if "skip_compile" isn't specified, it defaults to "ext_model_file".  This keeps backward compatibility while making it easier to work with external models and testbenches.
6. Now using "None" rather than "[]" and "{}" in kwarg defaults in SystemVerilogTarget.__init__ and SystemVerilogTarget.run (the correct defaults are filled in the body of the function itself)
7. Added **test_ext_tb** and **test_inc_dir**.
8. Refactored **test_def_vlog**, **test_ext_vlog**, and **test_while_loop** to take advantage of new features.