### PR TITLE
Property Prototype

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
       # install python dependencies for testing
       pip install pytest-cov pytest-codestyle
       pip install --upgrade "mantle>=2.0.0"
-      pip install vcdvcd
+      pip install vcdvcd decorator
 
       # install fault
       pip install -e .
@@ -49,7 +49,7 @@ steps:
       # install python dependencies for testing
       pip install wheel
       pip install pytest-cov pytest-codestyle
-      pip install vcdvcd
+      pip install vcdvcd decorator
       pip install --upgrade "mantle>=2.0.0"
 
       # install fault

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           pip install pytest
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
-          pip install vcdvcd
+          pip install vcdvcd decorator
           pip install .
 
     - name: Pytest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
           pip install pytest
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
-          pip install vcdvcd
+          pip install vcdvcd decorator
           pip install .
 
     - name: Pytest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
           pip install pytest
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
-          pip install vcdvcd
+          pip install vcdvcd decorator
           pip install .
     - name: Pytest
       shell: bash -l {0}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install verilator
       shell: bash
       run: |
-          brew upgrade
+          brew update
           brew install verilator gmp mpfr libmpc
           verilator --version
     - name: Install Python packages

--- a/doc/property.md
+++ b/doc/property.md
@@ -6,6 +6,13 @@ a magic implementation of the `__or__` and `__ror__` methods to define custom
 "infix" operators.  The second provides an interface to provide strings
 containing SVA operator syntax.
 # Infix Operator Interface
+This interface overloads the use of the `|` operator to define a "custom infix"
+operator.  Here's an example of a property where `io.I` being high implies that
+the value (driver) of `io.O` will be high one cycle later.
+```python
+f.assert_(io.I | f.implies | f.delay[1] | (io.O.value() == 0),
+          on=f.posedge(io.CLK))
+```
 ## Operators
 * `f.implies` corresponds to SVA `|->`
 * `f.delay[N]` corresponds to SVA `##N`

--- a/doc/property.md
+++ b/doc/property.md
@@ -1,0 +1,42 @@
+**NOTE** Property support is experimental, please submit bug reports and
+feature requests via GitHub Issues.
+
+Fault provides two interfaces for defining temporal assertions.  The firt uses
+a magic implementation of the `__or__` and `__ror__` methods to define custom
+"infix" operators.  The second provides an interface to provide strings
+containing SVA operator syntax.
+# Infix Operator Interface
+## Operators
+* `f.implies` corresponds to SVA `|->`
+* `f.delay[N]` corresponds to SVA `##N`
+* `f.delay[M:N]` corresponds to SVA `##[M:N]`
+* `f.delay[0:]` corresponds to SVA `##[*]`
+* `f.delay[1:]` corresponds to SVA `##[+]`
+* `f.repeat[N]` corresponds to SVA `[*N]`
+* `f.repeat[0:]` corresponds to SVA `[*]`
+* `f.repeat[1:]` corresponds to SVA `[+]`
+* `f.goto[N]` corresponds to SVA `[-> N]`
+* `f.goto[M:N]` corresponds to SVA `[-> M:N]`
+
+# SVA 
+Use the `f.sva` function to construct sva properties by interleaving magma
+signal/expressions and SVA operators. Here's a simple example:
+```python
+f.assert_(f.sva(io.I, "|-> ##1", io.O.value() == 0),
+          on=f.posedge(io.CLK))
+```
+
+# Examples
+## Basic assertion
+
+```python
+class Main(m.Circuit):
+    io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
+    io.O @= m.Register(T=m.Bits[8])()(io.I)
+    # SVA
+    f.assert_(f.sva(io.I, "|-> ##1", io.O.value() == 0),
+              on=f.posedge(io.CLK))
+    # Infix
+    f.assert_(io.I | f.implies | f.delay[1] | (io.O.value() == 0),
+              on=f.posedge(io.CLK))
+```

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -13,5 +13,6 @@ from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
 
