### PR TITLE
Add coverage command to verilator and ncsim

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -56,7 +56,7 @@ class SystemVerilogTarget(VerilogTarget):
                  ext_libs=None, defines=None, flags=None, inc_dirs=None,
                  ext_test_bench=False, top_module=None, ext_srcs=None,
                  use_input_wires=False, parameters=None, disp_type='on_error',
-                 waveform_file=None, use_kratos=False):
+                 waveform_file=None, coverage=False, use_kratos=False):
         """
         circuit: a magma circuit
 
@@ -157,7 +157,7 @@ class SystemVerilogTarget(VerilogTarget):
         # call the super constructor
         super().__init__(circuit, circuit_name, directory, skip_compile,
                          include_verilog_libraries, magma_output,
-                         magma_opts, use_kratos=use_kratos)
+                         magma_opts, coverage=coverage, use_kratos=use_kratos)
 
         # sanity check
         if simulator is None:
@@ -870,6 +870,10 @@ class SystemVerilogTarget(VerilogTarget):
             from kratos_runtime import get_ncsim_flag
             cmd += get_ncsim_flag().split()
 
+        # coverage flags
+        if self.coverage:
+            cmd += ["-coverage", "b", "-covoverwrite"]
+
         # return arg list
         return cmd
 
@@ -927,6 +931,10 @@ class SystemVerilogTarget(VerilogTarget):
             # +vpi -load libkratos-runtime.so:initialize_runtime_vpi -acc+=rw
             from kratos_runtime import get_vcs_flag
             cmd += get_vcs_flag().split()
+
+        # not supported yet
+        if self.coverage:
+            raise NotImplementedError("coverage in vcs is not implemented yet")
 
         if self.dump_waveforms:
             cmd += ['+vcs+vcdpluson', '-debug_pp']

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -39,9 +39,12 @@ double sc_time_stamp () {{       // Called by $time in Verilog
 }}
 
 // function to write_coverage
+#ifdef _VERILATED_COV_H_
 void write_coverage() {{
      VerilatedCov::write("logs/coverage.dat");
 }}
+
+#endif
 
 #if VM_TRACE
 VerilatedVcdC* tracer;
@@ -88,9 +91,9 @@ int main(int argc, char **argv) {{
 #endif
   {kratos_exit_call}
 
-  if ({coverage}) {{
+#ifdef _VERILATED_COV_H_
     write_coverage();
-  }}
+#endif
 
 }}
 """  # nopep8
@@ -582,13 +585,10 @@ if (!({expr_str})) {{
             kratos_start_call = ""
             kratos_exit_call = ""
 
-        coverage = "true" if self.coverage else "false"
-
         src = src_tpl.format(
             includes=includes_src,
             main_body=main_body,
             circuit_name=self.circuit_name,
-            coverage=coverage,
             kratos_start_call=kratos_start_call,
             kratos_exit_call=kratos_exit_call
         )

--- a/fault/verilator_utils.py
+++ b/fault/verilator_utils.py
@@ -18,7 +18,7 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
                        include_verilog_libraries=None,
                        include_directories=None,
                        driver_filename=None, verilator_flags=None,
-                       use_kratos=False):
+                       coverage=False, use_kratos=False):
     # set defaults
     if include_verilog_libraries is None:
         include_verilog_libraries = []
@@ -52,6 +52,8 @@ def verilator_comp_cmd(top=None, verilog_filename=None,
     # vpi flag
     if use_kratos:
         retval += ["--vpi"]
+    if coverage:
+        retval += ["--coverage"]
 
     # return the command
     return retval

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -21,8 +21,8 @@ class VerilogTarget(Target):
 
     def __init__(self, circuit, circuit_name=None, directory="build/",
                  skip_compile=False, include_verilog_libraries=None,
-                 magma_output="verilog", magma_opts=None, use_kratos=False,
-                 value_file_name='get_value_file.txt'):
+                 magma_output="verilog", magma_opts=None, coverage=False,
+                 use_kratos=False, value_file_name='get_value_file.txt'):
         super().__init__(circuit)
 
         if circuit_name is None:
@@ -68,6 +68,8 @@ class VerilogTarget(Target):
         value_file_path = (Path(self.directory) / value_file_name).resolve()
         self.value_file = File(name=str(value_file_path), tester=None,
                                mode='w', chunk_size=None, endianness=None)
+        # coverage
+        self.coverage = coverage
 
     @abstractmethod
     def compile_expression(self, value):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,60 @@
+from fault import Tester
+from .common import TestBasicCircuit
+import tempfile
+import os
+import pytest
+import shutil
+
+
+def test_verilator_coverage():
+    circ = TestBasicCircuit
+    tester = Tester(circ)
+    # dummy input and outputs to provide
+    # input for the coverage
+    tester.zero_inputs()
+    tester.poke(circ.I, 1)
+    tester.eval()
+    tester.expect(circ.O, 1)
+
+    with tempfile.TemporaryDirectory() as temp:
+        tester.compile_and_run(
+            target="verilator",
+            coverage=True,
+            directory=temp
+        )
+
+        # make sure it generates a non empty file
+        cov_file = os.path.join(temp, "logs", "coverage.dat")
+        assert os.path.isfile(cov_file)
+        assert os.stat(cov_file).st_size > 0
+
+
+def test_ncsim_coverage():
+    irun = shutil.which("irun")
+    if irun is None:
+        pytest.skip("ncsim not found")
+    circ = TestBasicCircuit
+    tester = Tester(circ)
+    # dummy input and outputs to provide
+    # input for the coverage
+    tester.zero_inputs()
+    tester.poke(circ.I, 1)
+    tester.eval()
+    tester.expect(circ.O, 1)
+
+    with tempfile.TemporaryDirectory() as temp:
+        tester.compile_and_run(
+            target="system-verilog",
+            simulator="ncsim",
+            coverage=True,
+            directory=temp
+        )
+
+        # make sure it generates a non empty file
+        cov_dir = os.path.join(temp, "cov_work")
+        assert os.path.isdir(cov_dir)
+        assert len(os.listdir(cov_dir)) > 0
+
+
+if __name__ == "__main__":
+    test_ncsim_coverage()


### PR DESCRIPTION
This maybe a duplicate of #65.

What does this PR do:
- Add flag `coverage` to all targets
- Tested on `ncsim` and `Verilator`. Haven't tried `vcs` yet since I'm not an expert in `vcs`; someone needs to help me out there.
- For `Verilator`, the coverage file can be parsed directly, whereas for `ncsim` we need `IMC` tools since it's a gzipped file linked to its compiled model. `kratos` has built-in ability to parse both format. Maybe there is an opportunity for tight integration so that fault can digest coverage information through `kratos`.