### PR TITLE
Add Icarus Verilog to Regression Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
   include:
   - os: linux
+    dist: bionic
     addons:
       apt:
         sources:
@@ -11,6 +12,7 @@ matrix:
         - libmpfr-dev
         - libmpc-dev
         - verilator
+        - iverilog
     env:
     - CC=gcc-7
     - CXX=g++-7
@@ -68,20 +70,6 @@ install:
 - export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.7:${LD_LIBRARY_PATH}"
 - pysmt-install --check
 # End setup CoSA dependencies
-
-before_script:
-# Begin install Icarus Verilog for Linux
-# We unfortunately cannot use the Travis package
-# list feature to do this because the default 
-# version for Xenial is too old.
-- |
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
-    echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
-    sudo apt-get update
-    sudo apt-get install verilog
-  fi
-# End install Icarus Verilog for Linux
 
 script:
 - pytest --cov fault --pycodestyle fault -v --cov-report term-missing tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
         - libmpfr-dev
         - libmpc-dev
         - verilator
-        - iverilog
     env:
     - CC=gcc-7
     - CXX=g++-7
@@ -69,6 +68,20 @@ install:
 - export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.7:${LD_LIBRARY_PATH}"
 - pysmt-install --check
 # End setup CoSA dependencies
+
+before_script:
+# Begin install Icarus Verilog for Linux
+# We unfortunately cannot use the Travis package
+# list feature to do this because the default 
+# version for Xenial is too old.
+- |
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
+    echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
+    sudo apt-get update
+    sudo apt-get install verilog
+  fi
+# End install Icarus Verilog for Linux
 
 script:
 - pytest --cov fault --pycodestyle fault -v --cov-report term-missing tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - libmpfr-dev
         - libmpc-dev
         - verilator
+        - iverilog
     env:
     - CC=gcc-7
     - CXX=g++-7
@@ -20,6 +21,7 @@ matrix:
       homebrew:
         packages:
           - verilator
+          - icarus-verilog
 
 # python managed by conda until 3.7 available
 # python:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -775,8 +775,9 @@ end
         if len(self.ext_libs) > 0:
             cmd += ['-Y.v', '-Y.sv']
 
-        # Icarus verilog does not have an option like "-v" that allows individual files
-        # to be included, so the best we can do is gather a list of unique library directories
+        # Icarus verilog does not have an option like "-v" that allows
+        # individual files to be included, so the best we can do is gather a
+        # list of unique library directories
         unq_lib_dirs = {}
         for lib in self.ext_libs:
             parent_dir = Path(lib).parent


### PR DESCRIPTION
Currently Icarus Verilog support is not checked as part of Travis or BuildKite tests.  This PR adds Icarus Verilog to the list of simulators tested with Travis, and fixes a few minor bugs causing some tests to fail when run using Icarus Verilog.

Details:
1. Travis Linux distro upgraded to "bionic" from "xenial" so that a modern **iverilog** version could be used (in particular, we need one supporting the "-g2012" flag)
2. Icarus Verilog is installed as a package for Linux and OSX targets on Travis.
3. Waveform dumping is fixed for Icarus Verilog using code from PR #180.
4. File writing is fixed for Icarus Verilog.  $fwrite doesn't work properly for Icarus Verilog when dealing with individual bytes because it won't write the byte "0x00".  As a result, for the **iverilog** simulator the non-standard function $fputc is used instead.
5. Library file inclusion is fixed for Icarus Verilog.  Since iverilog doesn't have a command like "-v" that allows a single library file to be included, a list of all unique library directories is built up and passed using the "-y" flag.