### PR TITLE
Add support for bitwise peek

### DIFF
--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -931,6 +931,10 @@ def test_peek_bitwise(target, simulator, capsys):
                                    disp_type="realtime")
 
     out, _ = capsys.readouterr()
-    # vcs prints extra lines at end
-    offset = 8 if simulator == "vcs" else 2
-    assert out.splitlines()[-offset] == "_*****_*"
+    # vcs/ncsim prints extra lines at end
+    offset = {
+        None: 2,
+        "vcs": 8,
+        "ncsim": 5
+    }[simulator]
+    assert out.splitlines()[-offset] == "_*****_*", out

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -931,4 +931,6 @@ def test_peek_bitwise(target, simulator, capsys):
                                    disp_type="realtime")
 
     out, _ = capsys.readouterr()
-    assert out.splitlines()[-2] == "_*****_*"
+    # vcs prints extra lines at end
+    offset = 8 if simulator == "vcs" else 2
+    assert out.splitlines()[-offset] == "_*****_*"

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -934,6 +934,7 @@ def test_peek_bitwise(target, simulator, capsys):
     # vcs/ncsim prints extra lines at end
     offset = {
         "vcs": 8,
-        "ncsim": 5
+        "ncsim": 5,
+        "vivado": 8
     }.get(simulator, 2)
     assert out.splitlines()[-offset] == "_*****_*", out

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -933,8 +933,7 @@ def test_peek_bitwise(target, simulator, capsys):
     out, _ = capsys.readouterr()
     # vcs/ncsim prints extra lines at end
     offset = {
-        None: 2,
         "vcs": 8,
         "ncsim": 5
-    }[simulator]
+    }.get(simulator, 2)
     assert out.splitlines()[-offset] == "_*****_*", out

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -910,3 +910,25 @@ def test_wait_until_tuple(target, simulator):
             kwargs["simulator"] = simulator
             kwargs["magma_opts"] = {"sv": True}
         tester.compile_and_run(**kwargs)
+
+
+def test_peek_bitwise(target, simulator, capsys):
+    tester = fault.Tester(TestByteCircuit)
+    tester.circuit.I = 0xBE
+    tester.eval()
+    for i in range(8):
+        if_tester = tester._if(tester.circuit.I[i])
+        if_tester.print("*")
+        if_tester._else().print("_")
+    tester.print("\n")
+
+    with tempfile.TemporaryDirectory(dir=".") as _dir:
+        if target == "verilator":
+            tester.compile_and_run(target, directory=_dir,
+                                   disp_type="realtime")
+        else:
+            tester.compile_and_run(target, directory=_dir, simulator=simulator,
+                                   disp_type="realtime")
+
+    out, _ = capsys.readouterr()
+    assert out.splitlines()[-2] == "_*****_*"

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -935,6 +935,6 @@ def test_peek_bitwise(target, simulator, capsys):
     offset = {
         "vcs": 8,
         "ncsim": 5,
-        "vivado": 8
+        "vivado": 7
     }.get(simulator, 2)
     assert out.splitlines()[-offset] == "_*****_*", out


### PR DESCRIPTION
Follow up to https://github.com/leonardt/fault/pull/194 to support the same pattern for bitwise peek of verilator values (verilator stores bits as C scalars, so we need to use masking to fetch the bit of interest)