### PR TITLE
Use non-blocking assign for SV poke

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -296,7 +296,7 @@ class SystemVerilogTarget(VerilogTarget):
         value = self.process_value(action.port, action.value)
         # Build up the poke action, including delay
         retval = []
-        retval += [f'{name} = {value};']
+        retval += [f'{name} <= {value};']
         if action.delay is not None:
             retval += [f'#({action.delay}*1s);']
         return retval

--- a/tests/test_verilog_target.py
+++ b/tests/test_verilog_target.py
@@ -131,6 +131,7 @@ def test_print_nested_arrays(capsys, target, simulator):
     circ = TestNestedArraysCircuit
     actions = [Print(TEST_START + '\n')] + [
         Poke(circ.I, [BitVector[4](i) for i in range(3)]),
+        Eval(),
     ] + [Print("%x\n", i) for i in circ.I] + [
         Eval(),
         Expect(circ.O, [BitVector[4](i) for i in range(3)]),
@@ -161,6 +162,7 @@ def test_print_double_nested_arrays(capsys, target, simulator):
     actions = [Print(TEST_START + '\n')] + [
         Poke(circ.I, [[BitVector[4](i + j * 3) for i in range(3)]
                       for j in range(2)]),
+        Eval(),
     ] + [Print("%x\n", j) for i in circ.I for j in i] + [
         Eval(),
         Expect(circ.O, [[BitVector[4](i + j * 3) for i in range(3)]


### PR DESCRIPTION
Verilator effectively uses non-blocking semantics because pokes are staged until `eval` is called.  This updates the system verilog target to do the same by using non-blocking assign.