### PR TITLE
Add support for abs, max, min expressions

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -20,4 +20,4 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
                             assume)
 from fault.sva import sva
 from fault.assert_immediate import assert_immediate
-from fault.expression import abs, min, max, signed
+from fault.expression import abs, min, max, signed, integer

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -20,3 +20,4 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
                             assume)
 from fault.sva import sva
 from fault.assert_immediate import assert_immediate
+from fault.expression import abs, min, max, signed

--- a/fault/expression.py
+++ b/fault/expression.py
@@ -158,3 +158,40 @@ class XOr(BinaryOp):
 
 class Or(BinaryOp):
     op_str = "|"
+
+
+class FunctionCall(Expression):
+    def __init__(self, *args):
+        self.args = args
+
+
+class Abs(FunctionCall):
+    func_str = "abs"
+
+
+def abs(x):
+    return Abs(x)
+
+
+class Min(FunctionCall):
+    func_str = "min"
+
+
+def min(x, y):
+    return min(x, y)
+
+
+class Max(FunctionCall):
+    func_str = "max"
+
+
+def max(x, y):
+    return max(x, y)
+
+
+class Signed(FunctionCall):
+    func_str = "signed"
+
+
+def signed(x):
+    return Signed(x)

--- a/fault/expression.py
+++ b/fault/expression.py
@@ -178,7 +178,7 @@ class Min(FunctionCall):
 
 
 def min(x, y):
-    return min(x, y)
+    return Min(x, y)
 
 
 class Max(FunctionCall):
@@ -186,7 +186,7 @@ class Max(FunctionCall):
 
 
 def max(x, y):
-    return max(x, y)
+    return Max(x, y)
 
 
 class Signed(FunctionCall):
@@ -195,3 +195,11 @@ class Signed(FunctionCall):
 
 def signed(x):
     return Signed(x)
+
+
+class Integer(FunctionCall):
+    func_str = "int'"
+
+
+def integer(x):
+    return Integer(x)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -376,7 +376,13 @@ class SystemVerilogTarget(VerilogTarget):
             value = value.name
         elif isinstance(value, expression.FunctionCall):
             args = ", ".join(self.compile_expression(x) for x in value.args)
-            return f"${value.func_str}({args})"
+            func_str = value.func_str
+            if not isinstance(value, expression.Integer):
+                # special casting syntax
+                func_str = f"${func_str}"
+            return f"{func_str}({args})"
+        elif isinstance(value, int):
+            return str(value)
         return value
 
     def make_poke(self, i, action):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -374,6 +374,9 @@ class SystemVerilogTarget(VerilogTarget):
             return self.process_peek(value)
         elif isinstance(value, actions.Var):
             value = value.name
+        elif isinstance(value, expression.FunctionCall):
+            args = ", ".join(self.compile_expression(x) for x in value.args)
+            return f"${value.func_str}({args})"
         return value
 
     def make_poke(self, i, action):
@@ -626,6 +629,8 @@ class SystemVerilogTarget(VerilogTarget):
             if issubclass(type_, m.Array) and \
                     issubclass(type_.T, m.Digital):
                 width_str = f" [{len(type_) - 1}:0]"
