### PR TITLE
Kratos debugging system integration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,10 +27,6 @@ steps:
       # install kratos runtime
       pip install kratos-runtime
       
-      # REMOVE ME
-      # install testing branch for importing kratos circuit
-      pip install --ignore-installed git+http://github.com/Kuree/magma@from_kratos#egg=magma-lang
-      
       # run tests
       ./conda_env/bin/pytest --cov fault --pycodestyle fault --cov-report term-missing tests -v -r s
       

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,13 @@ steps:
       # install SMT solvers
       mkdir ./smt_solvers
       ./conda_env/bin/pysmt-install --install-path ./smt_solvers --bindings-path=./conda_env/lib/python3.7/site-packages --msat --confirm-agreement
+
+      # install kratos runtime
+      pip install kratos-runtime
+      
+      # REMOVE ME
+      # install testing branch for importing kratos circuit
+      pip install --ignore-installed git+http://github.com/Kuree/magma@from_kratos#egg=magma-lang
       
       # run tests
       ./conda_env/bin/pytest --cov fault --pycodestyle fault --cov-report term-missing tests -v -r s

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,9 @@ install:
 - pysmt-install --check
 # End setup CoSA dependencies
 
+# install testing branch for importing kratos circuit
+pip install --ignore-installed git+http://github.com/Kuree/magma@from_kratos#egg=magma-lang
+
 script:
 - pytest --cov fault --pycodestyle fault -v --cov-report term-missing tests
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,6 @@ install:
 - pysmt-install --check
 # End setup CoSA dependencies
 
-# install testing branch for importing kratos circuit
-pip install --ignore-installed git+http://github.com/Kuree/magma@from_kratos#egg=magma-lang
-
 script:
 - pytest --cov fault --pycodestyle fault -v --cov-report term-missing tests
 deploy:

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -45,7 +45,7 @@ class SystemVerilogTarget(VerilogTarget):
                  ext_libs=None, defines=None, flags=None, inc_dirs=None,
                  ext_test_bench=False, top_module=None, ext_srcs=None,
                  use_input_wires=False, parameters=None, disp_type='on_error',
-                 waveform_file=None, top_name=None, use_kratos=False):
+                 waveform_file=None, use_kratos=False):
         """
         circuit: a magma circuit
 
@@ -122,7 +122,7 @@ class SystemVerilogTarget(VerilogTarget):
 
         waveform_file: name of file to dump waveforms (default is
                        "waveform.vcd" for ncsim and "waveform.vpd" for vcs)
-        top_name: top level test bench name (default is {circuit_name}_tb
+        use_kratos: If True, set the environment up for debugging in kratos
         """
         # set default for list of external sources
         if include_verilog_libraries is None:
@@ -145,7 +145,7 @@ class SystemVerilogTarget(VerilogTarget):
         # call the super constructor
         super().__init__(circuit, circuit_name, directory, skip_compile,
                          include_verilog_libraries, magma_output,
-                         magma_opts)
+                         magma_opts, use_kratos=use_kratos)
 
         # sanity check
         if simulator is None:
@@ -186,7 +186,7 @@ class SystemVerilogTarget(VerilogTarget):
                 self.waveform_file = "waveforms.vcd"
             else:
                 raise NotImplementedError(self.simulator)
-        self.top_name = top_name if top_name is not None \
+        self.top_name = "TOP" if use_kratos is not None \
             else f"{circuit_name}_tb"
         self.use_kratos = use_kratos
         # check to see if runtime is installed

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -190,9 +190,10 @@ class SystemVerilogTarget(VerilogTarget):
         self.use_kratos = use_kratos
         # check to see if runtime is installed
         if use_kratos:
-            try:
-                import kratos_runtime
-            except ImportError:
+            import sys
+            assert sys.platform == "linux" or sys.platform == "linux2",\
+                "Currently only linux is supported"
+            if not fault.util.has_kratos_runtime():
                 raise ImportError("Cannot find kratos-runtime in the system. "
                                   "Please do \"pip install kratos-runtime\" "
                                   "to install.")

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -578,7 +578,8 @@ end
             port_list=f',\n{2*tab}'.join(port_list),
             param_list=f',\n{2*tab}'.join(param_list),
             circuit_name=self.circuit_name,
-            top_module=self.top_module
+            top_module=self.top_module if self.top_module is not None else
+            f"{self.circuit_name}_tb"
         )
 
         return src
