### PR TITLE
Add Tester logic to find default clock

### DIFF
--- a/fault/tester/base.py
+++ b/fault/tester/base.py
@@ -54,7 +54,7 @@ class TesterBase:
             if isinstance(port, m.Clock):
                 next_clock = port
             elif isinstance(port, (m.Array, m.Tuple)):
-                nested_clock = self._find_default_clock(port)
+                nested_clock = self._find_default_clock(port.ts)
                 if nested_clock is not None:
                     next_clock = nested_clock
             if next_clock is not None:

--- a/fault/tester/base.py
+++ b/fault/tester/base.py
@@ -26,8 +26,9 @@ class TesterBase:
         self.poke_delay_default = poke_delay_default
         self.expect_strict_default = expect_strict_default
         self.actions = []
-        if clock is not None and not isinstance(clock, m.Clock):
-            raise TypeError(f"Expected clock port: {clock, type(clock)}")
+        if clock is not None:
+            if not isinstance(clock, m.Clock):
+                raise TypeError(f"Expected clock port: {clock, type(clock)}")
         else:
             clock = self._find_default_clock(
                 self._circuit.interface.ports.values()


### PR DESCRIPTION
Traverses the interface and uses a clock port if there is only one.  If
there are multiple, we ask the user to choose one explicitly rather than
guessing.
