### PR TITLE
Raise attribute error instead of exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
     # speed up the build process until it's fixed at z3
     # see https://github.com/Z3Prover/z3/issues/2800
     pip install https://github.com/Z3Prover/z3/releases/download/Nightly/z3_solver-4.8.8.0-py2.py3-none-macosx_10_14_x86_64.whl
+    pip install kratos==0.0.25
   fi
 - pip install pytest-cov pytest-codestyle
 - pip install mantle>=2.0.0  # for tests.common

--- a/fault/wrapper.py
+++ b/fault/wrapper.py
@@ -77,13 +77,11 @@ class PortWrapper(expression.Expression):
     def __getattr__(self, key):
         try:
             object.__getattribute__(self, "init_done")
-            if not isinstance(self.port, m.Tuple):
-                raise Exception(f"Can only use getattr with tuples, "
-                                f"not {type(self.port)}")
-            select_path = self.select_path
-            return PortWrapper(getattr(self.port, key), self.parent)
         except AttributeError:
             return object.__getattribute__(self, key)
+        if isinstance(self.port, m.Tuple):
+            return PortWrapper(getattr(self.port, key), self.parent)
+        return object.__getattribute__(self, key)
 
     def __setattr__(self, key, value):
         try:


### PR DESCRIPTION
This adjusts the code so that it will raise an AttributeError (implicitly) rather than explicitly raising a plain Exception so `hasattr` will work.