-from fault.property import assert_, implies, delay, posedge, repeat, goto
+from fault.property import (assert_, implies, delay, posedge, repeat, goto,
+                            sequence)
 from fault.sva import sva

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -13,5 +13,5 @@ from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
 
-from fault.property import assert_, implies, delay, posedge
+from fault.property import assert_, implies, delay, posedge, repeat
 from fault.sva import sva

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -12,4 +12,5 @@ from .tester_samples import (SRAMTester, InvTester, BufTester,
 from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
+
 from fault.property import assert_, implies, delay, posedge

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -12,3 +12,4 @@ from .tester_samples import (SRAMTester, InvTester, BufTester,
 from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
+from fault.property import assert_, implies, delay, posedge

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -13,5 +13,5 @@ from .random import random_bit, random_bv
 from .util import clog2
 from .spice_target import A2DError
 
-from fault.property import assert_, implies, delay, posedge, repeat
+from fault.property import assert_, implies, delay, posedge, repeat, goto
 from fault.sva import sva

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -14,3 +14,4 @@ from .util import clog2
 from .spice_target import A2DError
 
 from fault.property import assert_, implies, delay, posedge
+from fault.sva import sva

--- a/fault/property.py
+++ b/fault/property.py
@@ -94,7 +94,16 @@ class _Compiler:
                 result += self._compile(value.lhs) + " "
             num_cycles = value.num_cycles
             if isinstance(num_cycles, slice):
-                num_cycles = f"[{num_cycles.start}:{num_cycles.stop}]"
+                start = num_cycles.start
+                stop = num_cycles.stop
+                if stop is None:
+                    if start not in {0, 1}:
+                        raise ValueError("Variable length delay only supports "
+                                         "zero or more ([0:]) or one or more "
+                                         "([1:]) cycles")
+                    num_cycles = {0: "[*]", 1: "[+]"}[start]
+                else:
+                    num_cycles = f"[{start}:{stop}]"
             return result + f"##{num_cycles} {self._compile(value.rhs)}"
         if isinstance(value, m.Type):
             key = f"x{len(self.format_args)}"

--- a/fault/property.py
+++ b/fault/property.py
@@ -97,9 +97,9 @@ class _Compiler:
         return compiled, self.format_args
 
 
-def assert_(prop, name, on):
+def assert_(prop, on):
     prop, format_args = _Compiler().compile(prop)
     event_str = on.compile(format_args)
     m.inline_verilog(
-        f"{name}: assert property ({event_str} {prop});", **format_args
+        f"assert property ({event_str} {prop});", **format_args
     )

--- a/fault/property.py
+++ b/fault/property.py
@@ -2,6 +2,8 @@ from functools import partial
 
 import magma as m
 
+from fault.sva import SVAProperty
+
 
 class Property:
     pass
@@ -90,6 +92,16 @@ class _Compiler:
             key = f"x{len(self.format_args)}"
             self.format_args[key] = value
             return f"{{{key}}}"
+        if isinstance(value, SVAProperty):
+            property_str = ""
+            for arg in value.args:
+                if isinstance(arg, str):
+                    property_str += f" {arg} "
+                else:
+                    key = f"x{len(self.format_args)}"
+                    self.format_args[key] = arg
+                    property_str += f" {{{key}}} "
+            return property_str
         raise NotImplementedError(type(value))
 
     def compile(self, prop):

--- a/fault/property.py
+++ b/fault/property.py
@@ -1,0 +1,105 @@
+from functools import partial
+
+import magma as m
+
+
+class Property:
+    pass
+
+
+class Infix:
+    def __init__(self, func):
+        self.func = func
+
+    def __or__(self, other):
+        return self.func(other)
+
+    def __ror__(self, other):
+        return Infix(partial(self.func, other))
+
+
+class Implies(Property):
+    def __init__(self, antecedent, consequent):
+        self.antecedent = antecedent
+        self.consequent = consequent
+
+    def __or__(self, other):
+        self.consequent = self.consequent | other
+        return self
+
+
+@Infix
+def implies(antecedent, consequent):
+    return Implies(antecedent, consequent)
+
+
+class Delay(Property):
+    def __init__(self, num_cycles):
+        self.num_cycles = num_cycles
+        self.lhs = None
+        self.rhs = None
+
+    def __or__(self, other):
+        if self.rhs is not None:
+            self.rhs = self.rhs | other
+        else:
+            self.rhs = other
+        return self
+
+    def __ror__(self, other):
+        self.lhs = other
+        return self
+
+
+class DelayOp:
+    def __getitem__(self, val):
+        return Delay(val)
+
+
+delay = DelayOp()
+
+
+class Posedge:
+    def __init__(self, value):
+        self.value = value
+
+    def compile(self, format_args):
+        key = f"x{len(format_args)}"
+        format_args[key] = self.value
+        return f"@(posedge {{{key}}})"
+
+
+def posedge(value):
+    return Posedge(value)
+
+
+class _Compiler:
+    def __init__(self):
+        self.format_args = {}
+
+    def _compile(self, value):
+        if isinstance(value, Implies):
+            return (f"{self._compile(value.antecedent)} |-> "
+                    f"{self._compile(value.consequent)}")
+        if isinstance(value, Delay):
+            result = ""
+            if value.lhs:
+                result += self._compile(value.lhs) + " "
+            return result + f"##{value.num_cycles} {self._compile(value.rhs)}"
+        if isinstance(value, m.Type):
+            key = f"x{len(self.format_args)}"
+            self.format_args[key] = value
+            return f"{{{key}}}"
+        raise NotImplementedError(type(value))
+
+    def compile(self, prop):
+        compiled = self._compile(prop)
+        return compiled, self.format_args
+
+
+def assert_(prop, name, on):
+    prop, format_args = _Compiler().compile(prop)
+    event_str = on.compile(format_args)
+    m.inline_verilog(
+        f"{name}: assert property ({event_str} {prop});", **format_args
+    )

--- a/fault/property.py
+++ b/fault/property.py
@@ -37,6 +37,11 @@ def implies(antecedent, consequent):
 
 class Delay(Property):
     def __init__(self, num_cycles):
+        if isinstance(num_cycles, slice):
+            if num_cycles.start is None:
+                raise ValueError("Delay slice needs a start value")
+            if num_cycles.step is not None:
+                raise ValueError("Delay slice cannot have a step")
         self.num_cycles = num_cycles
         self.lhs = None
         self.rhs = None
@@ -87,7 +92,10 @@ class _Compiler:
             result = ""
             if value.lhs:
                 result += self._compile(value.lhs) + " "
-            return result + f"##{value.num_cycles} {self._compile(value.rhs)}"
+            num_cycles = value.num_cycles
+            if isinstance(num_cycles, slice):
+                num_cycles = f"[{num_cycles.start}:{num_cycles.stop}]"
+            return result + f"##{num_cycles} {self._compile(value.rhs)}"
         if isinstance(value, m.Type):
             key = f"x{len(self.format_args)}"
             self.format_args[key] = value

--- a/fault/sva.py
+++ b/fault/sva.py
@@ -1,0 +1,7 @@
+class SVAProperty:
+    def __init__(self, args):
+        self.args = args
+
+
+def sva(*args):
+    return SVAProperty(args)

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -88,3 +88,13 @@ def test_variable_delay(sva, capsys):
         tester.advance_cycle()
         tester.compile_and_run("system-verilog", simulator="ncsim",
                                flags=["-sv"], magma_opts={"inline": True})
+        tester.circuit.write = 1
+        tester.circuit.read = 0
+        tester.advance_cycle()
+        tester.advance_cycle()
+        tester.advance_cycle()
+        with pytest.raises(AssertionError):
+            tester.compile_and_run("system-verilog", simulator="ncsim",
+                                   flags=["-sv"], magma_opts={"inline": True})
+        out, _ = capsys.readouterr()
+        assert "Assertion Main_tb.dut.__assert_1 has failed" in out

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,0 +1,29 @@
+import fault as f
+import magma as m
+import shutil
+
+
+def test_basic_assert():
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
+        io.O @= m.Register(T=m.Bits[8])()(io.I)
+        f.assert_(io.I | f.implies | f.delay[1] | io.O, name="O_reg",
+                  on=f.posedge(io.CLK))
+
+    if shutil.which("ncsim"):
+        tester = f.SynchronousTester(Main, Main.CLK)
+        tester.circuit.I = 1
+        tester.advance_cycle()
+        tester.circuit.O.expect(1)
+        tester.circuit.I = 0
+        tester.advance_cycle()
+        tester.circuit.O.expect(0)
+        tester.advance_cycle()
+        tester.circuit.I = 1
+        tester.circuit.O.expect(0)
+        tester.advance_cycle()
+        tester.circuit.I = 0
+        tester.circuit.O.expect(1)
+        tester.advance_cycle()
+        tester.circuit.O.expect(0)
+        tester.compile_and_run("system_verilog", simulator="ncsim")

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -10,6 +10,7 @@ def test_basic_assert():
         io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
         io.O @= m.Register(T=m.Bits[8])()(io.I)
         f.assert_(io.I | f.implies | f.delay[1] | io.O, on=f.posedge(io.CLK))
+        f.assert_(f.sva(io.I, "|-> ##1", io.O), on=f.posedge(io.CLK))
 
     if shutil.which("ncsim"):
         tester = f.SynchronousTester(Main, Main.CLK)
@@ -28,15 +29,20 @@ def test_basic_assert():
         tester.advance_cycle()
         tester.circuit.O.expect(0)
         tester.compile_and_run("system-verilog", simulator="ncsim",
-                               flags=["-sv"])
+                               flags=["-sv"], magma_opts={"inline": True})
 
 
-@pytest.mark.xfail
-def test_basic_assert_fail():
+@pytest.mark.parametrize("sva", [True, False])
+def test_basic_assert_fail(sva, capsys):
     class Main(m.Circuit):
         io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
         io.O @= m.Register(T=m.Bits[8])()(io.I)
-        f.assert_(io.I | f.implies | f.delay[1] | ~io.O, on=f.posedge(io.CLK))
+        if sva:
+            f.assert_(f.sva(io.I, "|-> ##1", io.O.value() == 0),
+                      on=f.posedge(io.CLK))
+        else:
+            f.assert_(io.I | f.implies | f.delay[1] | (io.O.value() == 0),
+                      on=f.posedge(io.CLK))
 
     if shutil.which("ncsim"):
         tester = f.SynchronousTester(Main, Main.CLK)
@@ -45,5 +51,11 @@ def test_basic_assert_fail():
         tester.circuit.I = 0
         tester.advance_cycle()
         tester.advance_cycle()
-        tester.compile_and_run("system-verilog", simulator="ncsim",
-                               flags=["-sv"])
+        tester.circuit.I = 1
+        tester.advance_cycle()
+        tester.advance_cycle()
+        with pytest.raises(AssertionError):
+            tester.compile_and_run("system-verilog", simulator="ncsim",
+                                   flags=["-sv"], magma_opts={"inline": True})
+        out, _ = capsys.readouterr()
+        assert "Assertion Main_tb.dut.__assert_1 has failed" in out

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -27,7 +27,8 @@ def test_basic_assert():
         tester.circuit.O.expect(1)
         tester.advance_cycle()
         tester.circuit.O.expect(0)
-        tester.compile_and_run("system-verilog", simulator="ncsim", flags=["-sv"])
+        tester.compile_and_run("system-verilog", simulator="ncsim",
+                               flags=["-sv"])
 
 
 @pytest.mark.xfail
@@ -44,4 +45,5 @@ def test_basic_assert_fail():
         tester.circuit.I = 0
         tester.advance_cycle()
         tester.advance_cycle()
-        tester.compile_and_run("system-verilog", simulator="ncsim", flags=["-sv"])
+        tester.compile_and_run("system-verilog", simulator="ncsim",
+                               flags=["-sv"])

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -249,8 +249,8 @@ def test_goto_repetition(sva, num_reps, capsys):
             f.assert_(f.sva(io.write == 1, f"[-> {symb}]", '##1', io.read,
                             '##1', io.write), on=f.posedge(io.CLK))
         else:
-            f.assert_((io.write == 1) | f.goto[num_reps] | f.delay[1] | io.read |
-                      f.delay[1] | io.write, on=f.posedge(io.CLK))
+            f.assert_((io.write == 1) | f.goto[num_reps] | f.delay[1] | io.read
+                      | f.delay[1] | io.write, on=f.posedge(io.CLK))
 
     tester = f.SynchronousTester(Main, Main.CLK)
     tester.circuit.write = 1

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,3 +1,4 @@
+import pytest
 import fault as f
 import magma as m
 import shutil
@@ -25,4 +26,21 @@ def test_basic_assert():
         tester.circuit.O.expect(1)
         tester.advance_cycle()
         tester.circuit.O.expect(0)
+        tester.compile_and_run("system-verilog", simulator="ncsim", flags=["-sv"])
+
+
+@pytest.mark.xfail
+def test_basic_assert_fail():
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
+        io.O @= m.Register(T=m.Bits[8])()(io.I)
+        f.assert_(io.I | f.implies | f.delay[1] | ~io.O, on=f.posedge(io.CLK))
+
+    if shutil.which("ncsim"):
+        tester = f.SynchronousTester(Main, Main.CLK)
+        tester.circuit.I = 1
+        tester.advance_cycle()
+        tester.circuit.I = 0
+        tester.advance_cycle()
+        tester.advance_cycle()
         tester.compile_and_run("system-verilog", simulator="ncsim", flags=["-sv"])

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -158,6 +158,12 @@ def test_repetition(sva, capsys):
             tester.circuit.write = 0
             tester.circuit.read = 1
             tester.advance_cycle()
+        # Should fail if we don't see seq2
+        with pytest.raises(AssertionError):
+            tester.compile_and_run("system-verilog", simulator="ncsim",
+                                   flags=["-sv"], magma_opts={"inline": True})
+        out, _ = capsys.readouterr()
+        assert "Assertion Main_tb.dut.__assert_1 has failed" in out
         tester.circuit.write = 0
         tester.circuit.read = 1
         tester.advance_cycle()
@@ -168,5 +174,61 @@ def test_repetition(sva, capsys):
         tester.advance_cycle()
         tester.compile_and_run("system-verilog", simulator="ncsim",
                                flags=["-sv"], magma_opts={"inline": True})
+    else:
+        pytest.skip("need ncsim for SVA test")
+
+
+@pytest.mark.parametrize("sva", [True, False])
+@pytest.mark.parametrize("zero_or_one", [0, 1])
+def test_repetition_or_more(sva, zero_or_one, capsys):
+    # TODO: Parens/precedence with nested sequences (could wrap in seq object?)
+    class Main(m.Circuit):
+        io = m.IO(write=m.In(m.Bit), read=m.In(m.Bit)) + m.ClockIO()
+        if sva:
+            seq0 = f.sva(~io.read, "##1", io.write)
+            seq1 = f.sva(io.read, "##1", io.write)
+            symb = "*" if zero_or_one == 0 else "+"
+            f.assert_(f.sva(seq0, "|-> ##1", io.read, f"[{symb}] ##1", seq1),
+                      on=f.posedge(io.CLK))
+        else:
+            seq0 = ~io.read | f.delay[1] | io.write
+            seq1 = io.read | f.delay[1] | io.write
+            f.assert_(seq0 | f.implies | f.delay[1] | io.read |
+                      f.repeat[zero_or_one:] | f.delay[1] | seq1,
+                      on=f.posedge(io.CLK))
+
+    if shutil.which("ncsim"):
+        for i in range(0, 3):
+            tester = f.SynchronousTester(Main, Main.CLK)
+            tester.circuit.write = 0
+            tester.circuit.read = 0
+            tester.advance_cycle()
+            tester.circuit.write = 1
+            tester.advance_cycle()
+            # Should fail if we don't see seq2
+            with pytest.raises(AssertionError):
+                tester.compile_and_run("system-verilog", simulator="ncsim",
+                                       flags=["-sv"], magma_opts={"inline": True})
+            # do repeated sequence i times
+            for _ in range(i):
+                tester.circuit.write = 0
+                tester.circuit.read = 1
+                tester.advance_cycle()
+            tester.circuit.write = 0
+            tester.circuit.read = 1
+            tester.advance_cycle()
+            tester.circuit.write = 1
+            tester.circuit.read = 0
+            tester.advance_cycle()
+            tester.circuit.write = 0
+            tester.advance_cycle()
+            if i == 0 and zero_or_one == 1:
+                # Should fail on first try (0 times)
+                with pytest.raises(AssertionError):
+                    tester.compile_and_run("system-verilog", simulator="ncsim",
+                                           flags=["-sv"], magma_opts={"inline": True})
+            else:
+                tester.compile_and_run("system-verilog", simulator="ncsim",
+                                       flags=["-sv"], magma_opts={"inline": True})
     else:
         pytest.skip("need ncsim for SVA test")

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -59,3 +59,32 @@ def test_basic_assert_fail(sva, capsys):
                                    flags=["-sv"], magma_opts={"inline": True})
         out, _ = capsys.readouterr()
         assert "Assertion Main_tb.dut.__assert_1 has failed" in out
