### PR TITLE
Add assertion wire prefix

### DIFF
--- a/fault/property.py
+++ b/fault/property.py
@@ -239,7 +239,8 @@ class _Compiler:
         return compiled
 
 
-def assert_(prop, on, disable_iff=None, compile_guard=None, name=None):
+def assert_(prop, on, disable_iff=None, compile_guard=None, name=None,
+            inline_wire_prefix="_FAULT_ASSERT_WIRE_"):
     format_args = {}
     _compiler = _Compiler(format_args)
     prop = _compiler.compile(prop)
@@ -260,7 +261,8 @@ def assert_(prop, on, disable_iff=None, compile_guard=None, name=None):
     {prop_str}
 `endif
 """
-    m.inline_verilog(prop_str, **format_args)
+    m.inline_verilog(prop_str, inline_wire_prefix=inline_wire_prefix,
+                     **format_args)
 
 
 class Sequence:

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -531,6 +531,7 @@ def test_disable_if():
                                flags=["-sv"], magma_opts={"inline": True})
 
 
+@requires_ncsim
 def test_ifdef_and_name(capsys):
     class Main(m.Circuit):
         io = m.IO(a=m.In(m.Bit), b=m.In(m.Bit))
@@ -556,7 +557,7 @@ def test_ifdef_and_name(capsys):
                            flags=["-sv"], magma_opts={"inline": True})
     # Check that wire prefix is generated properly
     with open("build/Main.v", "r") as file_:
-        assert "wire _FAULT_ASSERT_WIRE_0" in file_.read() 
+        assert "wire _FAULT_ASSERT_WIRE_0" in file_.read()
     # Should fail
     with pytest.raises(AssertionError):
         tester.compile_and_run("system-verilog", simulator="ncsim",


### PR DESCRIPTION
Fault follow up to https://github.com/phanrahan/magma/pull/832 (depends on it)

Wires generated via inline verilog and fault for the assertion logic now have a special prefix, making it easy to filter out lint related unused warnings when they are only used inside an assertion that's disabled via a macro.