### PR TITLE
Fix clock init bug

### DIFF
--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -79,12 +79,15 @@ class Tester(TesterBase):
         """
         super().__init__(circuit, clock, reset, poke_delay_default,
                          expect_strict_default)
-        if clock is not None:
-            # Default initalize clock to zero (e.g. for SV targets)
-            self.poke(clock, 0)
+        self.init_clock()
         self.targets = {}
         # For public verilator modules
         self.verilator_includes = []
+
+    def init_clock(self):
+        if self.clock is not None:
+            # Default initalize clock to zero (e.g. for SV targets)
+            self.poke(self.clock, 0)
 
     def make_target(self, target: str, **kwargs):
         """
@@ -393,7 +396,16 @@ class LoopIndex:
         return self.name
 
 
-class LoopTester(Tester):
+class NoClockInit:
+    """
+    Sub testers should not initialize the clock
+    """
+
+    def init_clock(self):
+        pass
+
+
+class LoopTester(Tester, NoClockInit):
     __unique_index_id = -1
 
     def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
@@ -403,14 +415,14 @@ class LoopTester(Tester):
             f"__fault_loop_var_action_{LoopTester.__unique_index_id}")
 
 
-class ElseTester(Tester):
+class ElseTester(Tester, NoClockInit):
     def __init__(self, else_actions: List, circuit: m.Circuit,
                  clock: m.Clock = None):
         super().__init__(circuit, clock)
         self.actions = else_actions
 
 
-class IfTester(Tester):
+class IfTester(Tester, NoClockInit):
     def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
         super().__init__(circuit, clock)
         self.else_actions = []

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -8,8 +8,6 @@ class SynchronousTester(StagedTester):
         super().__init__(*args, **kwargs)
         if self.clock is None:
             raise ValueError("SynchronousTester requires a clock")
-        # Default clock to 0
-        self.poke(self.clock, 0)
 
     def eval(self):
         raise TypeError("Cannot eval with synchronous tester")

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -158,7 +158,6 @@ class VerilatorTarget(VerilogTarget):
                 coverage=self.coverage,
                 use_kratos=use_kratos
             )
-            print(comp_cmd)
             # shell=True since 'verilator' is actually a shell script
             subprocess_run(comp_cmd, cwd=self.directory, shell=True,
                            disp_type=self.disp_type)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -158,6 +158,7 @@ class VerilatorTarget(VerilogTarget):
                 coverage=self.coverage,
                 use_kratos=use_kratos
             )
+            print(comp_cmd)
             # shell=True since 'verilator' is actually a shell script
             subprocess_run(comp_cmd, cwd=self.directory, shell=True,
                            disp_type=self.disp_type)

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -630,6 +630,7 @@ def test_tester_while3(target, simulator):
     tester.poke(circ.I, 1)
     tester.eval()
     loop = tester._while(tester.peek(tester._circuit.O) == 0)
+    assert not loop.actions, "Should not default clock init"
     loop.poke(circ.I, 1)
     loop.eval()
     tester.expect(circ.O, 1)
@@ -649,8 +650,11 @@ def test_tester_if(target, simulator):
     loop._if(tester.circuit.O == 0).poke(circ.I, 1)
     loop.eval()
     if_tester = tester._if(tester.circuit.O == 0)
+    assert not if_tester.actions, "Should not default clock init"
     if_tester.poke(circ.I, 1)
-    if_tester._else().poke(circ.I, 0)
+    else_tester = if_tester._else()
+    assert not else_tester.actions, "Should not default clock init"
+    else_tester.poke(circ.I, 0)
     tester.eval()
     tester.expect(circ.O, 0)
     with tempfile.TemporaryDirectory(dir=".") as _dir:


### PR DESCRIPTION
The default clock logic was being inherited by sub-testers (e.g. for if/while loops) which was causing an unexpected setting of the clock to zero inside the TB