+
+
+@pytest.mark.parametrize("sva", [True, False])
+def test_variable_delay(sva, capsys):
+    class Main(m.Circuit):
+        io = m.IO(write=m.In(m.Bit), read=m.In(m.Bit)) + m.ClockIO()
+        if sva:
+            f.assert_(f.sva(io.write, "|-> ##[1:2]", io.read),
+                      on=f.posedge(io.CLK))
+        else:
+            f.assert_(io.write | f.implies | f.delay[1:2] | io.read,
+                      on=f.posedge(io.CLK))
+
+    if shutil.which("ncsim"):
+        tester = f.SynchronousTester(Main, Main.CLK)
+        tester.circuit.write = 1
+        tester.advance_cycle()
+        tester.circuit.write = 0
+        tester.circuit.read = 1
+        tester.advance_cycle()
+        tester.circuit.write = 1
+        tester.circuit.read = 0
+        tester.advance_cycle()
+        tester.circuit.write = 0
+        tester.advance_cycle()
+        tester.circuit.read = 1
+        tester.advance_cycle()
+        tester.compile_and_run("system-verilog", simulator="ncsim",
+                               flags=["-sv"], magma_opts={"inline": True})

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -136,37 +136,36 @@ def test_variable_delay(sva, capsys):
 @requires_ncsim
 @pytest.mark.parametrize("sva", [True, False])
 def test_repetition(sva, capsys):
