### PR TITLE
Add fork to systemverilog target

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -1,3 +1,4 @@
+import enum
 from abc import ABC, abstractmethod
 
 from .ms_types import (RealIn, RealOut, RealInOut,
@@ -247,6 +248,40 @@ class Loop(Action):
                    self.actions]
         return Loop(n_iter=self.n_iter, loop_var=self.loop_var,
                     actions=actions, count=self.count)
+
+
+class Fork(Action):
+    def __init__(self, name, actions):
+        self.name = name
+        self.actions = actions
+
+    def __str__(self):
+        return f"Fork({self.name}"
+
+    def retarget(self, new_circuit, clock):
+        actions = [action.retarget(new_circuit, clock) for action in
+                   self.actions]
+        return Fork(self.name, actions)
+
+
+class JoinType(enum.Enum):
+    Default = enum.auto()
+    None_ = enum.auto()
+    Any = enum.auto()
+
+
+class Join(Action):
+    def __init__(self, *processes, join_type=JoinType.Default):
+        self.join_type = join_type
+        self.processes = list(*processes)
+
+    def __str__(self):
+        return f"Join({self.join_type.name})"
+
+    def retarget(self, new_circuit, clock):
+        processes = [process.retarget(new_circuit, clock) for process in
+                     self.processes]
+        return Join(*processes, join_type=self.join_type)
 
 
 class FileOpen(Action):

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -271,17 +271,17 @@ class JoinType(enum.Enum):
 
 
 class Join(Action):
-    def __init__(self, *processes, join_type=JoinType.Default):
+    def __init__(self, processes, join_type=JoinType.Default):
         self.join_type = join_type
-        self.processes = list(*processes)
+        self.processes = processes
 
     def __str__(self):
         return f"Join({self.join_type.name})"
 
     def retarget(self, new_circuit, clock):
-        processes = [process.retarget(new_circuit, clock) for process in
-                     self.processes]
-        return Join(*processes, join_type=self.join_type)
+        processes = (process.retarget(new_circuit, clock) for process in
+                     self.processes)
+        return Join(processes, join_type=self.join_type)
 
 
 class FileOpen(Action):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -413,6 +413,19 @@ class SystemVerilogTarget(VerilogTarget):
         self.add_decl('integer', action.loop_var, exist_ok=True)
         return super().make_loop(i, action)
 
+    def make_join(self, i, action):
+        code = ["fork"]
+        for p in action.processes:
+            code += self.make_block(i, None, None, p.actions, p.name)
+        # join
+        if action.join_type == actions.JoinType.Default:
+            code += ["join"]
+        elif action.join_type == actions.JoinType.None_:
+            code += ["join_none"]
+        elif action.join_type == actions.JoinType.Any:
+            code += ["join_any"]
+        return code
+
     def make_file_open(self, i, action):
         # make sure the file mode is supported
         if not is_valid_file_mode(action.file.mode):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -424,6 +424,8 @@ class SystemVerilogTarget(VerilogTarget):
             code += ["join_none"]
         elif action.join_type == actions.JoinType.Any:
             code += ["join_any"]
+        else:
+            raise ValueError(f"Unexpected joint_type: {action.join_type}")
         return code
 
     def make_file_open(self, i, action):

--- a/fault/tester/control.py
+++ b/fault/tester/control.py
@@ -52,7 +52,13 @@ def add_control_structures(tester_class):
         def _else(self):
             return ElseTester(self.else_actions, self._circuit, self.clock)
 
+    class ForkTester(NoClockInit, tester_class):
+        def __init__(self, name, circuit: m.Circuit, clock: m.Clock = None):
+            super().__init__(circuit, clock)
+            self.name = name
+
     tester_class.LoopTester = LoopTester
     tester_class.ElseTester = ElseTester
     tester_class.IfTester = IfTester
+    tester_class.ForkTester = ForkTester
     return tester_class

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -336,6 +336,28 @@ class Tester(TesterBase):
                                  loop_tester.actions))
         return loop_tester
 
