### PR TITLE
Add support for Vivado as a simulator

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,3 +33,25 @@ steps:
     label: "test"
     agents:
       fault: "true"
+  - command: |
+      # set up environment
+      source /etc/environment
+      echo $$PATH
+
+      # create virtual environment
+      python3.7 -m venv venv
+      source venv/bin/activate
+
+      # install python dependencies
+      pip install mantle pytest
+      pip install -e .
+      
+      # run tests
+      pytest tests
+
+      # deactivate virtual environment
+      deactivate
+    label: "fpga_verif"
+    timeout_in_minutes: 60
+    agents:
+        fpga_verif: "true"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,6 @@ steps:
       source venv/bin/activate
 
       # install python dependencies
-      pip install wheel
       pip install mantle pytest
       pip install -e .
       

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,7 @@ steps:
       pip install -e .
       
       # run tests
-      pytest tests
+      pytest tests -x
 
       # deactivate virtual environment
       deactivate

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,7 @@ steps:
       source venv/bin/activate
 
       # install python dependencies
+      pip install wheel
       pip install mantle pytest
       pip install -e .
       

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -61,7 +61,7 @@ class SystemVerilogTarget(VerilogTarget):
 
         magma_opts: Options dictionary for `magma.compile` command
 
-        simulator: "ncsim", "vcs", or "iverilog"
+        simulator: "ncsim", "vcs", "iverilog", or "vivado"
 
         timescale: Set the timescale for the verilog simulation
                    (default 1ns/1ns)
@@ -150,7 +150,7 @@ class SystemVerilogTarget(VerilogTarget):
         if simulator is None:
             raise ValueError("Must specify simulator when using system-verilog"
                              " target")
-        if simulator not in {"vcs", "ncsim", "iverilog"}:
+        if simulator not in {"vcs", "ncsim", "iverilog", "vivado"}:
             raise ValueError(f"Unsupported simulator {simulator}")
 
         # save settings
@@ -181,7 +181,7 @@ class SystemVerilogTarget(VerilogTarget):
         if self.waveform_file is None and self.dump_waveforms:
             if self.simulator == "vcs":
                 self.waveform_file = "waveforms.vpd"
-            elif self.simulator in {"ncsim", "iverilog"}:
+            elif self.simulator in {"ncsim", "iverilog", "vivado"}:
                 self.waveform_file = "waveforms.vcd"
             else:
                 raise NotImplementedError(self.simulator)
@@ -593,6 +593,11 @@ end
                                      cmd_file=self.write_ncsim_tcl())
             bin_cmd = None
             sim_err_str = None
+        elif self.simulator == 'vivado':
+            sim_cmd = self.vivado_cmd(sources=vlog_srcs,
+                                      cmd_file=self.write_vivado_tcl())
+            bin_cmd = None
+            sim_err_str = ['CRITICAL WARNING', 'ERROR', 'Fatal']
         elif self.simulator == 'vcs':
             sim_cmd, bin_file = self.vcs_cmd(sources=vlog_srcs)
             bin_cmd = [bin_file]

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,9 +3,16 @@ import magma as m
 import mantle
 
 
-def pytest_sim_params(metafunc, *args):
+def pytest_sim_params(metafunc, *args, exclude=None):
+    # set defaults
+    if exclude is None:
+        exclude = []
+    elif isinstance(exclude, str):
+        exclude = [exclude]
+    exclude = set(exclude)
+
     # simulators supported by each kind of target
-    sims_by_arg = {'system-verilog': ['vcs', 'ncsim', 'iverilog'],
+    sims_by_arg = {'system-verilog': ['vcs', 'ncsim', 'iverilog', 'vivado'],
                    'verilog-ams': ['ncsim'],
                    'verilator': [None],
                    'spice': ['ngspice', 'spectre', 'hspice']}
@@ -17,7 +24,9 @@ def pytest_sim_params(metafunc, *args):
         targets = []
         for arg in args:
             for simulator in sims_by_arg[arg]:
-                if simulator is None or shutil.which(simulator):
+                if simulator in exclude:
+                    continue
+                elif simulator is None or shutil.which(simulator):
                     targets.append((arg, simulator))
 
         metafunc.parametrize("target,simulator", targets)

--- a/tests/test_bidir.py
+++ b/tests/test_bidir.py
@@ -5,7 +5,8 @@ from .common import pytest_sim_params
 
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc, 'system-verilog')
+    # Vivado doesn't support the "tran" keyword, so it must be excluded
+    pytest_sim_params(metafunc, 'system-verilog', exclude='vivado')
 
 
 def test_bidir(target, simulator):

--- a/tests/test_hi_z.py
+++ b/tests/test_hi_z.py
@@ -5,7 +5,8 @@ from .common import pytest_sim_params
 
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc, 'system-verilog')
+    # Vivado doesn't support the "tran" keyword, so it must be excluded
+    pytest_sim_params(metafunc, 'system-verilog', exclude='vivado')
 
 
 def test_hi_z(target, simulator):


### PR DESCRIPTION
This PR adds a new option for running SystemVerilog simulations using Vivado.  This option can be used by setting simulator='vivado' when invoking **compile_and_run**.

Vivado support is tested as part of the regression flow using the existing fpga-verif-* BuildKite agents.

Details:
1. Since Vivado can produce one of several error strings, the **subprocess_run** command was updated to allow the **err_str** argument to be a single string, a list of strings, or a regex pattern (re.Pattern). 
2. The file I/O tests in tests/test_tester.py had to be updated to pass input and output file locations as absolute paths, because the Vivado working directory is not the same as the Python working directory.
3. tests/test_bidir.py and tests/test_hi_z.py skip the Vivado simulator since it does not support the **tran** Verilog keyword used in those tests (this issue is [briefly mentioned](https://forums.xilinx.com/t5/Simulation-and-Verification/unsupported-primitive/td-p/884456) on the Xilinx forums).