### PR TITLE
Remove extraneous timesteps in action generation

### DIFF
--- a/fault/spice_target.py
+++ b/fault/spice_target.py
@@ -10,7 +10,7 @@ from fault.nutascii_parse import nutascii_parse
 from fault.psf_parse import psf_parse
 from fault.subprocess_run import subprocess_run
 from fault.pwl import pwc_to_pwl
-from fault.actions import Poke, Expect, Delay, Print
+from fault.actions import Poke, Expect, Delay, Print, Eval
 from fault.select_path import SelectPath
 
 
@@ -239,6 +239,8 @@ class SpiceTarget(Target):
                     saves.add(f'{port.name}')
             elif isinstance(action, Delay):
                 t += action.time
+            elif isinstance(action, Eval):
+                continue
             else:
                 raise NotImplementedError(action)
 

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -410,8 +410,8 @@ end
         return retval
 
     def make_eval(self, i, action):
-        # Eval implicit in SV simulations
-        return []
+        # Emulate eval by inserting a delay
+        return ['#0;']
 
     def make_step(self, i, action):
         name = verilog_name(action.clock.name)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -411,7 +411,7 @@ end
 
     def make_eval(self, i, action):
         # Emulate eval by inserting a delay
-        return ['#0;']
+        return ['#1;']
 
     def make_step(self, i, action):
         name = verilog_name(action.clock.name)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -181,7 +181,7 @@ class SystemVerilogTarget(VerilogTarget):
         if self.waveform_file is None and self.dump_waveforms:
             if self.simulator == "vcs":
                 self.waveform_file = "waveforms.vpd"
-            elif self.simulator == "ncsim":
+            elif self.simulator in {"ncsim", "iverilog"}:
                 self.waveform_file = "waveforms.vcd"
             else:
                 raise NotImplementedError(self.simulator)
@@ -269,9 +269,7 @@ class SystemVerilogTarget(VerilogTarget):
         # Build up the poke action, including delay
         retval = []
         retval += [f'{name} = {value};']
-        if action.delay is None:
-            retval += [f'#{self.clock_step_delay};']
-        else:
+        if action.delay is not None:
             retval += [f'#({action.delay}*1s);']
         return retval
 
@@ -419,7 +417,7 @@ end
         name = verilog_name(action.clock.name)
         code = []
         for step in range(action.steps):
-            code.append(f"#5 {name} ^= 1;")
+            code.append(f"#{self.clock_step_delay} {name} ^= 1;")
         return code
 
     def make_while(self, i, action):
@@ -538,6 +536,12 @@ end
         $vcdplusfile("{self.waveform_file}");
         $vcdpluson();
         $vcdplusmemon();
+"""
+        elif self.dump_waveforms and self.simulator == "iverilog":
+            # https://iverilog.fandom.com/wiki/GTKWAVE
+            initial_body += f"""
+        $dumpfile("{self.waveform_file}");
+        $dumpvars(0, dut);
 """
 
         for i, action in enumerate(actions):

--- a/tests/test_def_vlog.py
+++ b/tests/test_def_vlog.py
@@ -21,8 +21,10 @@ def test_def_vlog(target, simulator, n_bits=8, b_val=42):
 
     # define test
     tester.poke(defadd.a_val, 12)
+    tester.eval()
     tester.expect(defadd.c_val, 54)
     tester.poke(defadd.a_val, 34)
+    tester.eval()
     tester.expect(defadd.c_val, 76)
 
     # run simulation

--- a/tests/test_inv_tf.py
+++ b/tests/test_inv_tf.py
@@ -34,6 +34,7 @@ def test_inv_tf(
     for k in range(n_steps):
         in_ = k * vsup / (n_steps - 1)
         tester.poke(dut.in_, in_)
+        tester.eval()
         if in_ <= vil_rel * vsup:
             tester.expect(dut.out, vsup, above=voh_rel * vsup)
         elif in_ >= vih_rel * vsup:

--- a/tests/test_param_vlog.py
+++ b/tests/test_param_vlog.py
@@ -21,8 +21,10 @@ def test_def_vlog(target, simulator, n_bits=8, b_val=76):
 
     # define test
     tester.poke(paramadd.a_val, 98)
+    tester.eval()
     tester.expect(paramadd.c_val, 174)
     tester.poke(paramadd.a_val, 54)
+    tester.eval()
     tester.expect(paramadd.c_val, 130)
 
     # run simulation

--- a/tests/test_real_val.py
+++ b/tests/test_real_val.py
@@ -21,6 +21,7 @@ def test_real_val(target, simulator):
     tester = fault.Tester(realadd)
     tester.poke(realadd.a_val, 1.125)
     tester.poke(realadd.b_val, 2.5)
+    tester.eval()
     tester.expect(realadd.c_val, 3.625, abs_tol=1e-4)
 
     # run the test

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -214,7 +214,7 @@ def test_print_double_nested_arrays(capsys, target, simulator):
 6
 7
 8\
-""", out
+"""
 
 
 def test_target_tuple(target, simulator):

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -103,6 +103,7 @@ def test_target_clock(capsys, target, simulator):
     circ = TestBasicClkCircuit
     actions = [
         Poke(circ.I, 0),
+        Eval(),
         Print("%x\n", circ.I),
         Expect(circ.O, 0),
         Poke(circ.CLK, 0),


### PR DESCRIPTION
Before, fault was inserting #5 delays for every poke action, as a result the timing of the waveforms was off as it shows each poke action occurring during a different timestep.  I'm not sure why this was included, but removing it makes the timing more appropriate (delays only occur with clock events) and the tests pass.

There is still a `delay` parameter for poke actions that can be supplied explicitly by the user, this just removes the default delay for all pokes.

Also adds a small change to support vcd generation with iverilog