-    # TODO: Parens/precedence with nested sequences (could wrap in seq object?)
     class Main(m.Circuit):
         io = m.IO(write=m.In(m.Bit), read=m.In(m.Bit)) + m.ClockIO()
         N = 2
         if sva:
-            seq0 = f.sva(~io.read, "##1", io.write)
-            seq1 = f.sva(io.read, "##1", io.write)
-            f.assert_(f.sva(seq0, "|-> ##1", io.read, f"[*{N}] ##1", seq1),
-                      on=f.posedge(io.CLK))
+            seq0 = f.sequence(f.sva(~io.read, "##1", io.write))
+            seq1 = f.sequence(f.sva(io.read, "##1", io.write))
+            f.assert_(f.sva(~io.read & ~io.write, "[*2] |->", seq0,
+                            f"[*{N}] ##1", seq1), on=f.posedge(io.CLK))
         else:
-            seq0 = ~io.read | f.delay[1] | io.write
-            seq1 = io.read | f.delay[1] | io.write
-            f.assert_(seq0 | f.implies | f.delay[1] | io.read | f.repeat[N] |
-                      f.delay[1] | seq1, on=f.posedge(io.CLK))
+            seq0 = f.sequence(~io.read | f.delay[1] | io.write)
+            seq1 = f.sequence(io.read | f.delay[1] | io.write)
+            f.assert_(~io.read & ~io.write | f.repeat[2] | f.implies | seq0 |
+                      f.repeat[N] | f.delay[1] | seq1, on=f.posedge(io.CLK))
 
     tester = f.SynchronousTester(Main, Main.CLK)
     tester.circuit.write = 0
     tester.circuit.read = 0
     tester.advance_cycle()
