### PR TITLE
Add warning for no initialized clock

### DIFF
--- a/fault/tester.py
+++ b/fault/tester.py
@@ -263,7 +263,8 @@ class Tester:
         """
         if not self.clock_initialized:
             warnings.warn("Clock has not been initialized, the initial value "
-                          "will be X for system verilog targets")
+                          "will be X for system verilog targets.  In a future "
+                          "release, this will be an error", DeprecationWarning)
         self.targets[target] = self.make_target(target, **kwargs)
 
     def compile(self, target="verilator", **kwargs):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -130,23 +130,20 @@ def test_tester_peek(target, simulator):
             tester.compile_and_run(target, directory=_dir, simulator=simulator)
 
 
-def test_tester_no_clock_init(target, simulator):
+def test_tester_no_clock_init():
     circ = TestBasicClkCircuit
     tester = fault.Tester(circ, circ.CLK)
     tester.poke(circ.I, 0)
     tester.expect(circ.O, 0)
-    tester.step()
     with pytest.warns(DeprecationWarning,
                       match="Clock has not been initialized, the initial "
                             "value will be X for system verilog targets.  In "
                             "a future release, this will be an error"):
-        with tempfile.TemporaryDirectory(dir=".") as _dir:
-            if target == "verilator":
-                tester.compile_and_run(target, directory=_dir,
-                                       flags=["-Wno-fatal"])
-            else:
-                tester.compile_and_run(target, directory=_dir,
-                                       simulator=simulator)
+        tester.step()
+    # should not warn more than once
+    with pytest.warns(None) as record:
+        tester.step()
+        assert len(record) == 0
 
 
 def test_tester_peek_input(target, simulator):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -136,9 +136,10 @@ def test_tester_no_clock_init(target, simulator):
     tester.poke(circ.I, 0)
     tester.expect(circ.O, 0)
     tester.step()
-    with pytest.warns(UserWarning,
+    with pytest.warns(DeprecationWarning,
                       match="Clock has not been initialized, the initial "
-                            "value will be X for system verilog targets"):
+                            "value will be X for system verilog targets.  In "
+                            "a future release, this will be an error"):
         with tempfile.TemporaryDirectory(dir=".") as _dir:
             if target == "verilator":
                 tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -142,9 +142,11 @@ def test_tester_no_clock_init(target, simulator):
                             "a future release, this will be an error"):
         with tempfile.TemporaryDirectory(dir=".") as _dir:
             if target == "verilator":
-                tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
+                tester.compile_and_run(target, directory=_dir,
+                                       flags=["-Wno-fatal"])
             else:
-                tester.compile_and_run(target, directory=_dir, simulator=simulator)
+                tester.compile_and_run(target, directory=_dir,
+                                       simulator=simulator)
 
 
 def test_tester_peek_input(target, simulator):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -130,6 +130,22 @@ def test_tester_peek(target, simulator):
             tester.compile_and_run(target, directory=_dir, simulator=simulator)
 
 
+def test_tester_no_clock_init(target, simulator):
+    circ = TestBasicClkCircuit
+    tester = fault.Tester(circ, circ.CLK)
+    tester.poke(circ.I, 0)
+    tester.expect(circ.O, 0)
+    tester.step()
+    with pytest.warns(UserWarning,
+                      match="Clock has not been initialized, the initial "
+                            "value will be X for system verilog targets"):
+        with tempfile.TemporaryDirectory(dir=".") as _dir:
+            if target == "verilator":
+                tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
+            else:
+                tester.compile_and_run(target, directory=_dir, simulator=simulator)
+
+
 def test_tester_peek_input(target, simulator):
     circ = TestBasicCircuit
     tester = fault.Tester(circ)


### PR DESCRIPTION
Catches issue when clock is initialized to X for system verilog test benches.  In the future, we will turn this into an error, but for now we just issue a warning so we don't break existing code.