### PR TITLE
Control actions should produce Tester based on current subclass

### DIFF
--- a/fault/tester/control.py
+++ b/fault/tester/control.py
@@ -1,0 +1,58 @@
+import magma as m
+from typing import List
+
+
+class LoopIndex:
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
+
+class NoClockInit:
+    """
+    Sub testers should not initialize the clock
+    """
+
+    def init_clock(self):
+        pass
+
+
+def add_control_structures(tester_class):
+    """
+    Decorator to add control structures after Tester class definition so we can
+    use the definition as a base class.
+
+    This allows Loops, If, and Else testers to inherit the base class methods
+    (e.g. for SynchronousTester they should inherit the advance_cycle method)
+    """
+    class LoopTester(NoClockInit, tester_class):
+        __unique_index_id = -1
+
+        def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
+            super().__init__(circuit, clock)
+            LoopTester.__unique_index_id += 1
+            self.index = LoopIndex(
+                f"__fault_loop_var_action_{LoopTester.__unique_index_id}")
+
+
+    class ElseTester(NoClockInit, tester_class):
+        def __init__(self, else_actions: List, circuit: m.Circuit,
+                     clock: m.Clock = None):
+            super().__init__(circuit, clock)
+            self.actions = else_actions
+
+
+    class IfTester(NoClockInit, tester_class):
+        def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
+            super().__init__(circuit, clock)
+            self.else_actions = []
+
+        def _else(self):
+            return ElseTester(self.else_actions, self._circuit, self.clock)
+
+    tester_class.LoopTester = LoopTester
+    tester_class.ElseTester = ElseTester
+    tester_class.IfTester = IfTester
+    return tester_class

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -2,7 +2,10 @@ from .staged_tester import StagedTester
 from ..system_verilog_target import SynchronousSystemVerilogTarget
 from ..verilator_target import SynchronousVerilatorTarget
 
+from fault.tester.control import add_control_structures
 
+
+@add_control_structures
 class SynchronousTester(StagedTester):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_tester/test_control.py
+++ b/tests/test_tester/test_control.py
@@ -1,0 +1,15 @@
+import pytest
+
+import magma as m
+import fault
+
+
+@pytest.mark.parametrize('TesterClass', [fault.Tester,
+                                         fault.SynchronousTester])
+def test_inherit_methods(TesterClass):
+    class DUT(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit)) + m.ClockIO()
+
+    tester = TesterClass(DUT, DUT.CLK)
+    assert isinstance(tester._if(tester.circuit.O), TesterClass)
+    assert isinstance(tester._while(tester.circuit.O), TesterClass)

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -898,7 +898,7 @@ def test_wait_until_tuple(target, simulator):
 
         tff = m.Register(m.Bit, has_enable=True)()
         tff.CLK @= io.clocks.clk0
-        tff.CE @= count.O == 3
+        tff.CE @= m.enable(count.O == 3)
         io.clocks.clk1 @= tff(tff.O ^ 1)
 
     tester = fault.Tester(Main, Main.clocks.clk0)


### PR DESCRIPTION
Before, using a control structure such as `tester._if` would produce a
StagedTester instance.  This is problematic when using a
SynchronousTester, since the produced tester doesn't inherit the
expected methods (e.g. advance_cycle).

Also fix unrelated magma error from missing `m.enable` cast (regression introduced in latest magma release)