### PR TITLE
Print Errors

### DIFF
--- a/fault/spice_target.py
+++ b/fault/spice_target.py
@@ -35,7 +35,8 @@ class SpiceTarget(Target):
                  vsup=1.0, rout=1, model_paths=None, sim_env=None,
                  t_step=None, clock_step_delay=5, t_tr=0.2e-9, vil_rel=0.4,
                  vih_rel=0.6, rz=1e9, conn_order='alpha', bus_delim='<>',
-                 bus_order='descend', flags=None, ic=None):
+                 bus_order='descend', flags=None, ic=None,
+                 disp_type='on_error'):
         """
         circuit: a magma circuit
 
@@ -82,6 +83,10 @@ class SpiceTarget(Target):
 
         flags: List of additional arguments that should be passed to the
                simulator.
+
+        disp_type: 'on_error', 'realtime'.  If 'on_error', only print if there
+                   is an error.  If 'realtime', print out STDOUT as lines come
+                   in, then print STDERR after the process completes.
         """
         # call the super constructor
         super().__init__(circuit)
@@ -111,6 +116,7 @@ class SpiceTarget(Target):
         self.bus_order = bus_order
         self.flags = flags if flags is not None else []
         self.ic = ic if ic is not None else {}
+        self.disp_type = disp_type
 
     def run(self, actions):
         # compile the actions
@@ -131,7 +137,8 @@ class SpiceTarget(Target):
 
         # run the simulation commands
         for sim_cmd in sim_cmds:
-            subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
+            subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env,
+                           disp_type=self.disp_type)
 
         # process the results
         if self.simulator in {'ngspice', 'spectre'}:

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -139,7 +139,7 @@ def subprocess_run(args, cwd=None, env=None, disp_type='on_error', err_str=None,
         print(RED + BRIGHT + f'Found {len(err_msg)} error(s):' + RESET_ALL)
         for k, e in enumerate(err_msg):
             print(RED + BRIGHT + f'{k+1}) {e}' + RESET_ALL)
-        raise Exception()
+        raise AssertionError
 
     # if there were no errors, then return directly
     return CompletedProcess(args=args, returncode=returncode,

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -138,7 +138,8 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
         # get return code and check result if desired
         returncode = p.wait()
         if chk_ret_code:
-            assert not returncode, f'Got non-zero return code: {returncode}.'
+            assert not returncode, f'Got non-zero return code: {returncode}.' \
+                                   f'\n STDERR: {stderr} \n STDOUT: {stdout}'
 
         # look for errors in STDOUT or STDERR
         if err_str is not None:

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -1,4 +1,3 @@
-import logging
 import shlex
 from subprocess import Popen, PIPE, CompletedProcess
 from fault.user_cfg import FaultConfig
@@ -7,58 +6,58 @@ from fault.user_cfg import FaultConfig
 # Terminal formatting codes
 MAGENTA = '\x1b[35m'
 CYAN = '\x1b[36m'
+RED = '\x1b[31m'
 BRIGHT = '\x1b[1m'
 RESET_ALL = '\x1b[0m'
 
 
-def display_line(line, disp_type):
-    # generic function to display a line using various
-    # methods.
+class PrintDisplay:
+    def __init__(self, mode):
+        self.mode = mode
+        self.lines = []
 
-    # then display the line using the desired method
-    if disp_type is None:
-        pass
-    elif disp_type == 'print':
-        print(line)
-    elif disp_type == 'info':
-        logging.info(line.rstrip())
-    elif disp_type == 'warn':
-        logging.warning(line.rstrip())
-    else:
-        raise Exception(f'Invalid log_type: {disp_type}.')
+    def print(self, line):
+        line = line.rstrip()
+        if self.mode == 'realtime':
+            print(line)
+        elif self.mode == 'on_error':
+            self.lines.append(line)
+        else:
+            raise Exception('Invalid mode.')
+
+    def error_printing(self):
+        if self.mode == 'on_error':
+            for line in self.lines:
+                print(line)
+
+    def process_output(self, fd, name):
+        # generic line-processing function to display lines
+        # as they are produced as output in and check for errors.
+
+        retval = ''
+        any_line = False
+        for line in fd:
+            # Add line to value to be returned
+            retval += line
+
+            # Display opening text if needed
+            if not any_line:
+                any_line = True
+                self.print(MAGENTA + BRIGHT + f'<{name}>' + RESET_ALL)
+
+            # display if desired
+            self.print(line)
+
+        # Display closing text if needed
+        if any_line:
+            self.print(MAGENTA + BRIGHT + f'</{name}>' + RESET_ALL)
+
+        # Return the full output contents for further processing
+        return retval
 
 
-def process_output(fd, disp_type, name):
-    # generic line-processing function to display lines
-    # as they are produced as output in and check for errors.
-
-    retval = ''
-    any_line = False
-    for line in fd:
-        # Add line to value to be returned
-        retval += line
-
-        # Display opening text if needed
-        if not any_line:
-            any_line = True
-            display_line(MAGENTA + BRIGHT + f'<{name}>' + RESET_ALL,
-                         disp_type=disp_type)
-
-        # display if desired
-        display_line(line=line.rstrip(), disp_type=disp_type)
-
-    # Display closing text if needed
-    if any_line:
-        display_line(MAGENTA + BRIGHT + f'</{name}>' + RESET_ALL,
-                     disp_type=disp_type)
-
-    # Return the full output contents for further processing
-    return retval
-
-
-def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
-                   chk_ret_code=True, shell=False, plain_logging=True,
-                   use_fault_cfg=True):
+def subprocess_run(args, cwd=None, env=None, disp_type='on_error', err_str=None,
+                   chk_ret_code=True, shell=False, use_fault_cfg=True):
     # "Deluxe" version of subprocess.run that can display STDOUT lines as they
     # come in, looks for errors in STDOUT and STDERR (raising an exception if
     # one is found), and can check the return code from the subprocess
@@ -78,10 +77,9 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
     # env: Dictionary representing the environment variables to be set
     #      while running the subprocess.  In None, defaults are determined
     #      based on one of the optional fault user config files.
-    # disp_type: None, 'print', 'info', or 'warn'.  If None, don't display
-    #            anything while running the subprocess.  If 'print', use
-    #            the Python 'print' command to display output.  If 'info',
-    #            using logging.info, and if 'warn', use logging.warning.
+    # disp_type: 'on_error', 'realtime'.  If 'on_error', only print if there
+    #            is an error.  If 'realtime', print out STDOUT as lines come
+    #            in, then print STDERR after the process completes.
     # err_str: If not None, look for err_str in each line of STDOUT and
     #          STDERR, raising an AssertionError if it is found.
     # chk_ret_code: If True, check the return code after the subprocess runs,
@@ -90,10 +88,6 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
     #        a string, then Popen with shell=True.  This is sometimes needed
     #        when running programs if they are actually scripts (e.g.,
     #        Verilator)
-    # plain_logging: If True (default), use plain output formatting for
-    #                all logging.  This is recommended since it makes
-    #                it easier to read the many lines of output produced
-    #                by typical suprocess calls.
     # use_fault_cfg: If True (default) and env is None, then use FaultConfig
     #                to fill in default environment variables.
 
@@ -101,62 +95,52 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
     if env is None and use_fault_cfg:
         env = FaultConfig().get_sim_env()
 
-    # temporarily use plain formatting for all logging handlers.  this
-    # makes the output cleaner and more readable -- otherwise the
-    # output lines would all be prepended with the debug level,
-    # line number, etc.
-    if plain_logging:
-        orig_fmts = []
-        handlers = logging.getLogger().handlers
-        plain_fmt = logging.Formatter()
-        for handler in handlers:
-            orig_fmts.append(handler.formatter)
-            handler.setFormatter(plain_fmt)
+    # set up printing
+    display = PrintDisplay(mode=disp_type)
 
     # print out the command in a format that can be copy-pasted
     # directly into a terminal (i.e., with proper quoting of arguments)
     cmd_str = ' '.join(shlex.quote(arg) for arg in args)
-    display_line(CYAN + BRIGHT + 'Running command: ' + RESET_ALL + cmd_str,
-                 disp_type=disp_type)
+    display.print(CYAN + BRIGHT + 'Running command: ' + RESET_ALL + cmd_str)
 
     # combine arguments into a string if needed for shell=True
     if shell:
         args = cmd_str
 
     # run the subprocess
+    err_msg = []
     with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE, bufsize=1,
                universal_newlines=True, shell=shell) as p:
-
-        # get return code and check result if desired
-        returncode = p.wait()
-
-        if returncode:
-            disp_type = 'print'
 
         # print out STDOUT, then STDERR
         # threads could be used here but pytest does not detect exceptions
         # in child threads, so for now the outputs are printed sequentially
-        stdout = process_output(fd=p.stdout, disp_type=disp_type,
-                                name='STDOUT')
-        stderr = process_output(fd=p.stderr, disp_type=disp_type,
-                                name='STDERR')
+        stdout = display.process_output(fd=p.stdout, name='STDOUT')
+        stderr = display.process_output(fd=p.stderr, name='STDERR')
 
-        if chk_ret_code:
-            assert not returncode, f'Got non-zero return code: {returncode}.'
+        # get return code and check result if desired
+        returncode = p.wait()
+
+        if chk_ret_code and returncode:
+            err_msg += [f'Got return code {returncode}.']
 
         # look for errors in STDOUT or STDERR
         if err_str is not None:
-            assert err_str not in stdout, f'Found "{err_str}" in STDOUT.'  # noqa
-            assert err_str not in stderr, f'Found "{err_str}" in STDERR.'  # noqa
+            if err_str in stdout:
+                err_msg += [f'Found "{err_str}" in STDOUT.']
+            if err_str in stderr:
+                err_msg += [f'Found "{err_str}" in STDERR.']
 
-        # return a completed process object containing the results
-        retval = CompletedProcess(args=args, returncode=returncode,
-                                  stdout=stdout, stderr=stderr)
+    # if any errors were found, print out STDOUT and STDERR if they haven't
+    # already been printed, then print out what the error(s) were and
+    # raise an exception
+    if len(err_msg) != 0:
+        display.error_printing()
+        print(RED + BRIGHT + f'Found {len(err_msg)} error(s):' + RESET_ALL)
+        for k, e in enumerate(err_msg):
+            print(RED + BRIGHT + f'{k+1}) {e}' + RESET_ALL)
+        raise Exception()
 
-    # go back to using the original formatters for each logging handler
-    if plain_logging:
-        for handler, fmt in zip(handlers, orig_fmts):
-            handler.setFormatter(fmt)
-
-    # return the output from the subprocess
-    return retval
+    # if there were no errors, then return directly
+    return CompletedProcess(args=args, returncode=returncode,
+                            stdout=stdout, stderr=stderr)

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -141,7 +141,7 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
         # get return code and check result if desired
         returncode = p.wait()
         if chk_ret_code:
-            assert not returncode, f'Got non-zero return code: {returncode}'
+            assert not returncode, f'Got non-zero return code: {returncode}. \n {stderr}'
 
         # return a completed process object containing the results
         retval = CompletedProcess(args=args, returncode=returncode,

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -56,7 +56,7 @@ def process_output(fd, disp_type, name):
     return retval
 
 
-def subprocess_run(args, cwd=None, env=None, disp_type='print', err_str=None,
+def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
                    chk_ret_code=True, shell=False, plain_logging=True,
                    use_fault_cfg=True):
     # "Deluxe" version of subprocess.run that can display STDOUT lines as they
@@ -127,6 +127,12 @@ def subprocess_run(args, cwd=None, env=None, disp_type='print', err_str=None,
     with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE, bufsize=1,
                universal_newlines=True, shell=shell) as p:
 
+        # get return code and check result if desired
+        returncode = p.wait()
+
+        if returncode:
+            disp_type = 'print'
+
         # print out STDOUT, then STDERR
         # threads could be used here but pytest does not detect exceptions
         # in child threads, so for now the outputs are printed sequentially
@@ -135,8 +141,6 @@ def subprocess_run(args, cwd=None, env=None, disp_type='print', err_str=None,
         stderr = process_output(fd=p.stderr, disp_type=disp_type,
                                 name='STDERR')
 
-        # get return code and check result if desired
-        returncode = p.wait()
         if chk_ret_code:
             assert not returncode, f'Got non-zero return code: {returncode}.'
 

--- a/fault/subprocess_run.py
+++ b/fault/subprocess_run.py
@@ -56,7 +56,7 @@ def process_output(fd, disp_type, name):
     return retval
 
 
-def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
+def subprocess_run(args, cwd=None, env=None, disp_type='print', err_str=None,
                    chk_ret_code=True, shell=False, plain_logging=True,
                    use_fault_cfg=True):
     # "Deluxe" version of subprocess.run that can display STDOUT lines as they
@@ -138,8 +138,7 @@ def subprocess_run(args, cwd=None, env=None, disp_type='info', err_str=None,
         # get return code and check result if desired
         returncode = p.wait()
         if chk_ret_code:
-            assert not returncode, f'Got non-zero return code: {returncode}.' \
-                                   f'\n STDERR: {stderr} \n STDOUT: {stdout}'
+            assert not returncode, f'Got non-zero return code: {returncode}.'
 
         # look for errors in STDOUT or STDERR
         if err_str is not None:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -43,7 +43,7 @@ class SystemVerilogTarget(VerilogTarget):
                  sim_env=None, ext_model_file=None, ext_libs=None,
                  defines=None, flags=None, inc_dirs=None,
                  ext_test_bench=False, top_module=None, ext_srcs=None,
-                 use_input_wires=False, parameters=None):
+                 use_input_wires=False, parameters=None, disp_type='on_error'):
         """
         circuit: a magma circuit
 
@@ -111,6 +111,10 @@ class SystemVerilogTarget(VerilogTarget):
                          turn assigned to a reg.
 
         parameters: Dictionary of parameters to be defined for the DUT.
+
+        disp_type: 'on_error', 'realtime'.  If 'on_error', only print if there
+                   is an error.  If 'realtime', print out STDOUT as lines come
+                   in, then print STDERR after the process completes.
         """
         # set default for list of external sources
         if include_verilog_libraries is None:
@@ -160,6 +164,7 @@ class SystemVerilogTarget(VerilogTarget):
         self.top_module = top_module
         self.use_input_wires = use_input_wires
         self.parameters = parameters if parameters is not None else {}
+        self.disp_type = disp_type
 
     def add_decl(self, *decls):
         self.declarations.extend(decls)
@@ -561,12 +566,13 @@ end
         sim_cmd += self.flags
 
         # compile the simulation
-        subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env)
+        subprocess_run(sim_cmd, cwd=self.directory, env=self.sim_env,
+                       disp_type=self.disp_type)
 
         # run the simulation binary (if applicable)
         if bin_cmd is not None:
             subprocess_run(bin_cmd, cwd=self.directory, env=self.sim_env,
-                           err_str=sim_err_str)
+                           err_str=sim_err_str, disp_type=self.disp_type)
 
     def write_test_bench(self, actions, power_args):
         # determine the path of the testbench file

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -1,12 +1,12 @@
 from .subprocess_run import subprocess_run
 
 
-def verilator_version():
+def verilator_version(disp_type='on_error'):
     # assemble the command
     cmd = ['verilator', '--version']
 
     # run the command and parse out the version number
-    result = subprocess_run(cmd, shell=True)
+    result = subprocess_run(cmd, shell=True, disp_type=disp_type)
     version = float(result.stdout.split()[1])
 
     # return version number

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,6 +23,13 @@ def pytest_sim_params(metafunc, *args):
         metafunc.parametrize("target,simulator", targets)
 
 
+def outlines(capsys):
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    lines = [line.rstrip() for line in lines]
+    return lines
+
+
 def define_simple_circuit(T, circ_name, has_clk=False):
     class _Circuit(m.Circuit):
         __test__ = False   # Disable pytest discovery


### PR DESCRIPTION
It appears that https://github.com/leonardt/fault/pull/150 disabled printing errors. When verilator fails due to an assertion, that pull request ends the program before emitting stderr. This adds back printing stderr.

Did I add back the error printing in the correct place?