### PR TITLE
Fixes for bugs found when implementing OpenRAM experiment

### DIFF
--- a/examples/sram_snm.py
+++ b/examples/sram_snm.py
@@ -36,8 +36,7 @@ def run(noise=0.0):
     )
 
     # instantiate the tester
-    tester = fault.Tester(dut, expect_strict_default=True,
-                          poke_delay_default=0)
+    tester = fault.Tester(dut, poke_delay_default=0)
 
     # initialize
     tester.poke(dut.lbl, fault.HiZ)

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,3 +1,4 @@
+from .wrapped_internal_port import WrappedVerilogInternalPort
 from .real_type import RealIn, RealOut, RealKind, RealType
 from .elect_type import ElectIn, ElectOut, ElectKind, ElectType
 from .tester import Tester
@@ -11,14 +12,3 @@ from .tester_samples import (SRAMTester, InvTester, BufTester,
 from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
-
-
-class WrappedVerilogInternalPort:
-    def __init__(self, path: str, type_):
-        """
-        path: <instance_name>.<port_name> (can nest instances)
-
-        type_: magma type of the signal (e.g. m.Bits(2))
-        """
-        self.path = path
-        self.type_ = type_

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -603,7 +603,7 @@ class SystemVerilogTarget(VerilogTarget):
             top_module = f'{self.circuit_name}_tb'
 
         # add timescale
-        timescale=f'`timescale {self.timescale}'
+        timescale = f'`timescale {self.timescale}'
 
         # fill out values in the testbench template
         src = src_tpl.format(

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -21,6 +21,7 @@ from numbers import Number
 
 
 src_tpl = """\
+{timescale}
 module {top_module};
 {declarations}
 {assigns}
@@ -601,8 +602,12 @@ class SystemVerilogTarget(VerilogTarget):
         else:
             top_module = f'{self.circuit_name}_tb'
 
+        # add timescale
+        timescale=f'`timescale {self.timescale}'
+
         # fill out values in the testbench template
         src = src_tpl.format(
+            timescale=timescale,
             declarations=declarations,
             assigns=assigns,
             initial_body=initial_body,

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -65,7 +65,7 @@ class Tester:
 
     def __init__(self, circuit: m.Circuit, clock: m.Clock = None,
                  reset: m.Reset = None, poke_delay_default=None,
-                 expect_strict_default=False):
+                 expect_strict_default=True):
         """
         `circuit`: the device under test (a magma circuit)
         `clock`: optional, a port from `circuit` corresponding to the clock

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -224,7 +224,7 @@ class Tester:
             if isinstance(value, dict):
                 for k, v in value.items():
                     self.expect(port=getattr(port, k), value=v, strict=strict,
-                                caller=caller)
+                                caller=caller, **kwargs)
             else:
                 _value = value
                 if isinstance(_value, int):

--- a/fault/tester.py
+++ b/fault/tester.py
@@ -10,7 +10,6 @@ try:
 except ModuleNotFoundError:
     MagmaSimulatorTarget = None
     pass
-
 from fault.vector_builder import VectorBuilder
 from fault.value_utils import make_value
 from fault.verilator_target import VerilatorTarget
@@ -22,6 +21,7 @@ from fault.circuit_utils import check_interface_is_subset
 from fault.wrapper import CircuitWrapper, PortWrapper
 from fault.file import File
 from fault.select_path import SelectPath
+from fault.wrapped_internal_port import WrappedVerilogInternalPort
 import fault.expression as expression
 import os
 import inspect
@@ -134,7 +134,7 @@ class Tester:
     def get_type(self, port):
         if isinstance(port, SelectPath):
             port = port[-1]
-        if isinstance(port, fault.WrappedVerilogInternalPort):
+        if isinstance(port, WrappedVerilogInternalPort):
             type_ = port.type_
             print(port.type_)
         else:
@@ -171,13 +171,13 @@ class Tester:
 
         # implement poke
         if isinstance(port, SelectPath):
-            if self.is_recursive_type(type(port[-1])) or \
-                    (not isinstance(port[-1], fault.WrappedVerilogInternalPort) and \
-                     isinstance(port[-1].name, m.ref.AnonRef)):
+            if (self.is_recursive_type(type(port[-1]))
+                or (not isinstance(port[-1], WrappedVerilogInternalPort) and
+                    isinstance(port[-1].name, m.ref.AnonRef))):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
-        elif not isinstance(port, fault.WrappedVerilogInternalPort) and\
+        elif not isinstance(port, WrappedVerilogInternalPort) and\
                 isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 
@@ -234,13 +234,13 @@ class Tester:
                                 **kwargs)
 
         if isinstance(port, SelectPath):
