### PR TITLE
Assert examples

### DIFF
--- a/doc/property.md
+++ b/doc/property.md
@@ -269,7 +269,7 @@ class Foo(m.Circuit):
     f.assert_(
         f.sva(f.not_(f.onehot(io.a)), "&&",
               io.b.reduce_or(), "&&",
-              x[0], "|=>", io.y != f.past(io.y, 2)
+              io.x[0], "|=>", io.y != f.past(io.y, 2)
         ),
         name="name_A",
         on=f.posedge(io.CLK),
@@ -279,7 +279,7 @@ class Foo(m.Circuit):
     f.assert_(
         f.not_(f.onehot(io.a)) &
         io.b.reduce_or() &
-        x[0] |f.implies| io.y != f.past(io.y, 2),
+        io.x[0] |f.implies| io.y != f.past(io.y, 2),
         name="name_A",
         on=f.posedge(io.CLK),
         disable_iff=f.not_(io.RESETN)

--- a/doc/property.md
+++ b/doc/property.md
@@ -17,8 +17,8 @@ f.assert_(io.I | f.implies | f.delay[1] | (io.O.value() == 0),
 * `f.implies` corresponds to SVA `|->`
 * `f.delay[N]` corresponds to SVA `##N`
 * `f.delay[M:N]` corresponds to SVA `##[M:N]`
-* `f.delay[0:]` corresponds to SVA `##[*]`
-* `f.delay[1:]` corresponds to SVA `##[+]`
+* `f.delay[0:]` corresponds to SVA `##[*]` or `##[*0:$]`
+* `f.delay[1:]` corresponds to SVA `##[+]` or `##[*1:$]`
 * `f.repeat[N]` corresponds to SVA `[*N]`
 * `f.repeat[0:]` corresponds to SVA `[*]`
 * `f.repeat[1:]` corresponds to SVA `[+]`
@@ -246,3 +246,100 @@ def test_coverage(capsys):
 # Assume
 Fault provides the function `f.assume` that uses the same interface as
 `f.assert_` and will generate a system verilog `assume` statement
+
+# Advanced Examples
+## Example 1
+### Verilog
+```verilog
+input [7:0] a, b, c;
+output [7:0] x, y;
+
+`ASSERT(name_A,
+  !$onehot(a) && |b && x[0] |=> y != $past(y, 2),
+ clk, resetn
+)
+```
+### Python
+```python
+class Foo(m.Circuit):
+    io = m.IO(a=m.In(m.Bits[8]), b=m.In(m.Bits[8]), c=m.In(m.Bits[8]),
+              x=m.Out(m.Bits[8]), y=m.Out(m.Bits[8]))
+    io += m.ClockIO(has_resetn=True)
+    # sva syntax
+    f.assert_(
+        f.sva(f.not_(f.onehot(io.a)), "&&",
+              io.b.reduce_or(), "&&",
+              x[0], "|=>", io.y != f.past(io.y, 2)
+        ),
+        name="name_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+    # infix syntax
+    f.assert_(
+        f.not_(f.onehot(io.a)) &
+        io.b.reduce_or() &
+        x[0] |f.implies| io.y != f.past(io.y, 2),
+        name="name_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+```
+
+## Example 2
+### Verilog
+```verilog
+input valid, sop, eop;
+output ready;
+
+`ASSERT(eop_must_happen_btn_two_sop_A,
+  not(!(valid && ready && eop) throughout ((valid && ready && sop)[->2])),
+ clk, resetn
+)
+
+`ASSERT(first_valid_after_eop_must_have_sop_A,
+  (valid && ready && eop) ##1 (!valid)[*0:$] ##1 valid |-> sop,
+ clk, resetn
+)
+```
+```python
+class Foo(m.Circuit):
+    io = m.IO(valid=m.In(m.Bit), sop=m.In(m.Bit), eop=m.In(m.Bit),
+              ready=m.Out(m.Bit))
+    # sva syntax
+    f.assert_(
+        f.sva(f.not_(~(io.valid & io.ready & io.eop)), "throughout",
+            # Note: need sequence here to wrap parens
+            f.sequence(f.sva((io.valid & io.ready & io.sop), "[-> 2]"))
+        ),
+        name="eop_must_happen_btn_two_sop_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+    f.assert_(
+        f.sva(io.valid & io.ready & io.eop, "##1",
+            f.sequence(~io.valid), "[*0:$] ##1", io.valid, "|->", io.sop
+        ),
+        name="first_valid_after_eop_must_have_sop_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+
+    # infix syntax
+    f.assert_(
+        f.sva(f.not_(~(io.valid & io.ready & io.eop)) |f.throughout|
+            ((io.valid & io.ready & io.sop) | f.goto[2])
+        ),
+        name="eop_must_happen_btn_two_sop_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+    f.assert_(
+        f.sva(io.valid & io.ready & io.eop |f.delay[1]|
+            (~io.valid) |f.delay[0:]|f.delay[1]| io.valid |f.implies| io.sop
+        ),
+        name="first_valid_after_eop_must_have_sop_A",
+        on=f.posedge(io.CLK),
+        disable_iff=f.not_(io.RESETN)
+    )
+```

--- a/fault/expression.py
+++ b/fault/expression.py
@@ -1,3 +1,7 @@
+from magma.t import Type
+from fault.infix import Infix
+
+
 class Expression:
     def __and__(self, other):
         return And(self, other)
@@ -56,6 +60,9 @@ class Expression:
         return Div(self, other)
 
     def __or__(self, other):
+        if isinstance(other, Infix):
+            # Force Infix operator logic
+            return NotImplemented
         return Or(self, other)
 
     def __xor__(self, other):

--- a/fault/infix.py
+++ b/fault/infix.py
@@ -1,0 +1,12 @@
+from functools import partial
+
+
+class Infix:
+    def __init__(self, func):
+        self.func = func
+
+    def __or__(self, other):
+        return self.func(other)
+
+    def __ror__(self, other):
+        return Infix(partial(self.func, other))

--- a/fault/property.py
+++ b/fault/property.py
@@ -3,6 +3,8 @@ from functools import partial
 import magma as m
 
 from fault.sva import SVAProperty
+from fault.expression import Expression, UnaryOp, BinaryOp
+from fault.infix import Infix
 
 
 class Property:
@@ -17,17 +19,6 @@ class Property:
             return result
         self.rhs = self.rhs | other
         return self
-
-
-class Infix:
-    def __init__(self, func):
-        self.func = func
-
-    def __or__(self, other):
-        return self.func(other)
-
-    def __ror__(self, other):
-        return Infix(partial(self.func, other))
 
 
 class Implies(Property):
@@ -212,7 +203,7 @@ class _Compiler:
                 if isinstance(arg, str):
                     property_str += f" {arg} "
                 elif isinstance(arg, (SVAProperty, Sequence, FunctionCall,
-                                      PropertyUnaryOp)):
+                                      PropertyUnaryOp, Expression)):
                     property_str += f" {self._compile(arg)} "
                 else:
                     key = f"x{len(self.format_args)}"
@@ -233,6 +224,21 @@ class _Compiler:
             return f"{{{{{contents}}}}}"
         if isinstance(value, int):
             return str(value)
+        if isinstance(value, BinaryOp):
+            left = self._compile(value.left)
+            right = self._compile(value.right)
+            op = value.op_str
+            if op == "==":
+                # Use strict eq
+                op = "==="
+            elif op == "!=":
+                # Use strict neq
+                op = "!=="
+            return f"({left}) {op} ({right})"
+        if isinstance(value, UnaryOp):
+            operand = self._compile(value.operand)
+            op = value.op_str
+            return f"{op} ({operand})"
         raise NotImplementedError(type(value))
 
     def compile(self, prop):
@@ -301,7 +307,7 @@ def sequence(prop):
     return Sequence(prop)
 
 
-class FunctionCall:
+class FunctionCall(Expression):
     def __init__(self, func, args):
         self.func = func
         self.args = args
@@ -329,7 +335,7 @@ class PropertyUnaryOp:
     pass
 
 
-class Not(PropertyUnaryOp):
+class Not(PropertyUnaryOp, Expression):
     op_str = "!"
 
     def __init__(self, arg):

--- a/fault/property.py
+++ b/fault/property.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import magma as m
 
 from fault.sva import SVAProperty
@@ -331,11 +329,11 @@ fell = Function("$fell")
 stable = Function("$stable")
 
 
-class PropertyUnaryOp:
+class PropertyUnaryOp(Expression):
     pass
 
 
-class Not(PropertyUnaryOp, Expression):
+class Not(PropertyUnaryOp):
     op_str = "!"
 
     def __init__(self, arg):


### PR DESCRIPTION
Adds 2 more complex assertion examples to the documentation and tests.

Minor improvement to make them work:
* need to support expressions with property constructs (e.g. `value != f.past(value, 2)`).  For now, we piggy back on fault's expression language used for peek values.  In the future, we should consider supporting this in the downstream tools (e.g. we can treat `f.past(value, 2)` as a verification instance.  I think we can just represent these structures in the graph, but we probably want to group them together so they're code generated separate from the RTL (we don't want verification code to introduce RTL-like instances that may affect synthesis or cause the synthesis/verification code to have a mismatch).