+    def fork(self, name):
+        """
+        Returns a fork process to record actions inside the fork
+        """
+        fork_tester = self.ForkTester(name, self._circuit, self.clock)
+        return fork_tester
+
+    def join(self, *args, join_type=actions.JoinType.Default):
+        """
+        Join all forked processes together
+        """
+        processes = [actions.Fork(p.name, p.actions) for p in args]
+        join_action = actions.Join(processes, join_type=join_type)
+        self.actions.append(join_action)
+        return join_action
+
+    def join_any(self, *args):
+        return self.join(*args, join_type=actions.JoinType.Any)
+
+    def join_none(self, *args):
+        return self.join(*args, join_type=actions.JoinType.None_)
+
     def file_open(self, file_name, mode="r", chunk_size=1, endianness="little"):
         """
         mode : "r" for read, "w" for write

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -427,6 +427,9 @@ if (({got}) != ({expected})) {{
             code.append("main_time += 5;")
         return code
 
+    def make_join(self, i, action):
+        raise NotImplementedError("fork/join not implemented for Verilator")
+
     def make_file_open(self, i, action):
         # make sure the file mode is supported
         if not is_valid_file_mode(action.file.mode):

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -10,7 +10,8 @@ def pytest_generate_tests(metafunc):
 
 def test_fork_join(target, simulator):
     class dut(m.Circuit):
-        io = m.IO(I=m.In(m.Bits[2]), O=m.Out(m.Bits[2]))
+        # add dummy clock
+        io = m.IO(I=m.In(m.Bits[4]), O=m.Out(m.Bits[4]), clk=m.In(m.Clock))
         io.O @= io.I
 
     tester = fault.Tester(dut)
@@ -18,14 +19,17 @@ def test_fork_join(target, simulator):
     proc2 = tester.fork("proc2")
 
     for i, proc in enumerate([proc1, proc2]):
-        proc.poke(tester.circuit.I[i], 1)
+        proc.poke(tester.circuit.I[1 - i], 1)
         proc.eval()
-        proc.expect(tester.circuit.O[i], 1)
+        proc.wait_until_high(tester.circuit.I[i])
+        proc.poke(tester.circuit.I[i + 2], 1)
 
     tester.join(proc1, proc2)
+    tester.eval()
+    tester.expect(tester.circuit.O, 0xF)
 
     tester.compile_and_run(
         target=target,
         simulator=simulator,
-        tmp_dir=True
+        tmp_dir=False
     )

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import fault
+import magma as m
+from .common import pytest_sim_params
+
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc, 'system-verilog')
+
+
+def test_fork_join(target, simulator):
+    class dut(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[2]), O=m.Out(m.Bits[2]))
+        io.O @= io.I
+
+    tester = fault.Tester(dut)
+    proc1 = tester.fork("proc1")
+    proc2 = tester.fork("proc2")
+
+    for i, proc in enumerate([proc1, proc2]):
+        proc.poke(tester.circuit.I[i], 1)
+        proc.eval()
+        proc.expect(tester.circuit.O[i], 1)
+
+    tester.join(proc1, proc2)
+
+    tester.compile_and_run(
+        target=target,
+        simulator=simulator,
+        tmp_dir=True
+    )


### PR DESCRIPTION
## Introduction
This is a prototype implementation of `fork` presented in #277 

## Usage
```Python
tester = fault.Tester(dut)
proc1 = tester.fork("proc1")
proc2 = tester.fork("proc2")

for i, proc in enumerate([proc1, proc2]):
    proc.poke(tester.circuit.I[i], 1)
    proc.eval()
    proc.expect(tester.circuit.O[i], 1)

tester.join(proc1, proc2)
```
Name is required for each forked process so it's easy to identify and useful for the waveform debugging. The current implementation should also support tested fork, as long as `join()` is called at the process, e.g. `proc.join(proc3, proc4)`.

Here is generated SV:
```SystemVerilog
    initial begin
        fork
        begin : proc1
            I[0] <= 1'b1;
            #1;
            if (!(O[0] === 1'b1)) begin
                $error("Failed on action=0 checking port dut.O[0] with traceback /home/keyi/workspace/fault/tests/test_fork.py:24.  Expected %x, got %x.", 1'b1, O[0]);
            end
            fork
            begin : proc3
                #1;
            end
            join
        end
        begin : proc2
            I[1] <= 1'b1;
            #1;
            if (!(O[1] === 1'b1)) begin
                $error("Failed on action=0 checking port dut.O[1] with traceback /home/keyi/workspace/fault/tests/test_fork.py:24.  Expected %x, got %x.", 1'b1, O[1]);
            end
        end
        join
        #20 $finish;
    end

```

## How it works
- Several new actions are introduced to allow fork and join: `Fork` and `Join` class
- `JoinType` is introduced to handle different join, i.e. `join`, `join_any`, and `join_none`. Helper functions are added so user can directly call `tester.join_any()` and `tester.join_none()`.
- Actions are added to the main tester only after join is called.

## Limitations
- Need to implement semaphore to avoid race conditions. In some cases the race conditions can be statically determined, which could be an interesting research project itself.