-            if self.is_recursive_type(type(port[-1])) or \
-                    (not isinstance(port[-1], fault.WrappedVerilogInternalPort) and \
-                     isinstance(port[-1].name, m.ref.AnonRef)):
+            if (self.is_recursive_type(type(port[-1]))
+                or (not isinstance(port[-1], WrappedVerilogInternalPort)
+                    and isinstance(port[-1].name, m.ref.AnonRef))):
                 return recurse(port[-1])
         elif self.is_recursive_type(type(port)):
             return recurse(port)
-        elif not isinstance(port, fault.WrappedVerilogInternalPort) and \
+        elif not isinstance(port, WrappedVerilogInternalPort) and \
                 isinstance(port.name, m.ref.AnonRef):
             return recurse(port)
 

--- a/fault/tester_samples.py
+++ b/fault/tester_samples.py
@@ -4,14 +4,17 @@ from abc import ABCMeta, abstractmethod
 
 class GenericCellTester(fault.Tester, metaclass=ABCMeta):
     def __init__(self, circuit, *args, n_trials=100, supply0='vss',
-                 supply1='vdd', **kwargs):
+                 supply1='vdd', td=100e-9, poke_delay_default=0,
+                 expect_strict_default=True, **kwargs):
         # call super constructor
-        super().__init__(circuit, *args, **kwargs)
+        super().__init__(circuit, *args, poke_delay_default=poke_delay_default,
+                         expect_strict_default=expect_strict_default, **kwargs)
 
         # save settings
         self.supply0 = supply0
         self.supply1 = supply1
         self.n_trials = n_trials
+        self.td = td
 
         # define the test
         self.define_test()
@@ -21,6 +24,7 @@ class GenericCellTester(fault.Tester, metaclass=ABCMeta):
 
     def poke(self, name, *args, **kwargs):
         super().poke(getattr(self._circuit, name), *args, **kwargs)
+        self.delay(self.td)
 
     def poke_optional(self, name, *args, **kwargs):
         if self.has_pin(name):

--- a/fault/tester_samples.py
+++ b/fault/tester_samples.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 
 class GenericCellTester(fault.Tester, metaclass=ABCMeta):
     def __init__(self, circuit, *args, n_trials=100, supply0='vss',
-                 supply1='vdd', td=100e-9, poke_delay_default=0, **kwargs):
+                 supply1='vdd', poke_delay_default=100e-9, **kwargs):
         # call super constructor
         super().__init__(circuit, *args, poke_delay_default=poke_delay_default,
                          **kwargs)
@@ -13,7 +13,6 @@ class GenericCellTester(fault.Tester, metaclass=ABCMeta):
         self.supply0 = supply0
         self.supply1 = supply1
         self.n_trials = n_trials
-        self.td = td
 
         # define the test
         self.define_test()
@@ -23,7 +22,6 @@ class GenericCellTester(fault.Tester, metaclass=ABCMeta):
 
     def poke(self, name, *args, **kwargs):
         super().poke(getattr(self._circuit, name), *args, **kwargs)
-        self.delay(self.td)
 
     def poke_optional(self, name, *args, **kwargs):
         if self.has_pin(name):