@@ -711,7 +712,7 @@ end
 
         # determine the name of the top module
         if self.top_module is None and not self.ext_test_bench:
-            top = f'{self.circuit_name}_tb'
+            top = f'{self.circuit_name}_tb' if not self.use_kratos else "TOP"
         else:
             top = self.top_module
 

--- a/fault/util.py
+++ b/fault/util.py
@@ -7,3 +7,11 @@ def clog2(x):
 
 def flatten(l):
     return [item for sublist in l for item in sublist]
+
+
+def has_kratos_runtime():
+    try:
+        import kratos_runtime
+        return True
+    except ImportError:
+        return False

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -17,6 +17,7 @@ from fault.subprocess_run import subprocess_run
 import fault.utils as utils
 import fault.expression as expression
 import platform
+import os
 
 
 max_bits = 64 if platform.architecture()[0] == "64bit" else 32
@@ -56,6 +57,7 @@ void my_assert(
     tracer->dump(main_time);
     tracer->close();
 #endif
+    {kratos_exit_call}
     exit(1);
   }}
 }}
@@ -63,7 +65,7 @@ void my_assert(
 int main(int argc, char **argv) {{
   Verilated::commandArgs(argc, argv);
   V{circuit_name}* top = new V{circuit_name};
-
+  {kratos_start_call}
 #if VM_TRACE
   Verilated::traceEverOn(true);
   tracer = new VerilatedVcdC;
@@ -77,6 +79,7 @@ int main(int argc, char **argv) {{
 #if VM_TRACE
   tracer->close();
 #endif
+  {kratos_exit_call}
 }}
 """  # nopep8
 
@@ -86,7 +89,7 @@ class VerilatorTarget(VerilogTarget):
                  flags=None, skip_compile=False, include_verilog_libraries=None,
                  include_directories=None, magma_output="coreir-verilog",
                  circuit_name=None, magma_opts=None, skip_verilator=False,
-                 disp_type='on_error'):
+                 disp_type='on_error', use_kratos=False):
         """
         Params:
             `include_verilog_libraries`: a list of verilog libraries to include
@@ -105,6 +108,14 @@ class VerilatorTarget(VerilogTarget):
 
         # Save settings
         self.disp_type = disp_type
+        self.use_kratos = use_kratos
+        if use_kratos:
+            try:
+                import kratos_runtime
+            except ImportError:
+                raise ImportError("Cannot find kratos-runtime in the system. "
+                                  "Please do \"pip install kratos-runtime\" "
+                                  "to install.")
 
         # Call super constructor
         super().__init__(circuit, circuit_name, directory, skip_compile,
@@ -120,7 +131,8 @@ class VerilatorTarget(VerilogTarget):
                 include_verilog_libraries=self.include_verilog_libraries,
                 include_directories=include_directories,
                 driver_filename=driver_file.name,
-                verilator_flags=flags
+                verilator_flags=flags,
+                use_kratos=use_kratos
             )
             # shell=True since 'verilator' is actually a shell script
             subprocess_run(comp_cmd, cwd=self.directory, shell=True,
@@ -513,10 +525,21 @@ for ({loop_expr}) {{
                      self.debug_includes]
 
         includes_src = "\n".join(["#include " + i for i in includes])
+        if self.use_kratos:
+            includes_src += "\nvoid initialize_runtime();\n"
+            includes_src += "void teardown_runtime();\n"
+            kratos_start_call = "initialize_runtime();"
+            kratos_exit_call = "teardown_runtime();"
+        else:
+            kratos_start_call = ""
+            kratos_exit_call = ""
+
         src = src_tpl.format(
             includes=includes_src,
             main_body=main_body,
             circuit_name=self.circuit_name,
+            kratos_start_call=kratos_start_call,
+            kratos_exit_call=kratos_exit_call
         )
 
         return src
@@ -534,6 +557,19 @@ for ({loop_expr}) {{
         with open(driver_file, "w") as f:
             f.write(src)
 
+        # if use kratos, symbolic link the library to dest folder
+        if self.use_kratos:
+            from kratos_runtime import get_lib_path
+            lib_name = os.path.basename(get_lib_path())
+            dst_path = os.path.abspath(os.path.join(self.directory, "obj_dir",
+                                                    lib_name))
+            if not os.path.isfile(dst_path):
+                os.symlink(get_lib_path(), dst_path)
+            # add ld library path
+            env = {"LD_LIBRARY_PATH": os.path.dirname(dst_path)}
+        else:
+            env = None
+
         # Run makefile created by verilator
         make_cmd = verilator_make_cmd(self.circuit_name)
         subprocess_run(make_cmd, cwd=self.directory, disp_type=self.disp_type)
@@ -542,7 +578,8 @@ for ({loop_expr}) {{
         # output to a logfile for later review or processing
         exe_cmd = [f'./obj_dir/V{self.circuit_name}']
         result = subprocess_run(exe_cmd, cwd=self.directory,
-                                disp_type=self.disp_type)
+                                disp_type=self.disp_type,
+                                env=env)
         log = Path(self.directory) / 'obj_dir' / f'{self.circuit_name}.log'
         with open(log, 'w') as f:
             f.write(result.stdout)

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -1,4 +1,5 @@
 from .subprocess_run import subprocess_run
+import os
 
 
 def verilator_version(disp_type='on_error'):
@@ -16,7 +17,8 @@ def verilator_version(disp_type='on_error'):
 def verilator_comp_cmd(top=None, verilog_filename=None,
                        include_verilog_libraries=None,
                        include_directories=None,
-                       driver_filename=None, verilator_flags=None):
+                       driver_filename=None, verilator_flags=None,
+                       use_kratos=False):
     # set defaults
     if include_verilog_libraries is None:
         include_verilog_libraries = []
@@ -34,6 +36,9 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
     retval += verilator_flags
     if verilog_filename is not None:
         retval += ['--cc', f'{verilog_filename}']
+        if use_kratos:
+            from kratos_runtime import get_lib_path
+            retval += [os.path.basename(get_lib_path())]
     # -v arguments
     for file_ in include_verilog_libraries:
         retval += ['-v', f'{file_}']
@@ -44,6 +49,9 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
         retval += ['--exe', f'{driver_filename}']
     if top is not None:
         retval += ['--top-module', f'{top}']
+    # vpi flag
+    if use_kratos:
+        retval += ["--vpi"]
 
     # return the command
     return retval

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -15,7 +15,7 @@ class VerilogTarget(Target):
     """
     def __init__(self, circuit, circuit_name=None, directory="build/",
                  skip_compile=False, include_verilog_libraries=None,
-                 magma_output="verilog", magma_opts=None):
+                 magma_output="verilog", magma_opts=None, use_kratos=False):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -35,7 +35,7 @@ class VerilogTarget(Target):
         self.magma_opts = magma_opts if magma_opts is not None else {}
 
         if hasattr(circuit, "verilog_file_name") and \
-                os.path.splitext(circuit.verilog_file_name)[-1] == ".sv":
+                os.path.splitext(circuit.verilog_file_name)[-1] == ".sv" or use_kratos:
             suffix = "sv"
         else:
             suffix = "v"
@@ -45,6 +45,11 @@ class VerilogTarget(Target):
             prefix = os.path.splitext(self.directory / self.verilog_file)[0]
             m.compile(prefix, self.circuit, output=self.magma_output,
                       **self.magma_opts)
+            if use_kratos:
+                # kratos generates SystemVerilog file
+                # Until magma/coreir can generate sv suffix, we have to move the files around
+                assert self.verilog_file == prefix + ".sv"
+                os.rename(prefix + ".v", self.verilog_file)
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f"Compiling {self.circuit} failed")
 

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -35,7 +35,8 @@ class VerilogTarget(Target):
         self.magma_opts = magma_opts if magma_opts is not None else {}
 
         if hasattr(circuit, "verilog_file_name") and \
-                os.path.splitext(circuit.verilog_file_name)[-1] == ".sv" or use_kratos:
+                os.path.splitext(circuit.verilog_file_name)[-1] == ".sv" or \
+                use_kratos:
             suffix = "sv"
         else:
             suffix = "v"
@@ -47,9 +48,9 @@ class VerilogTarget(Target):
                       **self.magma_opts)
             if use_kratos:
                 # kratos generates SystemVerilog file
-                # Until magma/coreir can generate sv suffix, we have to move the files around
-                assert self.verilog_file == prefix + ".sv"
-                os.rename(prefix + ".v", self.verilog_file)
+                # Until magma/coreir can generate sv suffix, we have to move
+                # the files around
+                os.rename(prefix + ".v", prefix + ".sv")
             if not (self.directory / self.verilog_file).is_file():
                 raise Exception(f"Compiling {self.circuit} failed")
 

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -3,17 +3,31 @@ import pytest
 import kratos
 import multiprocessing
 import time
-import pathlib
 import tempfile
-import os
-import magma
+import magma as m
 import shutil
+import operator
+import hwtypes
 
 try:
     import kratos_runtime
     has_runtime = True
 except ImportError:
     has_runtime = False
+
+
+def mock_debugger(fn):
+    # run it in a separate process to fake a debugger-simulator interaction
+    p = multiprocessing.Process(target=fn)
+    p.start()
+    # send an CONTINUE request to the runtime to check if it's working
+    from kratos_runtime import DebuggerMock
+    mock = DebuggerMock()
+    time.sleep(1)
+    mock.connect()
+    mock.continue_()
+    mock.wait_till_finish()
+    p.join()
 
 
 @pytest.mark.skipif((not shutil.which("irun")) and not has_runtime,
@@ -32,17 +46,7 @@ def test_load_runtime():
                                    directory=temp,
                                    magma_output="verilog",
                                    use_kratos=True)
-        # run it in a separate process to fake a debugger-simulator interaction
-        p = multiprocessing.Process(target=run_test)
-        p.start()
-        # send an CONTINUE request to the runtime to check if it's working
-        from kratos_runtime import DebuggerMock
-        mock = DebuggerMock()
-        time.sleep(1)
-        mock.connect()
-        mock.continue_()
-        mock.wait_till_finish()
-        p.join()
+        mock_debugger(run_test)
 
 
 @pytest.mark.skipif(not has_runtime, reason="runtime not available")
@@ -57,17 +61,85 @@ def test_veriltor_load():
             tester = fault.Tester(circuit)
             tester.compile_and_run(target="verilator",
                                    directory=temp,
-                                   disp_type="realtime",
                                    magma_output="verilog",
                                    use_kratos=True)
-        # run it in a separate process to fake a debugger-simulator interaction
-        p = multiprocessing.Process(target=run_test)
-        p.start()
-        # send an CONTINUE request to the runtime to check if it's working
-        from kratos_runtime import DebuggerMock
-        mock = DebuggerMock()
-        time.sleep(1)
-        mock.connect()
-        mock.continue_()
-        mock.wait_till_finish()
-        p.join()
+        mock_debugger(run_test)
+
+
+# TODO: move the function in magma as a normal library call
+def build_kratos_debug_info(circuit, is_top):
+    inst_to_defn_map = {}
+    for instance in circuit.instances:
+        instance_inst_to_defn_map = \
+            build_kratos_debug_info(type(instance), is_top=False)
+        for k, v in instance_inst_to_defn_map.values():
+            key = instance.name + "." + k
+            if is_top:
+                key = circuit.name + "." + key
+            inst_to_defn_map[key] = v
+        inst_name = instance.name
+        if is_top:
+            inst_name = circuit.name + "." + instance.name
+        if instance.kratos is not None:
+            inst_to_defn_map[inst_name] = instance.kratos
+    return inst_to_defn_map
+
+
+@pytest.mark.skipif(not has_runtime, reason="runtime not available")
+@pytest.mark.parametrize("target", ["verilator", "system-verilog"])
+def test_magma_debug(target):
+    if not shutil.which("irun"):
+        pytest.skip("irun not available")
+
+    class SimpleALU(m.Circuit):
+        IO = ["a", m.In(m.UInt[16]), "b", m.In(m.UInt[16]), "c",
+              m.Out(m.UInt[16]), "config_", m.In(m.Bits[2])]
+
+        m.config.set_debug_mode(True)
+
+        @m.circuit.combinational_to_verilog
+        def execute_alu(a: m.UInt[16], b: m.UInt[16], config_: m.Bits[2]) -> \
+                m.UInt[16]:
+            if config_ == m.bits(0, 2):
+                c = a + b
+            elif config_ == m.bits(1, 2):
+                c = a - b
+            elif config_ == m.bits(2, 2):
+                c = a * b
+            else:
+                c = m.bits(0, 16)
+            return c
+
+        @classmethod
+        def definition(io):
+            io.c <= io.execute_alu(io.a, io.b, io.config_)
+
+    inst_to_defn_map = build_kratos_debug_info(SimpleALU, is_top=True)
+    assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map
+    generators = []
+    for instance_name, mod in inst_to_defn_map.items():
+        mod.instance_name = instance_name
+        generators.append(mod)
+
+    tester = fault.Tester(SimpleALU)
+    ops = [operator.add, operator.sub, operator.mul, operator.floordiv]
+    for i, op in enumerate(ops):
+        tester.circuit.config_ = i
+        tester.circuit.a = a = hwtypes.BitVector.random(16)
+        tester.circuit.b = b = hwtypes.BitVector.random(16)
+        tester.eval()
+        if op == operator.floordiv:
+            tester.circuit.c.expect(0)
+        else:
+            tester.circuit.c.expect(op(a, b))
+
+    with tempfile.TemporaryDirectory() as temp:
+
+        def run_test():
+            kwargs = {"target": target, "directory": temp,
+                      "magma_output": "verilog",
+                      "use_kratos": True}
+            if target == "system-verilog":
+                kwargs["simulator"] = "ncsim"
+            tester.compile_and_run(**kwargs)
+        mock_debugger(run_test)

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -11,6 +11,7 @@ import shutil
 
 
 # @pytest.mark.skipif(not shutil.which("irun"), reason="irun not available")
+@pytest.mark.skipif(True)
 def test_load_runtime():
     # define an empty circuit
     mod = kratos.Generator("mod")
@@ -19,7 +20,7 @@ def test_load_runtime():
 
         def run_test():
             # -g without the db dump
-            circuit = magma.FromKratos(mod, insert_debug_info=True)
+            circuit = kratos.util.to_magma(mod, insert_debug_info=True)
             tester = fault.Tester(circuit)
             tester.compile_and_run(target="system-verilog",
                                    simulator="ncsim",
@@ -32,7 +33,7 @@ def test_load_runtime():
         p = multiprocessing.Process(target=run_test)
         p.start()
         # wait for 1 second, which should be enough
-        time.sleep(2)
+        time.sleep(5)
         # send an CONTINUE request to the runtime to check if it's working
         from kratos_runtime import DebuggerMock
         mock = DebuggerMock()
@@ -41,7 +42,3 @@ def test_load_runtime():
         p.join(timeout=1)
         assert os.path.isfile(finish_file), "Unable to continue the simulation"
         os.remove(finish_file)
-
-
-if __name__ == "__main__":
-    test_load_runtime()

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -9,11 +9,8 @@ import shutil
 import operator
 import hwtypes
 
-try:
-    import kratos_runtime
-    has_runtime = True
-except ImportError:
-    has_runtime = False
+
+has_runtime = fault.util.has_kratos_runtime()
 
 
 def mock_debugger(fn):

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -114,6 +114,9 @@ def test_magma_debug(target):
         def definition(io):
             io.c <= io.execute_alu(io.a, io.b, io.config_)
 
+        # turn the debug off
+        m.config.set_debug_mode(False)
+
     inst_to_defn_map = build_kratos_debug_info(SimpleALU, is_top=True)
     assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map
     generators = []

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -1,0 +1,45 @@
+import fault
+import pytest
+import kratos
+import multiprocessing
+import time
+import pathlib
+import tempfile
+import os
+import magma
+import shutil
+
+
+@pytest.mark.skipif(not shutil.which("irun"), reason="irun not available")
+def test_load_runtime():
+    # define an empty circuit
+    mod = kratos.Generator("mod")
+    with tempfile.TemporaryDirectory() as temp:
+        output_file = os.path.join(temp, "mod.sv")
+        finish_file = os.path.join(temp, "finish")
+
+        def run_test():
+            # -g without the db dump
+            kratos.verilog(mod, filename=output_file, insert_debug_info=True)
+            circuit = magma.DeclareFromTemplatedVerilogFile(output_file)[0]
+            tester = fault.Tester(circuit)
+            tester.compile_and_run(target="system-verilog",
+                                   simulator="ncsim",
+                                   directory=temp,
+                                   skip_compile=True,
+                                   use_kratos=True)
+            # touch a file
+            pathlib.Path(finish_file).touch(exist_ok=True)
+        # run it in a separate process to fake a debugger-simulator interaction
+        p = multiprocessing.Process(target=run_test)
+        p.start()
+        # wait for 1 second, which should be enough
+        time.sleep(1)
+        # send an CONTINUE request to the runtime to check if it's working
+        from kratos_runtime import DebuggerMock
+        mock = DebuggerMock()
+        mock.continue_()
+        # 1 second time out
+        p.join(timeout=1)
+        assert os.path.isfile(finish_file), "Unable to continue the simulation"
+        os.remove(finish_file)

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -10,23 +10,21 @@ import magma
 import shutil
 
 
-@pytest.mark.skipif(not shutil.which("irun"), reason="irun not available")
+# @pytest.mark.skipif(not shutil.which("irun"), reason="irun not available")
 def test_load_runtime():
     # define an empty circuit
     mod = kratos.Generator("mod")
     with tempfile.TemporaryDirectory() as temp:
-        output_file = os.path.join(temp, "mod.sv")
         finish_file = os.path.join(temp, "finish")
 
         def run_test():
             # -g without the db dump
-            kratos.verilog(mod, filename=output_file, insert_debug_info=True)
-            circuit = magma.DeclareFromTemplatedVerilogFile(output_file)[0]
+            circuit = magma.FromKratos(mod, insert_debug_info=True)
             tester = fault.Tester(circuit)
             tester.compile_and_run(target="system-verilog",
                                    simulator="ncsim",
                                    directory=temp,
-                                   skip_compile=True,
+                                   magma_output="verilog",
                                    use_kratos=True)
             # touch a file
             pathlib.Path(finish_file).touch(exist_ok=True)
@@ -34,7 +32,7 @@ def test_load_runtime():
         p = multiprocessing.Process(target=run_test)
         p.start()
         # wait for 1 second, which should be enough
-        time.sleep(1)
+        time.sleep(2)
         # send an CONTINUE request to the runtime to check if it's working
         from kratos_runtime import DebuggerMock
         mock = DebuggerMock()
@@ -43,3 +41,7 @@ def test_load_runtime():
         p.join(timeout=1)
         assert os.path.isfile(finish_file), "Unable to continue the simulation"
         os.remove(finish_file)
+
+
+if __name__ == "__main__":
+    test_load_runtime()

--- a/tests/test_kratos_debug.py
+++ b/tests/test_kratos_debug.py
@@ -9,8 +9,15 @@ import os
 import magma
 import shutil
 
+try:
+    import kratos_runtime
+    has_runtime = True
+except ImportError:
+    has_runtime = False
 
-@pytest.mark.skipif(not shutil.which("irun"), reason="irun not available")
+
+@pytest.mark.skipif((not shutil.which("irun")) and not has_runtime,
+                    reason="irun not available")
 def test_load_runtime():
     # define an empty circuit
     mod = kratos.Generator("mod")
@@ -23,6 +30,34 @@ def test_load_runtime():
             tester.compile_and_run(target="system-verilog",
                                    simulator="ncsim",
                                    directory=temp,
+                                   magma_output="verilog",
+                                   use_kratos=True)
+        # run it in a separate process to fake a debugger-simulator interaction
+        p = multiprocessing.Process(target=run_test)
+        p.start()
+        # send an CONTINUE request to the runtime to check if it's working
+        from kratos_runtime import DebuggerMock
+        mock = DebuggerMock()
+        time.sleep(1)
+        mock.connect()
+        mock.continue_()
+        mock.wait_till_finish()
+        p.join()
+
+
+@pytest.mark.skipif(not has_runtime, reason="runtime not available")
+def test_veriltor_load():
+    # define an empty circuit
+    mod = kratos.Generator("mod")
+    with tempfile.TemporaryDirectory() as temp:
+
+        def run_test():
+            # -g without the db dump
+            circuit = kratos.util.to_magma(mod, insert_debug_info=True)
+            tester = fault.Tester(circuit)
+            tester.compile_and_run(target="verilator",
+                                   directory=temp,
+                                   disp_type="realtime",
                                    magma_output="verilog",
                                    use_kratos=True)
         # run it in a separate process to fake a debugger-simulator interaction


### PR DESCRIPTION
- Modified backend to handle both verilator and system-verilog outputs.
- Introduced a flag called `use_kratos` at top level.
- Added tests to test out loading runtime directly as well as a simple ALU test for both verilator and ncsim. The ALU is copied from the magma test.
- User needs to install `kratos_runtime` separately as it's not required to use fault.
- `kratos_runtime` currently only has native build for linux systems. I will try to figure out how to build it on macos later, but it's not high priority on my list since ncsim/vcs can't run on macos.

I will add `vcs` tests as a separate PR.

I think we should refactor `build_kratos_debug_info` as a utility function magma. I just copied it here, which should be refactored.