### PR TITLE
Add flatten method to real_type

### DIFF
--- a/fault/real_type.py
+++ b/fault/real_type.py
@@ -23,6 +23,9 @@ class RealType(Type):
     def driven(self):
         return self._wire.driven()
 
+    def flatten(self):
+        return [self]
+
 
 class RealKind(Kind):
     __hash__ = Kind.__hash__


### PR DESCRIPTION
This is a tiny change to fix real_type after a recent change to magma. I can't run all the tests on my machine since I don't have all the simulators installed, but it did fix some things at least.