### PR TITLE
Resolve pytest and brew issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,7 @@ steps:
       echo $$PATH
 
       # install python dependencies for testing
+      pip install "pytest<6"
       pip install pytest-cov pytest-codestyle
       pip install --upgrade "mantle>=2.0.0"
       pip install vcdvcd decorator
@@ -48,6 +49,7 @@ steps:
 
       # install python dependencies for testing
       pip install wheel
+      pip install "pytest<6"
       pip install pytest-cov pytest-codestyle
       pip install vcdvcd decorator
       pip install --upgrade "mantle>=2.0.0"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest<6
+          pip install "pytest<6"
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest
+          pip install pytest<6
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest<6
+          pip install "pytest<6"
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest
+          pip install pytest<6
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest
+          pip install pytest<6
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Python packages
       shell: bash -l {0}
       run: |
-          pip install pytest<6
+          pip install "pytest<6"
           pip install pytest-cov pytest-codestyle
           pip install mantle>=2.0.0  # for tests.common
           pip install vcdvcd decorator

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: |
           brew update
-          brew upgrade mpfr
+          brew upgrade gmp mpfr libmpc
           brew install verilator icarus-verilog
           verilator --version
           iverilog -V

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,8 +25,10 @@ jobs:
       shell: bash
       run: |
           brew update
-          brew install verilator gmp mpfr libmpc icarus-verilog
+          brew upgrade mpfr
+          brew install verilator icarus-verilog
           verilator --version
+          iverilog -V
     - name: Install Python packages
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
This small PR gets the BuildKite and GitHub Actions tests passing again by constraining ``pytest`` to use a version number less than ``6.x.x``.

While fixing that issue, I found a separate problem in the ``MacOS Test`` on GitHub Actions.  ``gmp``, ``mpfr``, ``libmpc``are now installed by default; ``gmp`` and ``libmpc`` are the latest version whereas ``mpfr`` was an older version.  This appears to have caused an error when ``brew install`` was used.  ``brew upgrade`` fixed the problem.