### PR TITLE
Add timeout for BuildKite tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,6 +33,7 @@ steps:
       # upload coverage results
       bash <(curl -s https://codecov.io/bash)
     label: "test"
+    timeout_in_minutes: 60
     agents:
       fault2: "true"
   - command: |


### PR DESCRIPTION
This one-liner simply adds a 60 min timeout to BuildKite tests to prevent tests that are hanging from clogging the BuildKite queue.