+            if issubclass(type_, m.SInt):
+                width_str = f" signed {width_str}"
             if issubclass(type_, RealType):
                 t = "real"
             elif name in power_args.get("supply0s", []):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -239,6 +239,9 @@ if (({got}) != ({expected})) {{
             return self.process_peek(value)
         elif isinstance(value, actions.Var):
             return value.name
+        elif isinstance(value, expression.FunctionCall):
+            args = ", ".join(self.compile_expression(x) for x in value.args)
+            return f"{value.func_str}({args})"
         return value
 
     def process_bitwise_assign(self, port, name, value):

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -27,6 +27,7 @@ max_bits = 64 if platform.architecture()[0] == "64bit" else 32
 
 
 src_tpl = """\
+#include "math.h"
 {includes}
 
 // Based on https://www.veripool.org/projects/verilator/wiki/Manual-verilator#CONNECTING-TO-C
@@ -240,8 +241,16 @@ if (({got}) != ({expected})) {{
         elif isinstance(value, actions.Var):
             return value.name
         elif isinstance(value, expression.FunctionCall):
+            if isinstance(value, expression.Integer):
+                assert len(value.args) == 1
+                return f"((int) {self.compile_expression(value.args[0])})"
             args = ", ".join(self.compile_expression(x) for x in value.args)
-            return f"{value.func_str}({args})"
+            func_str = value.func_str
+            if func_str in {"min", "max"}:
+                func_str = f"std::{func_str}"
+            return f"{func_str}({args})"
+        elif isinstance(value, int):
+            return str(value)
         return value
 
     def process_bitwise_assign(self, port, name, value):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -16,11 +16,10 @@ def run_test(tester, target, simulator):
     with tempfile.TemporaryDirectory(dir=".") as _dir:
         kwargs = {
             "target": target,
-            "directory": _dir,
+            "directory": _dir
         }
         if target == "system-verilog":
             kwargs["simulator"] = simulator
-            kwargs["directory"] = "build"
         tester.compile_and_run(**kwargs)
 
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -186,3 +186,45 @@ def test_abs(target, simulator):
     tester.assert_(fault.abs(fault.signed(tester.circuit.O) - expect) <= 1)
     with pytest.raises(AssertionError):
         run_test(tester, target, simulator)
+
+
+def test_min(target, simulator):
+    if simulator == "iverilog":
+        pytest.skip("int casting does not work with iverilog")
+    if simulator == "ncsim":
+        pytest.skip("ncsim does not define $min")
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.SInt[2]), O=m.Out(m.SInt[2]))
+        io.O @= io.I
+
+    tester = fault.Tester(Foo)
+    tester.circuit.I = 1
+    tester.eval()
+    tester.assert_(fault.min(fault.integer(tester.circuit.O), 0) == 0)
+    tester.assert_(fault.min(fault.integer(tester.circuit.O), 2) == 1)
+    run_test(tester, target, simulator)
+
+    tester.assert_(fault.min(fault.integer(tester.circuit.O), 2) == 2)
+    with pytest.raises(AssertionError):
+        run_test(tester, target, simulator)
+
+
+def test_max(target, simulator):
+    if simulator == "iverilog":
+        pytest.skip("int casting does not work with iverilog")
+    if simulator == "ncsim":
+        pytest.skip("ncsim does not define $max")
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.SInt[2]), O=m.Out(m.SInt[2]))
+        io.O @= io.I
+
+    tester = fault.Tester(Foo)
+    tester.circuit.I = 1
+    tester.eval()
+    tester.assert_(fault.max(fault.integer(tester.circuit.O), 0) == 1)
+    tester.assert_(fault.max(fault.integer(tester.circuit.O), 2) == 2)
+    run_test(tester, target, simulator)
+
+    tester.assert_(fault.max(fault.integer(tester.circuit.O), 2) == 1)
+    with pytest.raises(AssertionError):
+        run_test(tester, target, simulator)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -193,6 +193,7 @@ def test_min(target, simulator):
         pytest.skip("int casting does not work with iverilog")
     if simulator == "ncsim":
         pytest.skip("ncsim does not define $min")
+
     class Foo(m.Circuit):
         io = m.IO(I=m.In(m.SInt[2]), O=m.Out(m.SInt[2]))
         io.O @= io.I
@@ -214,6 +215,7 @@ def test_max(target, simulator):
         pytest.skip("int casting does not work with iverilog")
     if simulator == "ncsim":
         pytest.skip("ncsim does not define $max")
+
     class Foo(m.Circuit):
         io = m.IO(I=m.In(m.SInt[2]), O=m.Out(m.SInt[2]))
         io.O @= io.I


### PR DESCRIPTION
Needed for floating point tests (off by one errors mean we should be checking `abs(value - expected) <= 1`