-    tester.circuit.write = 1
-    tester.advance_cycle()
     for _ in range(2):
         tester.circuit.write = 0
-        tester.circuit.read = 1
+        tester.circuit.read = 0
+        tester.advance_cycle()
+        tester.circuit.write = 1
         tester.advance_cycle()
     # Should fail if we don't see seq2
     with pytest.raises(AssertionError):
         tester.compile_and_run("system-verilog", simulator="ncsim",
                                flags=["-sv"], magma_opts={"inline": True})
     out, _ = capsys.readouterr()
-    assert "Assertion Main_tb.dut.__assert_1 has failed" in out
+    assert "Assertion Main_tb.dut.__assert_1 has failed" in out, out
     tester.circuit.write = 0
     tester.circuit.read = 1
     tester.advance_cycle()
@@ -174,7 +173,6 @@ def test_repetition(sva, capsys):
     tester.circuit.read = 0
     tester.advance_cycle()
     tester.circuit.write = 0
-    tester.advance_cycle()
     tester.compile_and_run("system-verilog", simulator="ncsim",
                            flags=["-sv"], magma_opts={"inline": True})
 

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,7 +1,8 @@
+import shutil
+
 import pytest
 import fault as f
 import magma as m
-import shutil
 
 
 def test_basic_assert():

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -7,8 +7,7 @@ def test_basic_assert():
     class Main(m.Circuit):
         io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO()
         io.O @= m.Register(T=m.Bits[8])()(io.I)
