### PR TITLE
Add generic assert_

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -356,3 +356,14 @@ class Var(Action, expression.Expression):
 
     def retarget(self, new_circuit, clock):
         return Var(self.name, self._type)
+
+
+class Assert(Action):
+    def __init__(self, expr):
+        self.expr = expr
+
+    def __str__(self):
+        return f"Assert({self.expr})"
+
+    def retarget(self, new_circuit, clock):
+        return Assert(self.expr)

--- a/fault/cosa_target.py
+++ b/fault/cosa_target.py
@@ -100,6 +100,9 @@ class CoSATarget(VerilogTarget):
     def make_get_value(self, i, action):
         raise NotImplementedError()
 
+    def make_assert(self, i, action):
+        raise NotImplementedError()
+
     def make_if(self, i, action):
         raise NotImplementedError()
 

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -286,11 +286,11 @@ class SystemVerilogTarget(VerilogTarget):
             left = self.compile_expression(value.left)
             right = self.compile_expression(value.right)
             op = value.op_str
-            return f"{left} {op} {right}"
+            return f"({left}) {op} ({right})"
         elif isinstance(value, expression.UnaryOp):
             operand = self.compile_expression(value.operand)
             op = value.op_str
-            return f"{op} {operand}"
+            return f"{op} ({operand})"
         elif isinstance(value, PortWrapper):
             return f"dut.{value.select_path.system_verilog_path}"
         elif isinstance(value, actions.Peek):
@@ -401,6 +401,10 @@ class SystemVerilogTarget(VerilogTarget):
         fmt = action.get_format()
         value = self.make_name(action.port)
         return [f'$fwrite({fd_var}, "{fmt}\\n", {value});']
+
+    def make_assert(self, i, action):
+        expr_str = self.compile_expression(action.expr)
+        return [f'if (!({expr_str})) $error("{expr_str} failed");']
 
     def make_expect(self, i, action):
         # don't do anything if any value is OK

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -180,6 +180,11 @@ class Tester:
         """
         self.actions.append(actions.Print(format_str, *args))
 
+    def assert_(self, expr):
+        if not isinstance(expr, expression.Expression):
+            raise TypeError("Expected instance of Expression")
+        self.actions.append(actions.Assert(expr))
+
     def expect(self, port, value, strict=None, caller=None, **kwargs):
         """
         Expect the current value of `port` to be `value`

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -506,6 +506,18 @@ class VerilatorTarget(VerilogTarget):
         value = f'top->{verilator_name(action.port.name)}'
         return [f'fprintf({fd_var}, "{fmt}\\n", {value});']
 
+    def make_assert(self, i, action):
+        expr_str = self.compile_expression(action.expr)
+        return f"""
+if (!({expr_str})) {{
+    std::cerr << "{expr_str} failed" << std::endl;
+    #if VM_TRACE
+      tracer->close();
+    #endif
+    exit(1);
+}}
+    """.splitlines()
+
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -152,6 +152,8 @@ class VerilogTarget(Target):
             return self.make_delay(i, action)
         elif isinstance(action, actions.GetValue):
             return self.make_get_value(i, action)
+        elif isinstance(action, actions.Assert):
+            return self.make_assert(i, action)
         raise NotImplementedError(action)
 
     @abstractmethod
@@ -244,6 +246,10 @@ class VerilogTarget(Target):
 
     @abstractmethod
     def make_get_value(self, i, action):
+        pass
+
+    @abstractmethod
+    def make_assert(self, i, action):
         pass
 
     def make_block(self, i, name, cond, actions):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -800,6 +800,26 @@ def test_poke_bitwise_nested(target, simulator):
     tester.circuit.O[0][1].expect(0)
     tester.circuit.O[1][0].expect(0)
     tester.circuit.O[1][1].expect(1)
+    tester.assert_((tester.circuit.O[0] | tester.circuit.O[1]) == 0b11)
+    with tempfile.TemporaryDirectory(dir=".") as _dir:
+        _dir = "build"
+        kwargs = {"target": target, "directory": _dir}
+        if target == "system-verilog":
+            kwargs["simulator"] = simulator
+        tester.compile_and_run(**kwargs)
+    tester.assert_((tester.circuit.O[0] | tester.circuit.O[1]) == 0b01)
+
+
+@pytest.mark.xfail(strict=True)
+def test_generic_expect_fail(target, simulator):
+    circ = TestNestedArraysCircuit
+    tester = fault.Tester(circ)
+    tester.circuit.I = 0
+    tester.eval()
+    tester.circuit.I[0][0] = 1
+    tester.circuit.I[1][1] = 1
+    tester.eval()
+    tester.assert_((tester.circuit.O[0] | tester.circuit.O[1]) == 0b01)
     with tempfile.TemporaryDirectory(dir=".") as _dir:
         _dir = "build"
         kwargs = {"target": target, "directory": _dir}

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -807,7 +807,6 @@ def test_poke_bitwise_nested(target, simulator):
         if target == "system-verilog":
             kwargs["simulator"] = simulator
         tester.compile_and_run(**kwargs)
-    tester.assert_((tester.circuit.O[0] | tester.circuit.O[1]) == 0b01)
 
 
 @pytest.mark.xfail(strict=True)


### PR DESCRIPTION
Allows the assertion of generic expressions (rather than just expecting on port values), e.g.
```
    tester.assert_((tester.circuit.O[0] | tester.circuit.O[1]) == 0b01)
```