### PR TITLE
Add support for poke/expect slice

### DIFF
--- a/fault/tester.py
+++ b/fault/tester.py
@@ -162,7 +162,8 @@ class Tester:
         if isinstance(port, SelectPath):
             if self.is_recursive_type(port[-1]):
                 return recurse(port[-1])
-        elif self.is_recursive_type(port):
+        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
+                self.is_recursive_type(port):
             return recurse(port)
 
         if not isinstance(value, (LoopIndex, actions.FileRead,
@@ -203,7 +204,8 @@ class Tester:
         if isinstance(port, SelectPath):
             if self.is_recursive_type(port[-1]):
                 return recurse(port[-1])
-        elif self.is_recursive_type(port):
+        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
+                self.is_recursive_type(port):
             return recurse(port)
 
         # set defaults

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -175,7 +175,8 @@ class Tester:
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
-        elif isinstance(port.name, m.ref.AnonRef):
+        elif not isinstance(port, fault.WrappedVerilogInternalPort) and\
+                isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 
         if not isinstance(value, (LoopIndex, actions.FileRead,
@@ -224,7 +225,8 @@ class Tester:
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
-        elif isinstance(port.name, m.ref.AnonRef):
+        elif not isinstance(port, fault.WrappedVerilogInternalPort) and\
+                isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 
         # set defaults

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -129,8 +129,7 @@ class Tester:
 
     def is_recursive_type(self, T):
         return issubclass(T, m.Tuple) or issubclass(T, m.Array) and \
-            not issubclass(T.T, m.Digital) or \
-            isinstance(T.name, m.ref.AnonRef)
+            not issubclass(T.T, m.Digital)
 
     def get_type(self, port):
         if isinstance(port, SelectPath):
@@ -175,6 +174,8 @@ class Tester:
             if self.is_recursive_type(type(port[-1])):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
+            return recurse(port)
+        elif isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 
         if not isinstance(value, (LoopIndex, actions.FileRead,
@@ -222,6 +223,8 @@ class Tester:
             if self.is_recursive_type(type(port[-1])):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
+            return recurse(port)
+        elif isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 
         # set defaults

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -172,6 +172,7 @@ class Tester:
         # implement poke
         if isinstance(port, SelectPath):
             if self.is_recursive_type(type(port[-1])) or \
+                    not isinstance(port, fault.WrappedVerilogInternalPort) and \
                     isinstance(port[-1].name, m.ref.AnonRef):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
@@ -223,11 +224,12 @@ class Tester:
 
         if isinstance(port, SelectPath):
             if self.is_recursive_type(type(port[-1])) or \
+                    not isinstance(port, fault.WrappedVerilogInternalPort) and \
                     isinstance(port[-1].name, m.ref.AnonRef):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
-        elif not isinstance(port, fault.WrappedVerilogInternalPort) and\
+        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
                 isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -1,4 +1,5 @@
 import inspect
+import fault
 import warnings
 import logging
 import magma as m

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -172,8 +172,8 @@ class Tester:
         # implement poke
         if isinstance(port, SelectPath):
             if self.is_recursive_type(type(port[-1])) or \
-                    not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                    isinstance(port[-1].name, m.ref.AnonRef):
+                    (not isinstance(port[-1], fault.WrappedVerilogInternalPort) and \
+                     isinstance(port[-1].name, m.ref.AnonRef)):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
@@ -224,8 +224,8 @@ class Tester:
 
         if isinstance(port, SelectPath):
             if self.is_recursive_type(type(port[-1])) or \
-                    not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                    isinstance(port[-1].name, m.ref.AnonRef):
+                    (not isinstance(port[-1], fault.WrappedVerilogInternalPort) and \
+                     isinstance(port[-1].name, m.ref.AnonRef)):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -171,7 +171,8 @@ class Tester:
 
         # implement poke
         if isinstance(port, SelectPath):
-            if self.is_recursive_type(type(port[-1])):
+            if self.is_recursive_type(type(port[-1])) or \
+                    isinstance(port[-1].name, m.ref.AnonRef):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
@@ -221,7 +222,8 @@ class Tester:
                     self.expect(p, v, strict, **kwargs)
 
         if isinstance(port, SelectPath):
-            if self.is_recursive_type(type(port[-1])):
+            if self.is_recursive_type(type(port[-1])) or \
+                    isinstance(port[-1].name, m.ref.AnonRef):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -127,6 +127,8 @@ class Tester:
         raise NotImplementedError(target)
 
     def is_recursive_type(self, T):
+        if isinstance(T, fault.WrappedVerilogInternalPort):
+            return False
         return isinstance(T, m.TupleType) or isinstance(T, m.ArrayType) and \
             not isinstance(T.T, (m._BitKind, m.BitType)) or \
             isinstance(T.name, m.ref.AnonRef)
@@ -163,8 +165,7 @@ class Tester:
         if isinstance(port, SelectPath):
             if self.is_recursive_type(port[-1]):
                 return recurse(port[-1])
-        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                self.is_recursive_type(port):
+        elif self.is_recursive_type(port):
             return recurse(port)
 
         if not isinstance(value, (LoopIndex, actions.FileRead,
@@ -205,8 +206,7 @@ class Tester:
         if isinstance(port, SelectPath):
             if self.is_recursive_type(port[-1]):
                 return recurse(port[-1])
-        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
-                self.is_recursive_type(port):
+        elif self.is_recursive_type(port):
             return recurse(port)
 
         # set defaults

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -778,9 +778,14 @@ def test_poke_bitwise(target, simulator):
     tester.circuit.I = 0
     tester.eval()
     tester.circuit.I[0] = 1
+    tester.circuit.I[2] = 1
     tester.eval()
     tester.circuit.O[0].expect(1)
     tester.circuit.O[1].expect(0)
+    tester.circuit.O[2].expect(1)
+    tester.circuit.I[1:] = 0b01
+    tester.eval()
+    tester.circuit.O[1:].expect(0b01)
     with tempfile.TemporaryDirectory(dir=".") as _dir:
         kwargs = {"target": target, "directory": _dir}
         if target == "system-verilog":


### PR DESCRIPTION
Adds the ability to poke/expect on a slice of bits, e.g.
```
    tester.circuit.I[1:] = 0b01
    tester.eval()
    tester.circuit.O[1:].expect(0b01)
```