### PR TITLE
Real-time subprocess output; initial conditions and selective probing for Spice.

### DIFF
--- a/examples/myinv.py
+++ b/examples/myinv.py
@@ -8,12 +8,12 @@ dut = m.DeclareCircuit('myinv', 'in_', m.BitIn, 'out', m.BitOut,
 
 # define the test
 t = fault.Tester(dut)
-t.poke(dut.vss, 0)
-t.poke(dut.vdd, 1)
-t.poke(dut.in_, 0)
-t.expect(dut.out, 1)
-t.poke(dut.in_, 1)
-t.expect(dut.out, 0)
+t.poke(dut.vss, False)
+t.poke(dut.vdd, True)
+t.poke(dut.in_, False)
+t.expect(dut.out, True)
+t.poke(dut.in_, True)
+t.expect(dut.out, False)
 
 # run the test
 t.compile_and_run(target='spice', simulator='ngspice', vsup=1.5,

--- a/examples/myinv.py
+++ b/examples/myinv.py
@@ -1,0 +1,20 @@
+import magma as m
+import fault
+from pathlib import Path
+
+# declare circuit
+dut = m.DeclareCircuit('myinv', 'in_', m.BitIn, 'out', m.BitOut,
+                       'vdd', m.BitIn, 'vss', m.BitIn)
+
+# define the test
+t = fault.Tester(dut)
+t.poke(dut.vss, 0)
+t.poke(dut.vdd, 1)
+t.poke(dut.in_, 0)
+t.expect(dut.out, 1)
+t.poke(dut.in_, 1)
+t.expect(dut.out, 0)
+
+# run the test
+t.compile_and_run(target='spice', simulator='ngspice', vsup=1.5,
+                  model_paths=[Path('myinv.sp').resolve()])

--- a/examples/myinv.sp
+++ b/examples/myinv.sp
@@ -1,0 +1,12 @@
+* NMOS/PMOS models from
+* https://people.rit.edu/lffeee/SPICE_Examples.pdf
+
+.model EENMOS NMOS (VTO=0.4 KP=432E-6 GAMMA=0.2 PHI=.88)
+.model EEPMOS PMOS (VTO=-0.4 KP=122E-6 GAMMA=0.2 PHI=.88)
+
+.subckt myinv in_ out vdd vss
+
+MP0 out in_ vdd vdd EEPMOS w=0.7u l=0.1u
+MN0 out in_ vss vss EENMOS w=0.4u l=0.1u
+
+.ends

--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -52,10 +52,11 @@ def run(noise=0.0):
     tester.expect(dut.lblb, True)
 
     # specify initial conditions
-    ic = {'X0.lbl_x': noise,
-          'X0.lblb_x': VDD - noise,
-          'lbl': VDD,
-          'lblb': VDD}
+
+    ic = {tester.internal('lbl_x'): noise,
+          tester.internal('lblb_x'): VDD - noise,
+          dut.lbl: VDD,
+          dut.lblb: VDD}
 
     # run the test
     tester.compile_and_run(
@@ -63,7 +64,7 @@ def run(noise=0.0):
         vsup=VDD,
         target='spice',
         simulator=SIMULATOR,
-        model_paths=[CIRCUIT_PATH],
+        model_paths=[CIRCUIT_PATH]
     )
 
 

--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -6,7 +6,7 @@ from pathlib import Path
 THIS_DIR = Path(__file__).resolve().parent
 
 
-def run(target='spice', simulator='ngspice', vsup=1.5, noise=0.0, td=5e-9):
+def run(target='spice', simulator='ngspice', vsup=1.5, noise=0.0, td=5):
     # declare circuit
     sram = m.DeclareCircuit(
         'sram_snm',
@@ -25,40 +25,43 @@ def run(target='spice', simulator='ngspice', vsup=1.5, noise=0.0, td=5e-9):
         dut = sram
 
     # instantiate the tester
-    tester = fault.Tester(dut)
+    tester = fault.Tester(dut, expect_strict_default=True,
+                          poke_delay_default=td)
 
     # initialize
-    tester.poke(dut.lbl, 0, delay=td)
-    tester.poke(dut.lblb, 0, delay=td)
-    tester.poke(dut.noise, 0, delay=td)
-    tester.poke(dut.vdd, 1, delay=td)
-    tester.poke(dut.vss, 0, delay=td)
-    tester.poke(dut.wl, 0, delay=td)
+    tester.poke(dut.lbl, 0)
+    tester.poke(dut.lblb, 0)
+    tester.poke(dut.noise, 0)
+    tester.poke(dut.vdd, 1)
+    tester.poke(dut.vss, 0)
+    tester.poke(dut.wl, 0)
 
     # write a "0"
-    tester.poke(dut.lbl, 0, delay=td)
-    tester.poke(dut.lblb, 1, delay=td)
-    tester.poke(dut.wl, 1, delay=td)
-    tester.poke(dut.wl, 0, delay=td)
+    tester.poke(dut.lbl, 0)
+    tester.poke(dut.lblb, 1)
+    tester.poke(dut.wl, 1)
+    tester.poke(dut.wl, 0)
 
     # apply noise
-    tester.poke(dut.noise, noise, delay=td)
-    tester.poke(dut.noise, 0, delay=td)
+    tester.poke(dut.noise, noise)
+    tester.poke(dut.noise, 0)
 
     # precharge
-    tester.poke(dut.lbl, 1, delay=td)
-    tester.poke(dut.lblb, 1, delay=td)
+    tester.poke(dut.lbl, 1)
+    tester.poke(dut.lblb, 1)
+    tester.delay(td)
 
     # set to Hi-Z
-    tester.poke(dut.lbl, fault.HiZ, delay=td)
-    tester.poke(dut.lblb, fault.HiZ, delay=td)
+    tester.poke(dut.lbl, fault.HiZ)
+    tester.poke(dut.lblb, fault.HiZ)
+    tester.delay(td)
 
     # access bit
-    tester.poke(dut.wl, 1, delay=td)
+    tester.poke(dut.wl, 1)
 
     # read back data, expecting "0"
-    tester.expect(dut.lbl, 0, strict=True)
-    tester.expect(dut.lblb, 1, strict=True)
+    tester.expect(dut.lbl, 0)
+    tester.expect(dut.lblb, 1)
 
     # set options
     kwargs = dict(

--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -18,7 +18,7 @@ VDD = 1.5
 
 # define the amount to time to wait before checking
 # the bit value
-TD = 10e-9
+TD = 100e-9
 
 # define the number of iterations to run
 N_ITER = 15
@@ -39,21 +39,19 @@ def run(noise=0.0):
     tester = fault.Tester(dut, expect_strict_default=True,
                           poke_delay_default=0)
 
-    # initialize with pre-charged bitlines
+    # initialize
     tester.poke(dut.lbl, fault.HiZ)
     tester.poke(dut.lblb, fault.HiZ)
     tester.poke(dut.vdd, True)
     tester.poke(dut.vss, False)
     tester.poke(dut.wl, True)
-
-    # delay
     tester.delay(TD)
 
     # read back data, expecting "0"
     tester.expect(dut.lbl, False)
     tester.expect(dut.lblb, True)
 
-    # determine initial conditions
+    # specify initial conditions
     ic = {'X0.lbl_x': noise,
           'X0.lblb_x': VDD - noise,
           'lbl': VDD,

--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -1,0 +1,94 @@
+import magma as m
+import fault
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+
+
+def run(target='spice', simulator='ngspice', vsup=1.5, noise=0.0, td=5e-9):
+    # declare circuit
+    sram = m.DeclareCircuit(
+        'sram_snm',
+        'lbl', m.BitInOut,
+        'lblb', m.BitInOut,
+        'noise', fault.RealIn,
+        'vdd', m.BitIn,
+        'vss', m.BitIn,
+        'wl', m.BitIn
+    )
+
+    # wrap if needed
+    if target == 'verilog-ams':
+        dut = fault.VAMSWrap(sram)
+    else:
+        dut = sram
+
+    # instantiate the tester
+    tester = fault.Tester(dut)
+
+    # initialize
+    tester.poke(dut.lbl, 0, delay=td)
+    tester.poke(dut.lblb, 0, delay=td)
+    tester.poke(dut.noise, 0, delay=td)
+    tester.poke(dut.vdd, 1, delay=td)
+    tester.poke(dut.vss, 0, delay=td)
+    tester.poke(dut.wl, 0, delay=td)
+
+    # write a "0"
+    tester.poke(dut.lbl, 0, delay=td)
+    tester.poke(dut.lblb, 1, delay=td)
+    tester.poke(dut.wl, 1, delay=td)
+    tester.poke(dut.wl, 0, delay=td)
+
+    # apply noise
+    tester.poke(dut.noise, noise, delay=td)
+    tester.poke(dut.noise, 0, delay=td)
+
+    # precharge
+    tester.poke(dut.lbl, 1, delay=td)
+    tester.poke(dut.lblb, 1, delay=td)
+
+    # set to Hi-Z
+    tester.poke(dut.lbl, fault.HiZ, delay=td)
+    tester.poke(dut.lblb, fault.HiZ, delay=td)
+
+    # access bit
+    tester.poke(dut.wl, 1, delay=td)
+
+    # read back data, expecting "0"
+    tester.expect(dut.lbl, 0, strict=True)
+    tester.expect(dut.lblb, 1, strict=True)
+
+    # set options
+    kwargs = dict(
+        target=target,
+        simulator=simulator,
+        model_paths=[THIS_DIR / 'sram_snm.sp'],
+        vsup=vsup,
+        t_tr=td / 10,
+        tmp_dir=True
+    )
+    if target == 'verilog-ams':
+        kwargs['use_spice'] = ['sram_snm']
+
+    # run the simulation
+    tester.compile_and_run(**kwargs)
+
+
+def main(vsup=1.5):
+    dn, up = 0, vsup
+    for k in range(15):
+        noise = 0.5 * (up + dn)
+        print(f'Iteration {k}: noise={noise}')
+        try:
+            run(vsup=vsup, noise=noise)
+        except (fault.A2DError, AssertionError):
+            up = noise
+        else:
+            dn = noise
+    print(f'Noise: {0.5*(up+dn)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -59,7 +59,7 @@ def run(noise=0.0):
           'lbl': VDD,
           'lblb': VDD}
 
-    # set options
+    # run the test
     tester.compile_and_run(
         ic=ic,
         vsup=VDD,

--- a/examples/sram_snm.sp
+++ b/examples/sram_snm.sp
@@ -1,0 +1,23 @@
+* NMOS/PMOS models from
+* https://people.rit.edu/lffeee/SPICE_Examples.pdf
+
+.model EENMOS NMOS (VTO=0.4 KP=432E-6 GAMMA=0.2 PHI=.88)
+.model EEPMOS PMOS (VTO=-0.4 KP=122E-6 GAMMA=0.2 PHI=.88)
+
+.subckt sram_snm lbl lblb noise vdd vss wl
+
+* inverter with lblb output
+E0 lbl_n lbl_x noise 0 1.0
+MP0 lblb_x lbl_n vdd vdd EEPMOS w=0.7u l=0.1u
+MN0 lblb_x lbl_n vss vss EENMOS w=0.4u l=0.1u
+
+* inverter with lbl output
+E1 lblb_x lblb_n noise 0 1.0
+MP1 lbl_x lblb_n vdd vdd EEPMOS w=0.7u l=0.1u
+MN1 lbl_x lblb_n vss vss EENMOS w=0.4u l=0.1u
+
+* access switches
+MN2 lbl wl lbl_x vss EENMOS w=1.2u l=0.1u
+MN3 lblb wl lblb_x vss EENMOS w=1.2u l=0.1u
+
+.ends

--- a/examples/sram_snm.sp
+++ b/examples/sram_snm.sp
@@ -4,17 +4,15 @@
 .model EENMOS NMOS (VTO=0.4 KP=432E-6 GAMMA=0.2 PHI=.88)
 .model EEPMOS PMOS (VTO=-0.4 KP=122E-6 GAMMA=0.2 PHI=.88)
 
-.subckt sram_snm lbl lblb noise vdd vss wl
+.subckt sram_snm lbl lblb vdd vss wl
 
 * inverter with lblb output
-E0 lbl_n lbl_x noise 0 1.0
-MP0 lblb_x lbl_n vdd vdd EEPMOS w=0.7u l=0.1u
-MN0 lblb_x lbl_n vss vss EENMOS w=0.4u l=0.1u
+MP0 lblb_x lbl_x vdd vdd EEPMOS w=0.7u l=0.1u
+MN0 lblb_x lbl_x vss vss EENMOS w=0.4u l=0.1u
 
 * inverter with lbl output
-E1 lblb_x lblb_n noise 0 1.0
-MP1 lbl_x lblb_n vdd vdd EEPMOS w=0.7u l=0.1u
-MN1 lbl_x lblb_n vss vss EENMOS w=0.4u l=0.1u
+MP1 lbl_x lblb_x vdd vdd EEPMOS w=0.7u l=0.1u
+MN1 lbl_x lblb_x vss vss EENMOS w=0.4u l=0.1u
 
 * access switches
 MN2 lbl wl lbl_x vss EENMOS w=1.2u l=0.1u

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -10,6 +10,7 @@ from .tester_samples import (SRAMTester, InvTester, BufTester,
                              NandTester, NorTester)
 from .random import random_bit, random_bv
 from .util import clog2
+from .spice_target import A2DError
 
 
 class WrappedVerilogInternalPort:

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -42,10 +42,11 @@ def is_input(port):
 
 
 class Poke(PortAction):
-    def __init__(self, port, value):
+    def __init__(self, port, value, delay=None):
         if is_input(port):
             raise ValueError(f"Can only poke inputs: {port.debug_name} "
                              f"{type(port)}")
+        self.delay = delay
         super().__init__(port, value)
 
 

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -90,6 +90,15 @@ class CoSATarget(VerilogTarget):
     def make_var(self, i, action):
         raise NotImplementedError()
 
+    def make_delay(self, i, action):
+        raise NotImplementedError()
+
+    def make_if(self, i, action):
+        raise NotImplementedError()
+
+    def make_while(self, i, action):
+        raise NotImplementedError()
+
     def make_step(self, i, action):
         self.step_offset += action.steps
         if self.step_offset % 2 == 0:

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -39,7 +39,7 @@ class SelectPath:
         elif isinstance(self.path[-1], str):
             path += [self.path[-1]]
         else:
-            path += verilog_name(self.path[-1].name)
+            path += [verilog_name(self.path[-1].name)]
 
         # Return the path string constructed with the provided separator.
         return separator.join(path)

--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -22,19 +22,34 @@ class SelectPath:
         self.path[index] = value
 
     def make_path(self, separator):
-        path_str = ""
-        # Skip outermost circuit definition (top) and innermost port
-        # (appended next)
+        # Initialize empty path
+        path = []
+
+        # Add the second through second-to-last entries to the path string.
+        # Note that the first path entry is simply skipped.
         for x in self.path[1:-1]:
-            path_str += x.instance.name + separator
+            if isinstance(x, str):
+                path += [x]
+            else:
+                path += [x.instance.name]
+
+        # Append the final path entry
         if isinstance(self.path[-1], fault.WrappedVerilogInternalPort):
-            path_str += self.path[-1].path
+            path += [self.path[-1].path]
+        elif isinstance(self.path[-1], str):
+            path += [self.path[-1]]
         else:
-            path_str += verilog_name(self.path[-1].name)
-        return path_str
+            path += verilog_name(self.path[-1].name)
+
+        # Return the path string constructed with the provided separator.
+        return separator.join(path)
 
     @property
     def system_verilog_path(self):
+        return self.make_path(".")
+
+    @property
+    def spice_path(self):
         return self.make_path(".")
 
     @property

--- a/fault/spice.py
+++ b/fault/spice.py
@@ -5,6 +5,13 @@ class SpiceNetlist(CodeGenerator):
     def comment(self, text):
         self.println(f'* {text}')
 
+    def ic(self, cond):
+        line = []
+        line += ['.ic']
+        for key, val in cond.items():
+            line += [f'v({key})={val}']
+        self.println(' '.join(line))
+
     def include(self, file_):
         self.println(f'.include {file_}')
 
@@ -90,8 +97,14 @@ class SpiceNetlist(CodeGenerator):
         # print the line
         self.println(' '.join(line))
 
-    def tran(self, t_step, t_stop):
-        self.println(f'.tran {t_step} {t_stop}')
+    def tran(self, t_step, t_stop, uic=False):
+        line = []
+        line += ['.tran']
+        line += [f'{t_step}']
+        line += [f'{t_stop}']
+        if uic:
+            line += ['uic']
+        self.println(' '.join(line))
 
     def start_subckt(self, name, *ports):
         port_str = ' '.join(ports)

--- a/fault/spice.py
+++ b/fault/spice.py
@@ -12,6 +12,13 @@ class SpiceNetlist(CodeGenerator):
             line += [f'v({key})={val}']
         self.println(' '.join(line))
 
+    def probe(self, *probes):
+        line = []
+        line += ['.probe']
+        for p in probes:
+            line += [f'{p}']
+        self.println(' '.join(line))
+
     def include(self, file_):
         self.println(f'.include {file_}')
 

--- a/fault/spice_target.py
+++ b/fault/spice_target.py
@@ -11,6 +11,7 @@ from fault.psf_parse import psf_parse
 from fault.subprocess_run import subprocess_run
 from fault.pwl import pwc_to_pwl
 from fault.actions import Poke, Expect, Delay, Print
+from fault.select_path import SelectPath
 
 
 # define a custom error for A2D conversion to make it easier
@@ -337,7 +338,13 @@ class SpiceTarget(Target):
         netlist.probe(*comp.saves)
 
         # specify initial conditions if needed
-        netlist.ic(self.ic)
+        ic = {}
+        for key, val in self.ic.items():
+            if isinstance(key, SelectPath):
+                ic[f'X0.{key.spice_path}'] = val
+            else:
+                ic[f'{key}'] = val
+        netlist.ic(ic)
 
         # specify the transient analysis
         t_step = (self.t_step if self.t_step is not None

--- a/fault/spice_target.py
+++ b/fault/spice_target.py
@@ -196,8 +196,11 @@ class SpiceTarget(Target):
                 # add the value to the list of actions
                 pwc_dict[action_port_name][0].append((t, stim_v))
                 pwc_dict[action_port_name][1].append((t, stim_s))
-                # increment time
-                t += self.clock_step_delay * 1e-9
+                # increment time if desired
+                if action.delay is None:
+                    t += self.clock_step_delay * 1e-9
+                else:
+                    t += action.delay
             elif isinstance(action, Expect):
                 checks.append((t, action))
             elif isinstance(action, Delay):

--- a/fault/spice_target.py
+++ b/fault/spice_target.py
@@ -120,8 +120,7 @@ class SpiceTarget(Target):
 
         # run the simulation commands
         for sim_cmd in sim_cmds:
-            res = subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
-            assert not res.returncode, f'Error running simulator: {self.simulator}'  # noqa
+            subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
 
         # process the results
         if self.simulator in {'ngspice', 'spectre'}:

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -135,7 +135,7 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
         # in child threads, so for now the outputs are processed sequentially
         stdout = process_output(fd=p.stdout, err_str=err_str,
                                 disp_type=disp_type, name='STDOUT')
-        stderr = process_output(fd=p.stdout, err_str=err_str,
+        stderr = process_output(fd=p.stderr, err_str=err_str,
                                 disp_type=disp_type, name='STDERR')
 
         # get return code and check result if desired

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -1,36 +1,72 @@
 import logging
-import subprocess
+import shlex
+from subprocess import Popen, PIPE
 from fault.user_cfg import FaultConfig
 
 
-def display_subprocess_output(result):
-    # display both standard output and standard error as INFO, since
-    # since some useful debugging info is included in standard error
+def display_line(line, disp_type):
+    # generic function to display a line using various
+    # methods.
+    if disp_type is None:
+        pass
+    elif disp_type == 'print':
+        print(line)
+    elif disp_type == 'info':
+        logging.info(line.rstrip())
+    elif disp_type == 'warn':
+        logging.warning(line.rstrip())
+    else:
+        raise Exception(f'Invalid log_type: {disp_type}.')
 
-    to_display = {
-        'STDOUT': result.stdout.decode(),
-        'STDERR': result.stderr.decode()
-    }
 
-    for name, val in to_display.items():
-        if val != '':
-            logging.info(f'*** {name} ***')
-            logging.info(val)
+def process_output(fd, err_str, disp_type, name):
+    # generic line-processing function to display lines
+    # as they are produced as output in and check for errors.
+    any_line = False
+    for line in fd:
+        # Display opening text if needed
+        if not any_line:
+            any_line = True
+            display_line(f'*** Start {name} ***', disp_type=disp_type)
+        # strip whitespace at end (including newline)
+        line = line.rstrip()
+        # display if desired
+        display_line(line=line, disp_type=disp_type)
+        # check for error
+        if err_str is not None:
+            assert err_str not in line, f'Found error in {name}: {line}'  # noqa
+    # Display closing text if needed
+    if any_line:
+        display_line(f'*** End {name} ***', disp_type=disp_type)
 
 
-def subprocess_run(args, cwd, env=None, display=True):
-    # Runs a subprocess in the user-specified directory with
-    # the user-specified environment.
+def subprocess_run(args, cwd, env=None, disp_type='info', err_str=None,
+                   chk_ret_code=True):
+    # Runs a subprocess while (optionally) displaying output
+    # and processing lines as they come in.
 
     # set defaults
     env = env if env is not None else FaultConfig().get_sim_env()
 
-    # run the command
-    logging.info(f"Running command: {' '.join(args)}")
-    result = subprocess.run(args, cwd=cwd, env=env, capture_output=True)
+    # print out the command in a format that can be copy-pasted
+    # directly into a terminal (i.e., with proper quoting of arguments)
+    cmd_str = ' '.join(shlex.quote(arg) for arg in args)
+    logging.info(f"Running command: {cmd_str}")
 
-    # display results if desired
-    if display:
-        display_subprocess_output(result)
+    with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE, bufsize=1,
+               universal_newlines=True) as p:
+        # process STDOUT, then STDERR
+        # threads could be used here but pytest does not detect exceptions
+        # in child threads, so for now the outputs are processed sequentially
+        process_output(fd=p.stdout, err_str=err_str, disp_type=disp_type,
+                       name='STDOUT')
+        process_output(fd=p.stdout, err_str=err_str, disp_type=disp_type,
+                       name='STDERR')
 
-    return result
+        # get return code and check result if desired
+        retcode = p.wait()
+        if chk_ret_code:
+            assert not retcode, f'Got non-zero return code: {retcode}'
+
+        # return the return code
+        return retcode

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -60,7 +60,8 @@ def process_output(fd, err_str, disp_type, name):
 
 
 def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
-                   chk_ret_code=True, shell=False, plain_logging=True):
+                   chk_ret_code=True, shell=False, plain_logging=True,
+                   use_fault_cfg=True):
     # "Deluxe" version of subprocess.run that can display STDOUT lines as they
     # come in, looks for errors in STDOUT and STDERR (raising an exception if
     # one is found), and can check the return code from the subprocess
@@ -96,9 +97,12 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
     #                all logging.  This is recommended since it makes
     #                it easier to read the many lines of output produced
     #                by typical suprocess calls.
+    # use_fault_cfg: If True (default) and env is None, then use FaultConfig
+    #                to fill in default environment variables.
 
     # set defaults
-    env = env if env is not None else FaultConfig().get_sim_env()
+    if env is None and use_fault_cfg:
+        env = FaultConfig().get_sim_env()
 
     # temporarily use plain formatting for all logging handlers.  this
     # makes the output cleaner and more readable -- otherwise the
@@ -143,8 +147,7 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
         retval = CompletedProcess(args=args, returncode=returncode,
                                   stdout=stdout, stderr=stderr)
 
-    # go back to using the original formatters for each
-    # logging handler
+    # go back to using the original formatters for each logging handler
     if plain_logging:
         for handler, fmt in zip(handlers, orig_fmts):
             handler.setFormatter(fmt)

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -1,6 +1,6 @@
 import logging
 import shlex
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, CompletedProcess
 from fault.user_cfg import FaultConfig
 
 
@@ -42,7 +42,7 @@ def process_output(fd, err_str, disp_type, name):
     if any_line:
         display_line(f'*** End {name} ***', disp_type=disp_type)
     # Return the full output contents for further processing
-    return retval
+    return '\n'.join(retval)
 
 
 def subprocess_run(args, cwd, env=None, disp_type='info', err_str=None,
@@ -69,9 +69,10 @@ def subprocess_run(args, cwd, env=None, disp_type='info', err_str=None,
                                 disp_type=disp_type, name='STDERR')
 
         # get return code and check result if desired
-        retcode = p.wait()
+        returncode = p.wait()
         if chk_ret_code:
-            assert not retcode, f'Got non-zero return code: {retcode}'
+            assert not returncode, f'Got non-zero return code: {returncode}'
 
-        # return the return code, standard output, and standard error
-        return retcode, stdout, stderr
+        # return a completed process object containing the results
+        return CompletedProcess(args=args, returncode=returncode,
+                                stdout=stdout, stderr=stderr)

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -4,9 +4,18 @@ from subprocess import Popen, PIPE, CompletedProcess
 from fault.user_cfg import FaultConfig
 
 
+# Terminal formatting codes
+MAGENTA = '\x1b[35m'
+CYAN = '\x1b[36m'
+BRIGHT = '\x1b[1m'
+RESET_ALL = '\x1b[0m'
+
+
 def display_line(line, disp_type):
     # generic function to display a line using various
     # methods.
+
+    # then display the line using the desired method
     if disp_type is None:
         pass
     elif disp_type == 'print':
@@ -28,7 +37,8 @@ def process_output(fd, err_str, disp_type, name):
         # Display opening text if needed
         if not any_line:
             any_line = True
-            display_line(f'*** Start {name} ***', disp_type=disp_type)
+            display_line(MAGENTA + BRIGHT + f'<{name}>' + RESET_ALL,
+                         disp_type=disp_type)
         # strip whitespace at end (including newline)
         line = line.rstrip()
         # display if desired
@@ -40,7 +50,8 @@ def process_output(fd, err_str, disp_type, name):
         retval.append(line)
     # Display closing text if needed
     if any_line:
-        display_line(f'*** End {name} ***', disp_type=disp_type)
+        display_line(MAGENTA + BRIGHT + f'</{name}>' + RESET_ALL,
+                     disp_type=disp_type)
     # Return the full output contents for further processing
     return '\n'.join(retval)
 
@@ -56,7 +67,8 @@ def subprocess_run(args, cwd, env=None, disp_type='info', err_str=None,
     # print out the command in a format that can be copy-pasted
     # directly into a terminal (i.e., with proper quoting of arguments)
     cmd_str = ' '.join(shlex.quote(arg) for arg in args)
-    logging.info(f"Running command: {cmd_str}")
+    display_line(CYAN + BRIGHT + 'Running command: ' + RESET_ALL + cmd_str,
+                 disp_type=disp_type)
 
     with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE, bufsize=1,
                universal_newlines=True) as p:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -543,15 +543,15 @@ end
             sim_cmd = self.ncsim_cmd(sources=vlog_srcs,
                                      cmd_file=self.write_ncsim_tcl())
             bin_cmd = None
-            err_str = None
+            sim_err_str = None
         elif self.simulator == 'vcs':
             sim_cmd, bin_file = self.vcs_cmd(sources=vlog_srcs)
             bin_cmd = [bin_file]
-            err_str = 'Error'
+            sim_err_str = 'Error'
         elif self.simulator == 'iverilog':
             sim_cmd, bin_file = self.iverilog_cmd(sources=vlog_srcs)
             bin_cmd = ['vvp', '-N', bin_file]
-            err_str = 'ERROR'
+            sim_err_str = 'ERROR'
         else:
             raise NotImplementedError(self.simulator)
 
@@ -559,15 +559,12 @@ end
         sim_cmd += self.flags
 
         # compile the simulation
-        sim_res = subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
-        assert not sim_res.returncode, 'Error running system verilog simulator'
+        subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
 
         # run the simulation binary (if applicable)
         if bin_cmd is not None:
-            bin_res = subprocess_run(bin_cmd, cwd=self.directory,
-                                     env=self.sim_env)
-            assert not bin_res.returncode, f'Running {self.simulator} binary failed'  # noqa
-            assert err_str not in str(bin_res.stdout), f'"{err_str}" found in stdout of {self.simulator} run'  # noqa
+            subprocess_run(bin_cmd, cwd=self.directory, env=self.sim_env,
+                           err_str=sim_err_str)
 
     def write_test_bench(self, actions, power_args):
         # determine the path of the testbench file

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -243,7 +243,17 @@ class SystemVerilogTarget(VerilogTarget):
         name = self.make_name(action.port)
         # For now we assume that verilog can handle big ints
         value = self.process_value(action.port, action.value)
-        return [f"{name} = {value};", f"#{self.clock_step_delay};"]
+        # Build up the poke action, including delay
+        retval = []
+        retval += [f'{name} = {value};']
+        if action.delay is None:
+            retval += [f'#{self.clock_step_delay};']
+        else :
+            retval += [f'#({action.delay}*1s);']
+        return retval
+
+    def make_delay(self, i, action):
+        return [f'#({action.time}*1s);']
 
     def make_print(self, i, action):
         # build up argument list for the $write command

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -103,8 +103,9 @@ class SystemVerilogTarget(VerilogTarget):
                     containing the generated testbench code.
 
         ext_srcs: Shorter alias for "include_verilog_libraries" argument.
-                  It is illegal to specify both "include_verilog_libraries"
-                  and "ext_srcs".
+                  If both "include_verilog_libraries" and ext_srcs are
+                  specified, then the sources from include_verilog_libraries
+                  will be processed first.
 
         use_input_wires: If True, drive DUT inputs through wires that are in
                          turn assigned to a reg.
@@ -113,15 +114,10 @@ class SystemVerilogTarget(VerilogTarget):
         """
         # set default for list of external sources
         if include_verilog_libraries is None:
-            if ext_srcs is None:
-                include_verilog_libraries = []
-            else:
-                include_verilog_libraries = ext_srcs
-        else:
-            if ext_srcs is None:
-                pass
-            else:
-                raise ValueError('Cannot specify both "include_verilog_libraries" and "ext_srcs".')  # noqa
+            include_verilog_libraries = []
+        if ext_srcs is None:
+            ext_srcs = []
+        include_verilog_libraries = include_verilog_libraries + ext_srcs
 
         # set default for there being an external model file
         if ext_model_file is None:
@@ -248,7 +244,7 @@ class SystemVerilogTarget(VerilogTarget):
         retval += [f'{name} = {value};']
         if action.delay is None:
             retval += [f'#{self.clock_step_delay};']
-        else :
+        else:
             retval += [f'#({action.delay}*1s);']
         return retval
 

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -12,6 +12,7 @@ from fault.actions import Loop, While, If
 from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper
 from fault.file import File
+from fault.select_path import SelectPath
 import fault.expression as expression
 import os
 import inspect
@@ -410,6 +411,10 @@ class Tester:
 
         # de-assert reset
         self.poke(self.reset_port, 0 if active_high else 1)
+
+    def internal(self, *args):
+        # return a SelectPath containing the desired path
+        return SelectPath([self.circuit] + list(args))
 
 
 class LoopIndex:

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -2,19 +2,17 @@ import logging
 import magma as m
 import fault.actions as actions
 from fault.magma_simulator_target import MagmaSimulatorTarget
-from fault.logging import warning
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
 from fault.system_verilog_target import SystemVerilogTarget
 from fault.verilogams_target import VerilogAMSTarget
 from fault.spice_target import SpiceTarget
-from fault.actions import Poke, Expect, Step, Print, Loop, While, If
+from fault.actions import Loop, While, If
 from fault.circuit_utils import check_interface_is_subset
-from fault.wrapper import CircuitWrapper, PortWrapper, InstanceWrapper
+from fault.wrapper import CircuitWrapper, PortWrapper
 from fault.file import File
 import fault.expression as expression
-import copy
 import os
 import inspect
 from fault.config import get_test_dir
@@ -97,7 +95,7 @@ class Tester:
             return SpiceTarget(self._circuit, **kwargs)
         raise NotImplementedError(target)
 
-    def poke(self, port, value):
+    def poke(self, port, value, delay=None):
         """
         Set `port` to be `value`
         """
@@ -108,7 +106,7 @@ class Tester:
             if not isinstance(value, (LoopIndex, actions.FileRead,
                                       expression.Expression)):
                 value = make_value(port, value)
-            self.actions.append(actions.Poke(port, value))
+            self.actions.append(actions.Poke(port, value, delay=delay))
 
     def peek(self, port):
         """

--- a/fault/tester_samples.py
+++ b/fault/tester_samples.py
@@ -1,7 +1,8 @@
 import fault
+from abc import ABCMeta, abstractmethod
 
 
-class GenericCellTester(fault.Tester):
+class GenericCellTester(fault.Tester, metaclass=ABCMeta):
     def __init__(self, circuit, *args, n_trials=100, supply0='vss',
                  supply1='vdd', **kwargs):
         # call super constructor
@@ -32,6 +33,7 @@ class GenericCellTester(fault.Tester):
         self.poke_optional(self.supply1, 1)
         self.poke_optional(self.supply0, 0)
 
+    @abstractmethod
     def define_trial(self):
         pass
 
@@ -50,8 +52,9 @@ class SingleOutputTester(GenericCellTester):
         # call super constructor
         super().__init__(circuit, *args, **kwargs)
 
+    @abstractmethod
     def model(self, *args):
-        raise NotImplementedError
+        pass
 
     def define_trial(self):
         # poke random data

--- a/fault/tester_samples.py
+++ b/fault/tester_samples.py
@@ -108,7 +108,7 @@ class SRAMTester(GenericCellTester):
 
     def define_init(self):
         self.poke(self.wl, 0)
-        self.poke(self.lblb, 0)
+        self.poke(self.lbl, 0)
         self.poke(self.lblb, 0)
         super().define_init()
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -443,6 +443,10 @@ for ({loop_expr}) {{
         return [f"fscanf({action.file.name_without_ext}_file, "
                 f"\"{action._format}\", {var_args});"]
 
+    def make_delay(self, i, action):
+        # TODO: figure out how delay should be interpreted for VerilatorTarget
+        raise NotImplementedError
+
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -1,33 +1,20 @@
-import logging
 import fault
-from .array import Array
 from pathlib import Path
-import subprocess
 import magma as m
 import fault.actions as actions
 from fault.actions import Poke, Eval
 from fault.verilog_target import VerilogTarget, verilog_name
 import fault.value_utils as value_utils
-import fault.verilator_utils as verilator_utils
+from fault.verilator_utils import (verilator_make_cmd, verilator_comp_cmd,
+                                   verilator_version)
 from fault.select_path import SelectPath
 from fault.wrapper import PortWrapper, InstanceWrapper
 import math
-from hwtypes import BitVector, SIntVector, AbstractBitVectorMeta
-import subprocess
-from fault.random import random_bv, constrained_random_bv
+from hwtypes import BitVector, AbstractBitVectorMeta
+from fault.random import constrained_random_bv
+from fault.subprocess_run import subprocess_run
 import fault.utils as utils
-import platform
-import os
 import fault.expression as expression
-
-
-def log(logger, message):
-    """
-    Helper function to ignore empty log messages
-    """
-    if message:
-        for line in message.splitlines():
-            logger(message)
 
 
 # max_bits = 64 if platform.architecture()[0] == "64bit" else 32
@@ -92,9 +79,9 @@ int main(int argc, char **argv) {{
 
 class VerilatorTarget(VerilogTarget):
     def __init__(self, circuit, directory="build/",
-                 flags=[], skip_compile=False, include_verilog_libraries=[],
-                 include_directories=[], magma_output="coreir-verilog",
-                 circuit_name=None, magma_opts={}, skip_verilator=False):
+                 flags=None, skip_compile=False, include_verilog_libraries=None,
+                 include_directories=None, magma_output="coreir-verilog",
+                 circuit_name=None, magma_opts=None, skip_verilator=False):
         """
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -105,31 +92,31 @@ class VerilatorTarget(VerilogTarget):
             -I flag. From the the verilator docs:
                 -I<dir>                    Directory to search for includes
         """
+        # Set defaults
+        if include_verilog_libraries is None:
+            include_verilog_libraries = []
+        if magma_opts is None:
+            magma_opts = {}
+
+        # Call super constructor
         super().__init__(circuit, circuit_name, directory, skip_compile,
                          include_verilog_libraries, magma_output, magma_opts)
-        self.flags = flags
-        self.include_directories = include_directories
 
         # Compile the design using `verilator`, if not skip
         if not skip_verilator:
             driver_file = self.directory / Path(
                 f"{self.circuit_name}_driver.cpp")
-            verilator_cmd = verilator_utils.verilator_cmd(
-                self.circuit_name, self.verilog_file.name,
-                self.include_verilog_libraries, self.include_directories,
-                driver_file.name, self.flags)
-            result = self.run_from_directory(verilator_cmd)
-            log(logging.info, result.stdout.decode())
-            log(logging.info, result.stderr.decode())
-            if result.returncode:
-                raise Exception(f"Running verilator cmd {verilator_cmd} failed:"
-                                f" {result.stderr.decode()}")
+            comp_cmd = verilator_comp_cmd(
+                top=self.circuit_name,
+                verilog_filename=self.verilog_file.name,
+                include_verilog_libraries=self.include_verilog_libraries,
+                include_directories=include_directories,
+                driver_filename=driver_file.name,
+                verilator_flags=flags
+            )
+            self.run_from_directory(comp_cmd)
         self.debug_includes = set()
-        verilator_version = subprocess.check_output("verilator --version",
-                                                    shell=True)
-        # Need to check version since they changed how internal signal access
-        # works
-        self.verilator_version = float(verilator_version.split()[1])
+        self.verilator_version = verilator_version()
 
     def get_verilator_prefix(self):
         if self.verilator_version > 3.874:
@@ -490,33 +477,30 @@ for ({loop_expr}) {{
         return src
 
     def run_from_directory(self, cmd):
-        logging.debug(cmd)
-        return subprocess.run(cmd, cwd=self.directory, shell=True,
-                              capture_output=True)
+        return subprocess_run(cmd, cwd=self.directory)
 
-    def run(self, actions, verilator_includes=[], num_tests=0,
+    def run(self, actions, verilator_includes=None, num_tests=0,
             _circuit=None):
-        driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
+        # Set defaults
+        if verilator_includes is None:
+            verilator_includes = []
+
         # Write the verilator driver to file.
         src = self.generate_code(actions, verilator_includes, num_tests,
                                  _circuit)
+        driver_file = self.directory / Path(f"{self.circuit_name}_driver.cpp")
         with open(driver_file, "w") as f:
             f.write(src)
-        # Run a series of commands: run the Makefile output by verilator, and
-        # finally run the executable created by verilator.
-        verilator_make_cmd = verilator_utils.verilator_make_cmd(
-            self.circuit_name)
-        result = self.run_from_directory(verilator_make_cmd)
-        log(logging.debug, result.stdout.decode())
-        assert not result.returncode, "Running verilator make_cmd_failed" \
-            + result.stderr.decode()
-        result = self.run_from_directory(
-            f"/bin/bash -c \"set -e -o pipefail; ./obj_dir/V{self.circuit_name}"
-            f" | tee ./obj_dir/{self.circuit_name}.log\"")
-        log(logging.info, result.stdout.decode())
-        log(logging.info, result.stderr.decode())
-        assert not result.returncode, "Running verilator binary failed: " + \
-            result.stderr.decode()
+
+        # Run the Makefile produced by verilator
+        self.run_from_directory(verilator_make_cmd(self.circuit_name))
+
+        # Run the executable created by verilator and write the standard
+        # output to a logfile for later review or processing
+        result = self.run_from_directory([f'./obj_dir/V{self.circuit_name}'])
+        log = Path(self.directory) / 'obj_dir' / f'{self.circuit_name}.log'
+        with open(log, 'w') as f:
+            f.write(result.stdout)
 
     def add_assumptions(self, circuit, actions, i):
         main_body = ""

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -1,27 +1,70 @@
-import magma
-import fault.actions as actions
+import shutil
+import shlex
+import subprocess
 
 
-def verilator_cmd(top, verilog_filename, include_verilog_libraries,
-                  include_directories, driver_filename, verilator_flags):
-    DEFAULT_FLAGS = [
-        "-Wall",
-        "-Wno-INCABSPATH",
-        "-Wno-DECLFILENAME"
-    ]
-    flags = DEFAULT_FLAGS
-    flags.extend(verilator_flags)
-    flag_str = " ".join(flags)
-    include_str = ' '.join(f'-v {file_}' for file_ in include_verilog_libraries)
-    if include_directories:
-        include_str += " " + " ".join(f"-I{dir_}" for dir_ in
-                                      include_directories)
-    return (f"verilator {flag_str} "
-            f"--cc {verilog_filename} "
-            f"{include_str} "
-            f"--exe {driver_filename} "
-            f"--top-module {top}")
+def bash_wrap(args):
+    retval = []
+    retval += ['bash']
+    retval += ['-c']
+    retval += [' '.join(shlex.quote(arg) for arg in args)]
+    return retval
+
+
+def verilator_version():
+    # assemble the command
+    cmd = [shutil.which('verilator'), '--version']
+    cmd = bash_wrap(cmd)
+
+    # run the command and parse out the version number
+    version = subprocess.check_output(cmd)
+    version = float(version.split()[1])
+
+    # return version number
+    return version
+
+
+def verilator_comp_cmd(top=None, verilog_filename=None,
+                       include_verilog_libraries=None,
+                       include_directories=None,
+                       driver_filename=None, verilator_flags=None):
+    # set defaults
+    if include_verilog_libraries is None:
+        include_verilog_libraries = []
+    if include_directories is None:
+        include_directories = []
+    if verilator_flags is None:
+        verilator_flags = []
+
+    # build up the command
+    retval = []
+    retval += [shutil.which('verilator')]
+    retval += ['-Wall']
+    retval += ['-Wno-INCABSPATH']
+    retval += ['-Wno-DECLFILENAME']
+    retval += verilator_flags
+    if verilog_filename is not None:
+        retval += ['--cc', f'{verilog_filename}']
+    # -v arguments
+    for file_ in include_verilog_libraries:
+        retval += ['-v', f'{file_}']
+    # -I arguments
+    for dir_ in include_directories:
+        retval += [f'-I{dir_}']
+    if driver_filename is not None:
+        retval += ['--exe', f'{driver_filename}']
+    if top is not None:
+        retval += ['--top-module', f'{top}']
+
+    # return the command
+    return bash_wrap(retval)
 
 
 def verilator_make_cmd(top):
-    return f"make -C obj_dir -j -f V{top}.mk V{top}"
+    cmd = []
+    cmd += ['make']
+    cmd += ['-C', 'obj_dir']
+    cmd += ['-j']
+    cmd += ['-f', f'V{top}.mk']
+    cmd += [f'V{top}']
+    return cmd

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -1,24 +1,13 @@
-import shutil
-import shlex
-import subprocess
-
-
-def bash_wrap(args):
-    retval = []
-    retval += ['bash']
-    retval += ['-c']
-    retval += [' '.join(shlex.quote(arg) for arg in args)]
-    return retval
+from .subprocess_run import subprocess_run
 
 
 def verilator_version():
     # assemble the command
-    cmd = [shutil.which('verilator'), '--version']
-    cmd = bash_wrap(cmd)
+    cmd = ['verilator', '--version']
 
     # run the command and parse out the version number
-    version = subprocess.check_output(cmd)
-    version = float(version.split()[1])
+    result = subprocess_run(cmd, shell=True)
+    version = float(result.stdout.split()[1])
 
     # return version number
     return version
@@ -38,7 +27,7 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
 
     # build up the command
     retval = []
-    retval += [shutil.which('verilator')]
+    retval += ['verilator']
     retval += ['-Wall']
     retval += ['-Wno-INCABSPATH']
     retval += ['-Wno-DECLFILENAME']
@@ -57,7 +46,7 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
         retval += ['--top-module', f'{top}']
 
     # return the command
-    return bash_wrap(retval)
+    return retval
 
 
 def verilator_make_cmd(top):

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -116,6 +116,8 @@ class VerilogTarget(Target):
             return self.make_var(i, action)
         if isinstance(action, actions.FileScanFormat):
             return self.make_file_scan_format(i, action)
+        if isinstance(action, actions.Delay):
+            return self.make_delay(i, action)
         raise NotImplementedError(action)
 
     @abstractmethod
@@ -164,4 +166,16 @@ class VerilogTarget(Target):
 
     @abstractmethod
     def make_var(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_delay(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_while(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_if(self, i, action):
         pass

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -14,24 +14,25 @@ class VerilogTarget(Target):
     Provides reuseable target logic for compiling circuits into verilog files.
     """
     def __init__(self, circuit, circuit_name=None, directory="build/",
-                 skip_compile=False, include_verilog_libraries=[],
-                 magma_output="verilog", magma_opts={}):
+                 skip_compile=False, include_verilog_libraries=None,
+                 magma_output="verilog", magma_opts=None):
         super().__init__(circuit)
 
         if circuit_name is None:
-            self.circuit_name = self.circuit.name
-        else:
-            self.circuit_name = circuit_name
+            circuit_name = self.circuit.name
+        self.circuit_name = circuit_name
 
         self.directory = Path(directory)
         os.makedirs(directory, exist_ok=True)
 
         self.skip_compile = skip_compile
 
+        if include_verilog_libraries is None:
+            include_verilog_libraries = []
         self.include_verilog_libraries = include_verilog_libraries
 
         self.magma_output = magma_output
-        self.magma_opts = magma_opts
+        self.magma_opts = magma_opts if magma_opts is not None else {}
 
         if hasattr(circuit, "verilog_file_name") and \
                 os.path.splitext(circuit.verilog_file_name)[-1] == ".sv":

--- a/fault/verilogams.py
+++ b/fault/verilogams.py
@@ -92,6 +92,7 @@ def VAMSWrap(circ, wrap_name=None, inst_name=None, tab='    ', nl='\n'):
     # Poke the VerilogAMS code into the magma circuit
     # (a bit hacky, probably should use a subclass instead)
     retval.vams_code = gen.text
+    retval.vams_inst_name = inst_name
 
     # Return the magma circuit
     return retval

--- a/fault/verilogams_target.py
+++ b/fault/verilogams_target.py
@@ -6,8 +6,8 @@ from .system_verilog_target import SystemVerilogTarget
 class VerilogAMSTarget(SystemVerilogTarget):
     def __init__(self, circuit, simulator='ncsim', directory='build/',
                  model_paths=None, stop_time=1, vsup=1.0, rout=1, flags=None,
-                 include_verilog_libraries=None, use_spice=None,
-                 use_input_wires=True, ext_model_file=True, **kwargs):
+                 ext_srcs=None, use_spice=None, use_input_wires=True,
+                 ext_model_file=True, bus_delim='<>', **kwargs):
         """
         simulator: Name of the simulator to be used for simulation.
         model_paths: paths to SPICE/Spectre files used in the simulation
@@ -19,8 +19,8 @@ class VerilogAMSTarget(SystemVerilogTarget):
         flags: Additional flags to be passed to the simulator.  Certain
         additional flags will be tacked onto this before passing to the
         SystemVerilogTarget.
-        include_verilog_libraries: Additional source files to be compiled
-        when building this simulation.
+        ext_srcs: Additional source files to be compiled when building this
+        simulation.
         use_spice: List of names of modules that should use a spice model
         rather than a verilog model.  Not always required, but sometimes
         needed when instantiating a spice module directly in SystemVerilog
@@ -30,7 +30,9 @@ class VerilogAMSTarget(SystemVerilogTarget):
         resolution for Verilog-AMS simulation.
         ext_model_file: If True, don't include the assumed model name in the
         list of Verilog sources.  The assumption is that the user has already
-        taken care of this via include_verilog_libraries.
+        taken care of this via ext_srcs.
+        bus_delim: '<>', '[]', or '_' indicating bus styles "a<3>", "b[2]",
+        c_1.
         """
 
         # save settings
@@ -38,6 +40,7 @@ class VerilogAMSTarget(SystemVerilogTarget):
         self.vsup = vsup
         self.rout = rout
         self.use_spice = use_spice if use_spice is not None else []
+        self.bus_delim = bus_delim
 
         # save file names that will be written
         self.amscf = 'amscf.scs'
@@ -52,18 +55,16 @@ class VerilogAMSTarget(SystemVerilogTarget):
         for path in model_paths:
             flags += ['-modelpath', f'{path}']
 
-        # update include_verilog_libraries
-        include_verilog_libraries = (include_verilog_libraries
-                                     if include_verilog_libraries is not None
-                                     else [])
-        include_verilog_libraries += [self.amscf]
+        # update ext_srcs
+        ext_srcs = ext_srcs if ext_srcs is not None else []
+        ext_srcs += [self.amscf]
         if hasattr(circuit, 'vams_code'):
-            include_verilog_libraries += [self.vamsf]
+            ext_srcs += [self.vamsf]
 
         # call the superconstructor
         super().__init__(circuit=circuit, simulator=simulator, flags=flags,
-                         include_verilog_libraries=include_verilog_libraries,
-                         directory=directory, use_input_wires=use_input_wires,
+                         ext_srcs=ext_srcs, directory=directory,
+                         use_input_wires=use_input_wires,
                          ext_model_file=ext_model_file, **kwargs)
 
     def run(self, *args, **kwargs):
@@ -80,17 +81,17 @@ class VerilogAMSTarget(SystemVerilogTarget):
     def gen_amscf(self, tab='    ', nl='\n'):
         # specify which modules instantiated in SystemVerilog code
         # should use SPICE models
-        config_lines = ''
+        amsd_lines = ''
         for model in self.use_spice:
-            config_lines += f'{tab}config cell={model} use=spice{nl}'
-            config_lines += f'{tab}portmap subckt={model} autobus=yes busdelim="<>"{nl}'  # noqa
+            amsd_lines += f'{tab}config cell={model} use=spice{nl}'
+            amsd_lines += f'{tab}portmap subckt={model} autobus=yes busdelim="{self.bus_delim}"{nl}'  # noqa
 
         # return text content of the AMS control file
         return f'''
 tranSweep tran stop={self.stop_time}s
 amsd {{
     ie vsup={self.vsup} rout={self.rout}
-{config_lines}
+{amsd_lines}
 }}'''
 
     def write_amscf(self):

--- a/tests/spice/my_init_cond.sp
+++ b/tests/spice/my_init_cond.sp
@@ -1,0 +1,27 @@
+* Initial conditions
+
+.subckt my_init_cond_3 vc
+* storage nodes
+Ca vc_x 0 1p
+* wiring
+Rb vc_x vc 1
+.ends
+
+.subckt my_init_cond_2 vb vc
+* storage nodes
+Cc vb_x 0 1p
+Xd vc_x my_init_cond_3
+* wiring
+Re vb_x vb 1
+Rf vc_x vc 1
+.ends
+
+.subckt my_init_cond va vb vc
+* storage nodes
+Cg va_x 0 1p
+Xh vb_x vc_x my_init_cond_2
+* wiring
+Ri va_x va 1
+Rj vb_x vb 1
+Rk vc_x vc 1
+.ends

--- a/tests/spice/my_init_cond.sp
+++ b/tests/spice/my_init_cond.sp
@@ -1,27 +1,18 @@
 * Initial conditions
 
-.subckt my_init_cond_3 vc
+.subckt my_init_cond_2 vc
 * storage nodes
 Ca vc_x 0 1p
 * wiring
 Rb vc_x vc 1
 .ends
 
-.subckt my_init_cond_2 vb vc
-* storage nodes
-Cc vb_x 0 1p
-Xd vc_x my_init_cond_3
-* wiring
-Re vb_x vb 1
-Rf vc_x vc 1
-.ends
-
 .subckt my_init_cond va vb vc
 * storage nodes
-Cg va_x 0 1p
-Xh vb_x vc_x my_init_cond_2
+Cc va 0 1p
+Cd vb_x 0 1p
+Xe vc_x my_init_cond_2
 * wiring
-Ri va_x va 1
-Rj vb_x vb 1
-Rk vc_x vc 1
+Rf vb_x vb 1
+Rg vc_x vc 1
 .ends

--- a/tests/test_init_cond.py
+++ b/tests/test_init_cond.py
@@ -5,7 +5,7 @@ from .common import pytest_sim_params
 
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc, 'spice')
+    pytest_sim_params(metafunc, 'verilog-ams', 'spice')
 
 
 def test_init_cond(target, simulator, va=1.234, vb=2.345, vc=3.456,
@@ -26,16 +26,16 @@ def test_init_cond(target, simulator, va=1.234, vb=2.345, vc=3.456,
 
     # define the test
     tester = fault.Tester(dut)
-    tester.expect(dut.vb, vb, abs_tol=abs_tol)
-    tester.delay(1e-12)
+    tester.delay(10e-9)
     tester.expect(dut.va, va, abs_tol=abs_tol)
+    tester.expect(dut.vb, vb, abs_tol=abs_tol)
     tester.expect(dut.vc, vc, abs_tol=abs_tol)
 
     # set options
     ic = {
-        tester.internal('va_x'): va,
-        dut.vb: vb,
-        tester.internal('Xh', 'Xd', 'vc_x'): vc
+        dut.va: va,
+        tester.internal('vb_x'): vb,
+        tester.internal('Xe', 'vc_x'): vc
     }
     kwargs = dict(
         target=target,

--- a/tests/test_init_cond.py
+++ b/tests/test_init_cond.py
@@ -1,0 +1,51 @@
+import magma as m
+import fault
+from pathlib import Path
+from .common import pytest_sim_params
+
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc, 'spice')
+
+
+def test_init_cond(target, simulator, va=1.234, vb=2.345, vc=3.456,
+                   abs_tol=1e-3):
+    # declare circuit
+    mycirc = m.DeclareCircuit(
+        'my_init_cond',
+        'va', fault.RealOut,
+        'vb', fault.RealOut,
+        'vc', fault.RealOut
+    )
+
+    # wrap if needed
+    if target == 'verilog-ams':
+        dut = fault.VAMSWrap(mycirc)
+    else:
+        dut = mycirc
+
+    # define the test
+    tester = fault.Tester(dut)
+    tester.expect(dut.vb, vb, abs_tol=abs_tol)
+    tester.delay(1e-12)
+    tester.expect(dut.va, va, abs_tol=abs_tol)
+    tester.expect(dut.vc, vc, abs_tol=abs_tol)
+
+    # set options
+    ic = {
+        tester.internal('va_x'): va,
+        dut.vb: vb,
+        tester.internal('Xh', 'Xd', 'vc_x'): vc
+    }
+    kwargs = dict(
+        target=target,
+        simulator=simulator,
+        model_paths=[Path('tests/spice/my_init_cond.sp').resolve()],
+        ic=ic,
+        tmp_dir=True
+    )
+    if target == 'verilog-ams':
+        kwargs['use_spice'] = ['my_init_cond']
+
+    # run the simulation
+    tester.compile_and_run(**kwargs)

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -113,10 +113,9 @@ def test_target_clock(caplog, target, simulator):
     messages = [record.message for record in caplog.records]
 
     if target == fault.verilator_target.VerilatorTarget:
-        lines = messages[-1].splitlines()
-        assert lines[-3] == "0"
-        assert lines[-2] == "0"
-        assert lines[-1] == "1"
+        assert messages[-4] == "0"
+        assert messages[-3] == "0"
+        assert messages[-2] == "1"
     else:
         if simulator == "ncsim":
             assert messages[-7] == "0"
@@ -146,8 +145,7 @@ def test_print_nested_arrays(caplog, target, simulator):
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
     messages = [record.message for record in caplog.records]
     if target == fault.verilator_target.VerilatorTarget:
-        lines = messages[-1].splitlines()
-        actual = "\n".join(lines[-9:])
+        actual = "\n".join(messages[-10:-1])
     else:
         if simulator == "ncsim":
             actual = "\n".join(messages[-13:-4])
@@ -185,8 +183,7 @@ def test_print_double_nested_arrays(caplog, target, simulator):
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
     messages = [record.message for record in caplog.records]
     if target == fault.verilator_target.VerilatorTarget:
-        lines = messages[-1].splitlines()
-        actual = "\n".join(lines[-18:])
+        actual = "\n".join(messages[-19:-1])
     else:
         if simulator == "ncsim":
             actual = "\n".join(messages[-22:-4])

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -110,22 +110,23 @@ def test_target_clock(caplog, target, simulator):
         Print("%x\n", circ.O),
     ]
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
-    out = caplog.record_tuples[-1][2]
+    records = caplog.records
 
-    lines = out.splitlines()
     if target == fault.verilator_target.VerilatorTarget:
-        assert lines[-3] == "0", out
-        assert lines[-2] == "0", out
-        assert lines[-1] == "1", out
+        lines = records[-1].message.splitlines()
+        assert lines[-3] == "0"
+        assert lines[-2] == "0"
+        assert lines[-1] == "1"
     else:
+        lines = [record.message for record in records]
         if simulator == "ncsim":
-            assert lines[-6] == "0", out
-            assert lines[-5] == "0", out
-            assert lines[-4] == "1", out
+            assert lines[-7] == "0"
+            assert lines[-6] == "0"
+            assert lines[-5] == "1"
         elif simulator == "vcs":
-            assert lines[4] == "0", out
-            assert lines[5] == "0", out
-            assert lines[6] == "1", out
+            assert lines[-10] == "0"
+            assert lines[-9] == "0"
+            assert lines[-8] == "1"
         else:
             raise NotImplementedError(f"Unsupported simulator: {simulator}")
 

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -110,23 +110,22 @@ def test_target_clock(caplog, target, simulator):
         Print("%x\n", circ.O),
     ]
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
-    records = caplog.records
+    messages = [record.message for record in caplog.records]
 
     if target == fault.verilator_target.VerilatorTarget:
-        lines = records[-1].message.splitlines()
+        lines = messages[-1].splitlines()
         assert lines[-3] == "0"
         assert lines[-2] == "0"
         assert lines[-1] == "1"
     else:
-        lines = [record.message for record in records]
         if simulator == "ncsim":
-            assert lines[-7] == "0"
-            assert lines[-6] == "0"
-            assert lines[-5] == "1"
+            assert messages[-7] == "0"
+            assert messages[-6] == "0"
+            assert messages[-5] == "1"
         elif simulator == "vcs":
-            assert lines[-10] == "0"
-            assert lines[-9] == "0"
-            assert lines[-8] == "1"
+            assert messages[-10] == "0"
+            assert messages[-9] == "0"
+            assert messages[-8] == "1"
         else:
             raise NotImplementedError(f"Unsupported simulator: {simulator}")
 
@@ -145,14 +144,15 @@ def test_print_nested_arrays(caplog, target, simulator):
     ] + [Print("%x\n", i) for i in circ.O]
 
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
-    out = caplog.record_tuples[-1][2]
+    messages = [record.message for record in caplog.records]
     if target == fault.verilator_target.VerilatorTarget:
-        actual = "\n".join(out.splitlines()[-9:])
+        lines = messages[-1].splitlines()
+        actual = "\n".join(lines[-9:])
     else:
         if simulator == "ncsim":
-            actual = "\n".join(out.splitlines()[-9 - 3: -3])
+            actual = "\n".join(messages[-13:-4])
         elif simulator == "vcs":
-            actual = "\n".join(out.splitlines()[4:13])
+            actual = "\n".join(messages[-16:-7])
         else:
             raise NotImplementedError(f"Unsupported simulator: {simulator}")
     assert actual == """\
@@ -164,7 +164,7 @@ def test_print_nested_arrays(caplog, target, simulator):
 2
 4
 3
-2""", out
+2"""
 
 
 def test_print_double_nested_arrays(caplog, target, simulator):
@@ -183,14 +183,15 @@ def test_print_double_nested_arrays(caplog, target, simulator):
         Eval(),
     ] + [Print("%x\n", j) for i in circ.O for j in i]
     run(circ, actions, target, simulator, flags=["-Wno-lint"])
-    out = caplog.record_tuples[-1][2]
+    messages = [record.message for record in caplog.records]
     if target == fault.verilator_target.VerilatorTarget:
-        actual = "\n".join(out.splitlines()[-18:])
+        lines = messages[-1].splitlines()
+        actual = "\n".join(lines[-18:])
     else:
         if simulator == "ncsim":
-            actual = "\n".join(out.splitlines()[-18 - 3: -3])
+            actual = "\n".join(messages[-22:-4])
         elif simulator == "vcs":
-            actual = "\n".join(out.splitlines()[4:22])
+            actual = "\n".join(messages[-25:-7])
         else:
             raise NotImplementedError(f"Unsupported simulator: {simulator}")
     assert actual == """\


### PR DESCRIPTION
## Introduction

The biggest change from this PR is more unified handling of subprocess calls for SystemVerilog, Verilator, VerilogAMS, and spice targets, through a "deluxe" version of subprocess.run that supports real-time output.  Other updates include exposing some more spice-level simulation capabilities and adding more examples.  Details included below.

## fault.subprocess_run.subprocess_run
1. Added capability to print out STDOUT lines as they come in.  Lines can be printed using logging or regular print(), depending on the optional **disp_type** argument.  This is useful for long simulations in which realtime output is helpful.  (STDERR is printed out in its entirety after the process run completes.)
2. To make the output easy to read, prepended logging info is temporarily disabled while running subprocess_run (otherwise every line would be prepended with "INFO <line info>".  In addition terminal coloring is now used to indicate the start of a new subprocess run and STDOUT vs. STDERR output sections.  The user can disable all output by setting **disp_type** to **None** or via the **logging** level.
3. Error checking is embedded in **subprocess_run** through the optional **err_str** argument. 
 When this argument is provided, each line of STDOUT and STDERR will be search to see if it contains the provided error string, raising an AssertionError if present.  In the future, it would be good to explore allowing regex, but for the existing tests a single **err_str** seems to be sufficient.
4. When **check_ret_code** is **True** (default), **subprocess_run** will raise an **AssertionError** if the subprocess exits with a non-zero code.
5. Updated VerilatorTarget to make use of new subprocess_run functions, making the handling of subprocess runs more standardized.

## SpiceTarget
1. Add selective probing to SpiceTarget: this cuts down the amount to data saved during spice simulation to just the minimum required needed to implement Print and Expect
2. Add capability to set initial conditions for spice and verilog-ams targets (tested by tests/test_init_cond.py).  The main difficulty is is specifying the path to nodes that should be initialized in a target-agnostic manner.  For this I have added Tester.internal, which is sort of like an os.path.join for producing SelectPaths.  In the future I hope to better integrate this with things like WrappedVerilogPort.
3. Fix convergence issues in switch model used for target=spice, simulator=ngspice

## Other
1. Add minimal example for spice simulation: examples/myinv.py
2. Add example for determine SRAM noise margin: examples/sram_snm.py
3. Add optional defaults to Poke and Expect at the tester level: Expects can now be made "strict" by default and Poke default delays can be set to any value (most importantly, "0") through optional arguments to the Tester constructor.