### PR TITLE
Init synchronous tester

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -1,7 +1,8 @@
 from .wrapped_internal_port import WrappedVerilogInternalPort
 from .real_type import RealIn, RealOut, RealKind, RealType
 from .elect_type import ElectIn, ElectOut, ElectKind, ElectType
-from .tester import Tester, SymbolicTester, PythonTester, TesterBase
+from .tester import (Tester, SymbolicTester, PythonTester, TesterBase,
+                     SynchronousTester)
 from .power_tester import PowerTester
 from .value import Value, AnyValue, UnknownValue, HiZ
 import fault.random

--- a/fault/tester/__init__.py
+++ b/fault/tester/__init__.py
@@ -2,3 +2,4 @@ from .base import TesterBase
 from .staged_tester import Tester
 from .symbolic_tester import SymbolicTester
 from .interactive_tester import PythonTester
+from .synchronous import SynchronousTester

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -422,3 +422,6 @@ class IfTester(Tester):
 
     def _else(self):
         return ElseTester(self.else_actions, self.circuit, self.clock)
+
+
+StagedTester = Tester

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -1,5 +1,6 @@
 from .staged_tester import StagedTester
 from ..system_verilog_target import SynchronousSystemVerilogTarget
+from ..verilator_target import SynchronousVerilatorTarget
 
 
 class SynchronousTester(StagedTester):
@@ -20,4 +21,7 @@ class SynchronousTester(StagedTester):
         if target == "system-verilog":
             return SynchronousSystemVerilogTarget(self._circuit,
                                                   clock=self.clock, **kwargs)
+        elif target == "system-verilog":
+            return SynchronousVerilatorTarget(self._circuit, clock=self.clock,
+                                              **kwargs)
         return super().make_target(target, **kwargs)

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -5,6 +5,8 @@ from ..system_verilog_target import SynchronousSystemVerilogTarget
 class SynchronousTester(StagedTester):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.clock is None:
+            raise ValueError("SynchronousTester requires a clock")
         # Default clock to 0
         self.poke(self.clock, 0)
 

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -21,7 +21,7 @@ class SynchronousTester(StagedTester):
         if target == "system-verilog":
             return SynchronousSystemVerilogTarget(self._circuit,
                                                   clock=self.clock, **kwargs)
-        elif target == "system-verilog":
+        if target == "system-verilog":
             return SynchronousVerilatorTarget(self._circuit, clock=self.clock,
                                               **kwargs)
         return super().make_target(target, **kwargs)

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -1,0 +1,21 @@
+from .staged_tester import StagedTester
+from ..system_verilog_target import SynchronousSystemVerilogTarget
+
+
+class SynchronousTester(StagedTester):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Default clock to 0
+        self.poke(self.clock, 0)
+
+    def eval(self):
+        raise TypeError("Cannot eval with synchronous tester")
+
+    def advance_cycle(self):
+        self.step(2)
+
+    def make_target(self, target, **kwargs):
+        if target == "system-verilog":
+            return SynchronousSystemVerilogTarget(self._circuit,
+                                                  clock=self.clock, **kwargs)
+        return super().make_target(target, **kwargs)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -696,3 +696,21 @@ if (!({expr_str})) {{
     }}
 """
         return main_body
+
+
+class SynchronousVerilatorTarget(VerilatorTarget):
+    def __init__(self, *args, clock=None, **kwargs):
+        if clock is None:
+            raise ValueError("Clock required")
+        self.clock = verilator_name(clock.name)
+
+    def make_step(self, i, action):
+        code = []
+        for _ in range(action.steps):
+            code.append(f"top->{self.clock} ^= 1;")
+            code.append("top->eval();")
+            code.append("main_time++;")
+            code.append("#if VM_TRACE")
+            code.append("tracer->dump(main_time);")
+            code.append("#endif")
+        return code

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -398,7 +398,8 @@ def test_tester_verilog_wrapped(target, simulator):
     ConfigReg, SimpleALU = m.DefineFromVerilogFile(
         "tests/simple_alu.v", type_map={"CLK": m.In(m.Clock)},
         target_modules=["SimpleALU", "ConfigReg"])
-    SimpleALU.place(ConfigReg())
+    with SimpleALU_inst0.open():
+        ConfigReg()
 
     circ = m.DefineCircuit("top",
                            "a", m.In(m.Bits[16]),

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -398,7 +398,7 @@ def test_tester_verilog_wrapped(target, simulator):
     ConfigReg, SimpleALU = m.DefineFromVerilogFile(
         "tests/simple_alu.v", type_map={"CLK": m.In(m.Clock)},
         target_modules=["SimpleALU", "ConfigReg"])
-    with SimpleALU_inst0.open():
+    with SimpleALU.open():
         ConfigReg()
 
     circ = m.DefineCircuit("top",

--- a/tests/test_tester/test_synchronous.py
+++ b/tests/test_tester/test_synchronous.py
@@ -1,0 +1,33 @@
+from fault import SynchronousTester
+from hwtypes import BitVector
+from ..common import SimpleALU, pytest_sim_params
+
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc, 'verilator', 'system-verilog')
+
+
+def test_synchronous_basic(target, simulator):
+    ops =[
+        lambda x, y: x + y,
+        lambda x, y: x - y,
+        lambda x, y: x * y,
+        lambda x, y: y - x
+    ]
+    tester = SynchronousTester(SimpleALU, SimpleALU.CLK)
+    for i in range(4):
+        tester.circuit.a = a = BitVector.random(16)
+        tester.circuit.b = b = BitVector.random(16)
+        tester.circuit.config_data = i
+        tester.circuit.config_en = 1
+        tester.advance_cycle()
+        # Make sure enable low works
+        tester.circuit.config_data = BitVector.random(2)
+        tester.circuit.config_en = 0
+        tester.circuit.c.expect(ops[i](a, b))
+        tester.advance_cycle()
+
+    if target == "verilator":
+        tester.compile_and_run("verilator", flags=['-Wno-unused'])
+    else:
+        tester.compile_and_run(target, simulator=simulator)

--- a/tests/test_tester/test_synchronous.py
+++ b/tests/test_tester/test_synchronous.py
@@ -8,7 +8,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_synchronous_basic(target, simulator):
-    ops =[
+    ops = [
         lambda x, y: x + y,
         lambda x, y: x - y,
         lambda x, y: x * y,


### PR DESCRIPTION
This adds an initial version of the synchronous tester.  This removes the ability to call `eval` and `step` directly, and instead presents an `advance_cycle` interface (which call step internally).

During code generation, `step` translates to `#5` (where 5 is parametrizable) which corresponds to a half-cycle.  `advance_cycle` always advances two steps (so you get a `#10` out).  The synchronous tester requires a clock, and this clock is used to generate an `always #5 CLK = ~CLK`.  Again the delay is parametrizable.  In the future, we could add support for multiple, parallel clock drivers, but I don't think this is an immediate use case.

The verilator target doesn't make any changes to the code generation currently because I think the interface should satisfy the desired behavior, but we can update it we find any semantic discrepancies.

The main change here from the original tester is disallowing `eval` (which relied on pound delay to implement) so now the output waveform should be consistent with the clock ticks.  When using `step` in verilator, it similarly will only advance simulator time in the waveform once during step (so you don't get the intermediated poke eval time steps).