-        f.assert_(io.I | f.implies | f.delay[1] | io.O, name="O_reg",
-                  on=f.posedge(io.CLK))
+        f.assert_(io.I | f.implies | f.delay[1] | io.O, on=f.posedge(io.CLK))
 
     if shutil.which("ncsim"):
         tester = f.SynchronousTester(Main, Main.CLK)
@@ -26,4 +25,4 @@ def test_basic_assert():
         tester.circuit.O.expect(1)
         tester.advance_cycle()
         tester.circuit.O.expect(0)
-        tester.compile_and_run("system_verilog", simulator="ncsim")
+        tester.compile_and_run("system-verilog", simulator="ncsim", flags=["-sv"])


### PR DESCRIPTION
Initial prototype of https://github.com/leonardt/fault/issues/240

Seems like we should be able to pull this off.  Will also add an example of the sva syntax.

For now we just compile to inline_verilog, eventually we should add corresponding coreir primitives and compile to that representation.

Unforuntately, verilator does not support the concurrent assertion syntax (at least the ## operator was causing an error. (also see https://www.veripool.org/projects/verilator/wiki/Manual-verilator#Assertions).

Fortunately, this gives us a good reason to support compiling these to pono (next gen CoSA, CC @makaimann) to test this feature in the open source environment.

There's still some work to organize the property code (e.g. class hierarchy and reuse for the infix operator logic, as well as the compiler logic) but this was just a first stab at showing that it's possible.  I started by defining a compile method on the property subtypes, but I found passing around the format_kwargs dictionary annoying, so I think it makes more sense to define a Compiler visitor (ala ast NodeTransformer pattern) so the compile code will live inside a separate class rather than with the properties.