### PR TITLE
Optimize ncsim flag usage

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -927,7 +927,8 @@ class SystemVerilogTarget(VerilogTarget):
         cmd += self.def_args(prefix='+define+')
 
         # misc flags
-        cmd += ['-access', '+rwc']
+        if self.dump_waveforms:
+            cmd += ["-access", "r"]
         cmd += ['-sverilog']
         cmd += ['-full64']
         cmd += ['+v2k']

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -868,6 +868,8 @@ class SystemVerilogTarget(VerilogTarget):
         cmd += self.def_args(prefix='+define+')
 
         # misc flags
+        if self.dump_waveforms:
+            cmd += ["-access", "r"]
         cmd += ['-notimingchecks']
         if self.no_warning:
             cmd += ['-neverwarn']
@@ -927,8 +929,6 @@ class SystemVerilogTarget(VerilogTarget):
         cmd += self.def_args(prefix='+define+')
 
         # misc flags
-        if self.dump_waveforms:
-            cmd += ["-access", "r"]
         cmd += ['-sverilog']
         cmd += ['-full64']
         cmd += ['+v2k']


### PR DESCRIPTION
Only use read access flags when dumping VCD. Otherwise no access flags. This should speed up simulation in most cases.

Side note:
I noticed that buildkite agents is blocked by a PR which seems to be run into infinite loop: https://buildkite.com/stanford-aha/fault/builds/1074#e2e03ea3-43f4-40e7-a62e-9de57226e1a2
We should probably set an up limit on how long a test should run on buildkite.