### PR TITLE
Fix iverilog top module selection on macOS

### DIFF
--- a/fault/select_path.py
+++ b/fault/select_path.py
@@ -47,7 +47,7 @@ class SelectPath:
     def system_verilog_path(self, disable_ndarray):
         def name_func(x):
             return verilog_name(x, disable_ndarray)
-        return self.make_path(".", 
+        return self.make_path(".",
                               name_func=name_func)
 
     @property

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -733,7 +733,7 @@ class SystemVerilogTarget(VerilogTarget):
             sim_err_str = ['syntax error', 'I give up.']
             # Run simulation
             bin_cmd = ['vvp', '-N', bin_file]
-            bin_err_str = 'ERROR'
+            bin_err_str = ['ERROR', 'FATAL']
         else:
             raise NotImplementedError(self.simulator)
 

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -726,7 +726,7 @@ class SystemVerilogTarget(VerilogTarget):
             sim_err_str = None
             # Run simulation
             bin_cmd = [bin_file]
-            bin_err_str = 'Error'
+            bin_err_str = ['Error', 'Fatal']
         elif self.simulator == 'iverilog':
             # Compile simulation
             sim_cmd, bin_file = self.iverilog_cmd(sources=vlog_srcs)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -1057,12 +1057,13 @@ class SystemVerilogTarget(VerilogTarget):
         # misc flags
         cmd += ['-g2012']
 
-        # source files
-        cmd += [f'{src}' for src in sources]
-
-        # set the top module
+        # set the top module.  note that the '-s' option must
+        # come before the source file list.
         if not self.no_top_module:
             cmd += ['-s', f'{self.top_module}']
+
+        # source files
+        cmd += [f'{src}' for src in sources]
 
         # return arg list and binary file location
         return cmd, bin_file

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ A Python package for testing hardware (part of the magma ecosystem)\
 
 setup(
     name='fault',
-    version='3.0.27',
+    version='3.0.28',
     description=DESCRIPTION,
     scripts=[],
     packages=[

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,39 @@
+import fault
+import pytest
+import magma as m
+from pathlib import Path
+from .common import pytest_sim_params
+
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc, 'system-verilog')
+
+
+@pytest.mark.xfail(strict=True)
+def test_error_task(target, simulator):
+    class error_task(m.Circuit):
+        io = m.IO()
+
+    tester = fault.Tester(error_task)
+    tester.compile_and_run(
+        target=target,
+        simulator=simulator,
+        ext_srcs=[Path('tests/verilog/error_task.sv').resolve()],
+        ext_test_bench=True,
+        tmp_dir=True
+    )
+
+
+@pytest.mark.xfail(strict=True)
+def test_fatal_task(target, simulator):
+    class fatal_task(m.Circuit):
+        io = m.IO()
+
+    tester = fault.Tester(fatal_task)
+    tester.compile_and_run(
+        target=target,
+        simulator=simulator,
+        ext_srcs=[Path('tests/verilog/fatal_task.sv').resolve()],
+        ext_test_bench=True,
+        tmp_dir=True
+    )

--- a/tests/test_top_module.py
+++ b/tests/test_top_module.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 import fault
 import magma as m
-from pathlib import Path
 from .common import pytest_sim_params
 
 
@@ -8,23 +8,22 @@ def pytest_generate_tests(metafunc):
     pytest_sim_params(metafunc, 'system-verilog')
 
 
-def test_inc_dir(target, simulator):
+def test_ext_vlog(target, simulator):
     # declare circuit
-    class mybuf_inc_test(m.Circuit):
+    class myinv(m.Circuit):
         io = m.IO(
             in_=m.In(m.Bit),
             out=m.Out(m.Bit)
         )
 
-    # define the test
-    tester = fault.BufTester(mybuf_inc_test)
+    # define test
+    tester = fault.InvTester(myinv)
 
     # run the test
     tester.compile_and_run(
         target=target,
         simulator=simulator,
-        ext_libs=[Path('tests/verilog/mybuf_inc_test.v').resolve()],
-        inc_dirs=[Path('tests/verilog').resolve()],
+        ext_srcs=[Path('tests/verilog/myinv_extra_module.v').resolve()],
         ext_model_file=True,
         tmp_dir=True
     )

--- a/tests/verilog/error_task.sv
+++ b/tests/verilog/error_task.sv
@@ -1,0 +1,6 @@
+module error_task;
+    initial begin
+        $error;
+        $finish;
+    end
+endmodule

--- a/tests/verilog/fatal_task.sv
+++ b/tests/verilog/fatal_task.sv
@@ -1,0 +1,5 @@
+module fatal_task;
+    initial begin
+        $fatal;
+    end
+endmodule

--- a/tests/verilog/myinv_extra_module.v
+++ b/tests/verilog/myinv_extra_module.v
@@ -1,0 +1,21 @@
+module extra_module #(
+    parameter file_name="file.mem"
+) (
+    input [1:0] addr,
+    output [2:0] data
+);
+    // read into rom
+    reg [2:0] rom [0:3];
+    initial begin
+        $readmemb(file_name, rom);
+    end
+    // assign to output
+    assign data=rom[addr];
+endmodule
+
+module myinv(
+    input in_,
+    output out
+);
+    assign out = ~in_;
+endmodule


### PR DESCRIPTION
This small PR fixes issue #252 by moving the position of ``-s`` for ``iverilog``.  It also includes a test of the top module selection feature, ``test_top_module.py``, pulled from a commit a few months back that was not merged.

It also fixes a small issue in which simulations that exited with ``$fatal`` were not raising exceptions if the simulator was ``iverilog`` or ``vcs``.  There is now test called ``test_error_handling.py`` to check this in the future, for both the ``$fatal`` and ``$error`` system tasks.