### PR TITLE
speed up travis build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,8 @@
 steps:
   - command: |
       # set up environment
-      export PATH=/usr/local/miniconda/bin:/usr/local/bin:$$PATH
+      export PATH=/usr/local/miniconda/bin:$$PATH
       echo $$PATH
-      export LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:/usr/local/lib
-      echo $$LD_LIBRARY_PATH
 
       # tool setup
       source /cad/modules/tcl/init/bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,9 @@ install:
     # avoid strange libjpeg error (see https://github.com/sgrif/pq-sys/issues/1
     # for some more info)
     export DYLD_LIBRARY_PATH=/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/:/usr/local/lib:$DYLD_LIBRARY_PATH
+    # speed up the build process until it's fixed at z3
+    # see https://github.com/Z3Prover/z3/issues/2800
+    pip install https://github.com/Z3Prover/z3/releases/download/Nightly/z3_solver-4.8.8.0-py2.py3-none-macosx_10_14_x86_64.whl
   fi
 - pip install pytest-cov pytest-codestyle
 - pip install mantle  # for tests.common


### PR DESCRIPTION
Use pre-built wheel for z3. This should speed up the macos build significantly.