### PR TITLE
Allow expect to use file_read

### DIFF
--- a/fault/tester.py
+++ b/fault/tester.py
@@ -245,7 +245,7 @@ class Tester:
             return recurse(port)
 
         # implement expect
-        if not isinstance(value, (actions.Peek, PortWrapper,
+        if not isinstance(value, (actions.Peek, PortWrapper, actions.FileRead,
                                   LoopIndex, expression.Expression)):
             type_ = self.get_type(port)
             value = make_value(type_, value)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -187,6 +187,12 @@ class VerilatorTarget(VerilogTarget):
             return value
         elif isinstance(value, actions.Var):
             return value.name
+        elif isinstance(value, actions.FileRead):
+            mask = "FF" * value.file.chunk_size
+            value = " | ".join(f"{value.file.name_without_ext}_in[{i}]" for
+                               i in range(value.file.chunk_size))
+            value = f"({value}) & 0x{mask}"
+            return value
         return value
 
     def process_signed_values(self, port, value):
@@ -294,11 +300,6 @@ class VerilatorTarget(VerilogTarget):
             return pokes
         else:
             value = action.value
-            if isinstance(value, actions.FileRead):
-                mask = "FF" * value.file.chunk_size
-                value = " | ".join(f"{value.file.name_without_ext}_in[{i}]" for
-                                   i in range(value.file.chunk_size))
-                value = f"({value}) & 0x{mask}"
             value = self.process_value(action.port, value)
             value = self.process_bitwise_assign(action.port, name, value)
             result = [f"top->{name} = {value};"]

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -495,6 +495,7 @@ def test_tester_file_io(target, simulator):
         loop.poke(circ.I, value)
         loop.eval()
         loop.expect(circ.O, loop.index)
+        loop.expect(circ.O, value)
         loop.file_write(file_out, circ.O)
         tester.file_close(file_in)
         tester.file_close(file_out)


### PR DESCRIPTION
#207 

    value = loop.file_read(file_in)
    loop.expect(circ.O, value)

verilator works, generated system-verilog looks legit