### PR TITLE
Nested compile guards

### DIFF
--- a/doc/property.md
+++ b/doc/property.md
@@ -65,6 +65,20 @@ This will wrap the generated property inside a macro.
 `endif
 ```
 
+For multiple guards, you can pass a list of strings, for example:
+```python
+f.assert_(..., compile_guard=["ASSERT_ON", "FORMAL_ON"], ...)
+```
+
+will produce
+```verilog
+`ifdef ASSERT_ON
+    `ifdef FORMAL_ON
+        ...
+    `endif
+`endif
+```
+
 **NOTE**: One issue with using a compile guard is that when the macro is disabled
 magma/fault will produce dangling wires (these are used inside the body
 of the macro which has been disabled).  As a temporary measure, fault will generate

--- a/fault/property.py
+++ b/fault/property.py
@@ -250,7 +250,7 @@ def assert_(prop, on, disable_iff=None, compile_guard=None, name=None,
     event_str = on.compile(format_args)
     prop_str = f"assert property ({event_str}{disable_str} {prop});"
     if name is not None:
-        if not isinstance(compile_guard, str):
+        if not isinstance(name, str):
             raise TypeError("Expected string for name")
         prop_str = f"{name}: {prop_str}"
     if compile_guard is not None:

--- a/fault/property.py
+++ b/fault/property.py
@@ -254,11 +254,16 @@ def assert_(prop, on, disable_iff=None, compile_guard=None, name=None,
             raise TypeError("Expected string for name")
         prop_str = f"{name}: {prop_str}"
     if compile_guard is not None:
-        if not isinstance(compile_guard, str):
-            raise TypeError("Expected string for compile_guard")
-        prop_str = f"""\
-`ifdef {compile_guard}
-    {prop_str}
+        if not isinstance(compile_guard, (str, list)):
+            raise TypeError("Expected string or list for compile_guard")
+        if isinstance(compile_guard, str):
+            compile_guard = [compile_guard]
+        for guard in reversed(compile_guard):
+            # Add tabs to line for indent
+            nested_prop_str = "\n    ".join(prop_str.splitlines())
+            prop_str = f"""\
+`ifdef {guard}
+    {nested_prop_str}
 `endif
 """
     m.inline_verilog(prop_str, inline_wire_prefix=inline_wire_prefix,


### PR DESCRIPTION
Allows the user to provide a list of compile guards (useful if some properties should require two defines).  We can't use `&&` inside `ifdef` so we have to generate nested `ifdef` statements.