--- a/fault/tester_samples.py
+++ b/fault/tester_samples.py
@@ -4,11 +4,10 @@ from abc import ABCMeta, abstractmethod
 
 class GenericCellTester(fault.Tester, metaclass=ABCMeta):
     def __init__(self, circuit, *args, n_trials=100, supply0='vss',
-                 supply1='vdd', td=100e-9, poke_delay_default=0,
-                 expect_strict_default=True, **kwargs):
+                 supply1='vdd', td=100e-9, poke_delay_default=0, **kwargs):
         # call super constructor
         super().__init__(circuit, *args, poke_delay_default=poke_delay_default,
-                         expect_strict_default=expect_strict_default, **kwargs)
+                         **kwargs)
 
         # save settings
         self.supply0 = supply0

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -223,7 +223,6 @@ class VerilatorTarget(VerilogTarget):
             value = f"({value} >> {i}) & 1"
         return value
 
-
     def make_poke(self, i, action):
         if self.verilator_version > 3.874:
             prefix = f"{self.circuit_name}"

--- a/fault/wrapped_internal_port.py
+++ b/fault/wrapped_internal_port.py
@@ -1,0 +1,9 @@
+class WrappedVerilogInternalPort:
+    def __init__(self, path: str, type_):
+        """
+        path: <instance_name>.<port_name> (can nest instances)
+
+        type_: magma type of the signal (e.g. m.Bits(2))
+        """
+        self.path = path
+        self.type_ = type_

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,11 @@ max-line-length = 80
 
 # E741: do not use variables named 'l', 'O', or 'I'
 # We ignore this because I and O is currently idiomatic magma for port names
-ignore = E741
+# W503: line break before binary operator
+# W504: line break before after operator
+# Ignore W503 and W504 since they are contradictory
+ignore = E741,W503,W504
 
 [tool:pytest]
-codestyle_ignore = E741
+codestyle_ignore = E741,W503,W504
 codestyle_max_line_length = 80

--- a/tests/test_bidir.py
+++ b/tests/test_bidir.py
@@ -18,14 +18,16 @@ def test_bidir(target, simulator):
     )
 
     # instantiate the tester
-    tester = fault.Tester(bidir)
+    tester = fault.Tester(bidir, expect_strict_default=True,
+                          poke_delay_default=0)
 
     # define common pattern for running all cases
     def run_case(a_in, b_in, a_out, b_out):
         tester.poke(bidir.a, a_in)
         tester.poke(bidir.b, b_in)
-        tester.expect(bidir.a, a_out, strict=True)
-        tester.expect(bidir.b, b_out, strict=True)
+        tester.delay(10e-9)
+        tester.expect(bidir.a, a_out)
+        tester.expect(bidir.b, b_out)
 
     # walk through all of the cases that produce a 0 or 1 output
     run_case(1, 1, 1, 1)

--- a/tests/test_bidir.py
+++ b/tests/test_bidir.py
@@ -18,8 +18,7 @@ def test_bidir(target, simulator):
     )
 
     # instantiate the tester
-    tester = fault.Tester(bidir, expect_strict_default=True,
-                          poke_delay_default=0)
+    tester = fault.Tester(bidir, poke_delay_default=0)
 
     # define common pattern for running all cases
     def run_case(a_in, b_in, a_out, b_out):

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -25,5 +25,5 @@ def test_ext_vlog(target, simulator):
         simulator=simulator,
         ext_libs=[Path('tests/verilog/myinv.v').resolve()],
         ext_model_file=True,
-        tmp_dir=True
+        tmp_dir=False
     )

--- a/tests/test_ext_vlog.py
+++ b/tests/test_ext_vlog.py
@@ -25,5 +25,5 @@ def test_ext_vlog(target, simulator):
         simulator=simulator,
         ext_libs=[Path('tests/verilog/myinv.v').resolve()],
         ext_model_file=True,
-        tmp_dir=False
+        tmp_dir=True
     )

--- a/tests/test_hi_z.py
+++ b/tests/test_hi_z.py
@@ -19,8 +19,7 @@ def test_hi_z(target, simulator):
     )
 
     # instantiate the tester
-    tester = fault.Tester(hizmod, expect_strict_default=True,
-                          poke_delay_default=0)
+    tester = fault.Tester(hizmod, poke_delay_default=0)
 
     # define common pattern for running all cases
     def run_case(a, b, c):

--- a/tests/test_hi_z.py
+++ b/tests/test_hi_z.py
@@ -19,13 +19,15 @@ def test_hi_z(target, simulator):
     )
 
     # instantiate the tester
