### PR TITLE
Improve handling of nested types

### DIFF
--- a/fault/tester.py
+++ b/fault/tester.py
@@ -127,7 +127,7 @@ class Tester:
         if self.is_recursive_type(port):
             recurse(port)
         elif isinstance(port, SelectPath) and \
-                (self.is_recursive_type(port[-1].T)):
+                (self.is_recursive_type(port[-1])):
             recurse(port[-1])
         else:
             if not isinstance(value, (LoopIndex, actions.FileRead,
@@ -164,7 +164,7 @@ class Tester:
         if self.is_recursive_type(port):
             recurse(port)
         elif isinstance(port, SelectPath) and \
-                (self.is_recursive_type(port[-1].T)):
+                (self.is_recursive_type(port[-1])):
             recurse(port[-1])
         else:
             # set defaults

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -122,9 +122,14 @@ class Tester:
         # implement poke
         if isinstance(port, m.TupleType):
             recurse(port)
-        elif isinstance(port, SelectPath) and \
-                isinstance(port[-1], m.TupleType):
+        elif isinstance(port, m.ArrayType) and \
+                not isinstance(port.T, m._BitKind):
             recurse(port)
+        elif isinstance(port, SelectPath) and \
+                (isinstance(port[-1], m.TupleType) or
+                 isinstance(port[-1], m.ArrayType) and
+                 not isinstance(port[-1].T, (m._BitKind, m.BitType))):
+            recurse(port[-1])
         else:
             if not isinstance(value, (LoopIndex, actions.FileRead,
                                       expression.Expression)):
@@ -159,8 +164,13 @@ class Tester:
                     self.expect(p, v, strict, **kwargs)
         if isinstance(port, m.TupleType):
             recurse(port)
+        elif isinstance(port, m.ArrayType) and \
+                not isinstance(port.T, m._BitKind):
+            recurse(port)
         elif isinstance(port, SelectPath) and \
-                isinstance(port[-1], m.TupleType):
+                (isinstance(port[-1], m.TupleType) or \
+                 isinstance(port[-1], m.ArrayType) and \
+                 not isinstance(port[-1].T, m._BitKind)):
             recurse(port[-1])
         else:
             # set defaults

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import magma as m
 import fault.actions as actions
 from fault.actions import Poke, Eval
-from fault.verilog_target import VerilogTarget, verilog_name
+from fault.verilog_target import VerilogTarget
+from fault.verilog_utils import verilator_name
 import fault.value_utils as value_utils
 from fault.verilator_utils import (verilator_make_cmd, verilator_comp_cmd,
                                    verilator_version)
@@ -137,7 +138,7 @@ class VerilatorTarget(VerilogTarget):
             path = value.port.path.replace(".", "->")
             return f"top->{self.get_verilator_prefix()}->{path}"
         else:
-            return f"top->{verilog_name(value.port.name)}"
+            return f"top->{verilator_name(value.port.name)}"
 
     def process_value(self, port, value):
         if isinstance(value, expression.Expression):
@@ -209,7 +210,7 @@ class VerilatorTarget(VerilogTarget):
                         circuit_name += f"_W{circuit.coreir_genargs['width']}"
                 self.debug_includes.add(f"{circuit_name}")
         else:
-            name = verilog_name(action.port.name)
+            name = verilator_name(action.port.name)
 
         # Special case poking internal registers
         is_reg_poke = isinstance(action.port, SelectPath) and \
@@ -268,7 +269,7 @@ class VerilatorTarget(VerilogTarget):
                     circuit_name = type(item.instance).name
                     self.debug_includes.add(f"{circuit_name}")
             else:
-                name = verilog_name(port.name)
+                name = verilator_name(port.name)
             port_names.append(name)
         ports = ", ".join(f"top->{name}" for name in port_names)
         if ports:
@@ -297,7 +298,7 @@ class VerilatorTarget(VerilogTarget):
                 self.debug_includes.add(f"{circuit_name}")
             debug_name = action.port[-1].debug_name
         else:
-            name = verilog_name(action.port.name)
+            name = verilator_name(action.port.name)
             debug_name = action.port.debug_name
         value = action.value
         if isinstance(value, actions.Peek):
@@ -330,7 +331,7 @@ class VerilatorTarget(VerilogTarget):
                 "tracer->dump(main_time);", "#endif"]
 
     def make_step(self, i, action):
-        name = verilog_name(action.clock.name)
+        name = verilator_name(action.clock.name)
         code = []
         code.append("top->eval();")
         for step in range(action.steps):
@@ -371,7 +372,7 @@ if ({name}_file == NULL) {{
         return [f"fclose({action.file.name_without_ext}_file);"]
 
     def make_file_write(self, i, action):
-        value = f"top->{verilog_name(action.value.name)}"
+        value = f"top->{verilator_name(action.value.name)}"
         if action.file.endianness == "big":
             loop_expr = f"int i = {action.file.chunk_size - 1}; i >= 0; i--"
         else:

--- a/fault/verilog_utils.py
+++ b/fault/verilog_utils.py
@@ -9,5 +9,19 @@ def verilog_name(name):
         return f"{array_name}_{name.index}"
     if isinstance(name, m.ref.TupleRef):
         tuple_name = verilog_name(name.tuple.name)
-        return f"{tuple_name}_{name.index}"
+        index = name.index
+        try:
+            int(index)
+            # python/coreir don't allow pure integer names
+            index = f"_{index}"
+        except ValueError:
+            pass
+        return f"{tuple_name}_{index}"
     raise NotImplementedError(name, type(name))
+
+def verilator_name(name):
+    name = verilog_name(name)
+    # pg 21 of verilator 4.018 manual
+    # To avoid conicts with Verilator's internal symbols, any double
+    # underscore are replaced with ___05F (5F is the hex code of an underscore.)
+    return name.replace("__", "___05F")

--- a/fault/verilog_utils.py
+++ b/fault/verilog_utils.py
@@ -19,6 +19,7 @@ def verilog_name(name):
         return f"{tuple_name}_{index}"
     raise NotImplementedError(name, type(name))
 
+
 def verilator_name(name):
     name = verilog_name(name)
     # pg 21 of verilator 4.018 manual

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -139,7 +139,7 @@ def test_setattr_double_nested_arrays_bulk(target, simulator):
     circ = TestDoubleNestedArraysCircuit
     tester = Tester(circ)
     expected = []
-    val = [random.randint(0, (1 << 4) - 1) for _ in range(3) for _ in range(2)]
+    val = [[random.randint(0, (1 << 4) - 1) for _ in range(3)] for _ in range(2)]
     tester.circuit.I = val
     tester.eval()
     tester.circuit.O.expect(val)

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -139,7 +139,8 @@ def test_setattr_double_nested_arrays_bulk(target, simulator):
     circ = TestDoubleNestedArraysCircuit
     tester = Tester(circ)
     expected = []
-    val = [[random.randint(0, (1 << 4) - 1) for _ in range(3)] for _ in range(2)]
+    val = [[random.randint(0, (1 << 4) - 1) for _ in range(3)]
+           for _ in range(2)]
     tester.circuit.I = val
     tester.eval()
     tester.circuit.O.expect(val)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -155,9 +155,11 @@ def test_tester_nested_arrays_bulk(target, simulator):
     tester.poke(circ.I, val)
     tester.eval()
     tester.expect(circ.O, val)
-    expected.append(Poke(circ.I, fault.array.Array(val, 3)))
+    for i in range(3):
+        expected.append(Poke(circ.I[i], val[i]))
     expected.append(Eval())
-    expected.append(Expect(circ.O, fault.array.Array(val, 3)))
+    for i in range(3):
+        expected.append(Expect(circ.O[i], val[i]))
     for i, exp in enumerate(expected):
         check(tester.actions[i], exp)
     with tempfile.TemporaryDirectory(dir=".") as _dir:
@@ -248,10 +250,20 @@ def test_print_arrays(capsys):
     out, err = capsys.readouterr()
     assert "\n".join(out.splitlines()[1:]) == """\
 Actions:
-    0: Poke(DoubleNestedArraysCircuit.I, Array([Array([BitVector[4](0), BitVector[4](1), BitVector[4](2)], 3), Array([BitVector[4](3), BitVector[4](4), BitVector[4](5)], 3)], 2))
-    1: Eval()
-    2: Expect(DoubleNestedArraysCircuit.O, Array([Array([BitVector[4](0), BitVector[4](1), BitVector[4](2)], 3), Array([BitVector[4](3), BitVector[4](4), BitVector[4](5)], 3)], 2))
-    3: Print("%08x", DoubleNestedArraysCircuit.O)
+    0: Poke(DoubleNestedArraysCircuit.I[0][0], 0)
+    1: Poke(DoubleNestedArraysCircuit.I[0][1], 1)
+    2: Poke(DoubleNestedArraysCircuit.I[0][2], 2)
+    3: Poke(DoubleNestedArraysCircuit.I[1][0], 3)
+    4: Poke(DoubleNestedArraysCircuit.I[1][1], 4)
+    5: Poke(DoubleNestedArraysCircuit.I[1][2], 5)
+    6: Eval()
+    7: Expect(DoubleNestedArraysCircuit.O[0][0], 0)
+    8: Expect(DoubleNestedArraysCircuit.O[0][1], 1)
+    9: Expect(DoubleNestedArraysCircuit.O[0][2], 2)
+    10: Expect(DoubleNestedArraysCircuit.O[1][0], 3)
+    11: Expect(DoubleNestedArraysCircuit.O[1][1], 4)
+    12: Expect(DoubleNestedArraysCircuit.O[1][2], 5)
+    13: Print("%08x", DoubleNestedArraysCircuit.O)
 """  # nopep8
 
 

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -80,9 +80,11 @@ def test_target_nested_arrays_bulk(target, simulator):
     circ = TestNestedArraysCircuit
     expected = [random.randint(0, (1 << 4) - 1) for i in range(3)]
     actions = []
-    actions.append(Poke(circ.I, expected))
+    for i in range(3):
+        actions.append(Poke(circ.I[i], expected[i]))
     actions.append(Eval())
-    actions.append(Expect(circ.O, expected))
+    for i in range(3):
+        actions.append(Expect(circ.O[i], expected[i]))
     run(circ, actions, target, simulator)
 
 


### PR DESCRIPTION
Fixes https://github.com/leonardt/fault/issues/160 by improving the tester logic to recurse when handling general arrays (this logic was added for tuples, but not arrays). Now the tester logic should properly recurse for both array and tuple types.