-    tester = fault.Tester(hizmod)
+    tester = fault.Tester(hizmod, expect_strict_default=True,
+                          poke_delay_default=0)
 
     # define common pattern for running all cases
     def run_case(a, b, c):
         tester.poke(hizmod.a, a)
         tester.poke(hizmod.b, b)
-        tester.expect(hizmod.c, c, strict=True)
+        tester.delay(10e-9)
+        tester.expect(hizmod.c, c)
 
     # walk through all of the cases that produce a 0 or 1 output
     run_case(1, 1, 1)

--- a/tests/test_setattr_interface.py
+++ b/tests/test_setattr_interface.py
@@ -155,14 +155,17 @@ def test_setattr_x(target, simulator):
         pytest.skip("X not support with Verilator")
     circ = AndCircuit
     tester = Tester(circ)
+    # "0" & "1" -> "0"
     tester.circuit.I0 = 0
     tester.circuit.I1 = 1
     tester.eval()
     tester.circuit.O.expect(0)
+    # "X" & "1" -> "X"
     tester.circuit.I0 = fault.UnknownValue
     tester.circuit.I1 = 1
     tester.eval()
-    tester.circuit.O.expect(0)
+    tester.circuit.O.expect(fault.UnknownValue)
+    # "X" & "X" -> "X"
     tester.circuit.I0 = fault.UnknownValue
     tester.circuit.I1 = fault.UnknownValue
     tester.eval()

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -116,13 +116,14 @@ def test_tester_peek(target, simulator):
     circ = TestBasicClkCircuit
     tester = fault.Tester(circ, circ.CLK)
     tester.poke(circ.I, 0)
+    tester.eval()
     tester.expect(circ.O, 0)
     check(tester.actions[0], Poke(circ.I, 0))
-    check(tester.actions[1], Expect(circ.O, 0))
+    check(tester.actions[2], Expect(circ.O, 0))
     tester.poke(circ.CLK, 0)
-    check(tester.actions[2], Poke(circ.CLK, 0))
+    check(tester.actions[3], Poke(circ.CLK, 0))
     tester.step()
-    check(tester.actions[3], Step(circ.CLK, 1))
+    check(tester.actions[4], Step(circ.CLK, 1))
     with tempfile.TemporaryDirectory(dir=".") as _dir:
         if target == "verilator":
             tester.compile_and_run(target, directory=_dir, flags=["-Wno-fatal"])
@@ -601,6 +602,7 @@ def test_tester_while(target, simulator):
     tester = fault.Tester(circ)
     tester.zero_inputs()
     tester.poke(circ.I, 0)
+    tester.eval()
     loop = tester._while(tester.circuit.O != 1)
     loop.poke(circ.I, 1)
     loop.eval()


### PR DESCRIPTION
This PR contains miscellaneous fixes for bugs encountered while testing multi-target capabilities with designs generated by OpenRAM.  In rough order of importance:
1. **expect_strict_default** now default to **True** for testers.  This means that if the user doesn't specify otherwise, **expect** actions will now use a strict equality check.  It is possible that with this change in default, existing tests written users may fail.  However, test failures caused by this change would almost certainly represent true bugs that users should know about.
2. The testbench generated by SystemVerilogTarget now includes a **`timescale** directive at the top.  This is necessary for **iverilog** because the timescale cannot be specified as a command-line argument for that simulator (and therefore actions that use absolute time like **delay** weren't working correctly in **iverilog**).
3. Fixed an issue in the **expect** action that was preventing **strict** and **caller** arguments from getting through on bus signals.
4. Fixed **GenericCellTester**, **test_setattr_x**, and **test_tester_while**, which was revealed to be broken after making changes 1-3.
5. W503 and W504 are now disabled in the **pycodestyle** check.  These have to do with warnings issued if there is a line break before or after a binary operator.  Since both were enabled by default, it was not possible to make **pycodestyle** happy, and this was generating noisy warnings.
6. SpiceTarget now allows the user to specify a **uic** flag even if there are no user-provided initial conditions.  This is sometimes used as a convergence aid as in the OpenRAM project.