### PR TITLE
Add var poke test for signed values

### DIFF
--- a/fault/value_utils.py
+++ b/fault/value_utils.py
@@ -8,6 +8,7 @@ from fault.ms_types import RealType
 from fault.array import Array
 from fault.select_path import SelectPath
 from hwtypes.adt import Enum
+from hwtypes import BitVector
 
 
 def make_value(type_, value):
@@ -26,6 +27,8 @@ def make_value(type_, value):
         return make_array(type_.T, type_.N, value)
     if issubclass(type_, magma.Tuple):
         raise NotImplementedError()
+    if issubclass(type_, BitVector):
+        return value
     raise NotImplementedError(type_, value)
 
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -271,6 +271,8 @@ if (!({cond})) {{
         # c type
         if isinstance(port, SelectPath):
             port = port[-1]
+        if isinstance(port, actions.Var):
+            port = port._type
         port_len = len(port)
         return BitVector[port_len](value).as_uint()
 
@@ -594,18 +596,14 @@ if (!({cond})) {{
         ])
 
     def make_var(self, i, action):
-        signed = False
-        if issubclass(action._type, SIntVector):
-            signed = True
         if isinstance(action._type, AbstractBitVectorMeta):
             size = action._type.size
-            size_map = [(1, "int8_t"), (2, "int16_t"), (4, "int32_t"),
-                        (8, "int64_t")]
+            size_map = [(1, "uint8_t"), (2, "uint16_t"), (4, "uint32_t"),
+                        (8, "uint64_t")]
             size_key = (size - 1) // 8 + 1
-            sign_prefix = "" if signed else "u"
             for s, t in size_map:
                 if size_key <= s:
-                    return [f"{sign_prefix}{t} {action.name};"]
+                    return [f"{t} {action.name};"]
 
         raise NotImplementedError(action._type)
 

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -1,7 +1,7 @@
 import os
 import magma as m
 import random
-from hwtypes import BitVector
+from hwtypes import BitVector, SIntVector
 import hwtypes
 import fault
 from fault.actions import Poke, Expect, Eval, Step, Print, Peek
@@ -868,20 +868,22 @@ def test_poke_bitwise_nested(target, simulator):
         tester.compile_and_run(**kwargs)
 
 
-def test_poke_expect_var(target, simulator):
+@pytest.mark.parametrize("T,value", [(BitVector[3], 1),
+                                     (SIntVector[3], -1)])
+def test_poke_expect_var(target, simulator, T, value):
     circ = TestArrayCircuit
     tester = fault.Tester(circ)
     tester.zero_inputs()
     tester.eval()
-    v = tester.Var("v", m.Bits[3])
-    tester.poke(v, 1)
+    v = tester.Var("v", T)
+    tester.poke(v, value)
     tester.eval()
     tester.poke(circ.I, v)
     tester.eval()
-    tester.expect(circ.O, 1)
+    tester.expect(circ.O, value)
     tester.expect(circ.O, v)
     with tempfile.TemporaryDirectory(dir=".") as _dir:
-        kwargs = {"target": target, "directory": _dir}
+        kwargs = {"target": target, "directory": "build"}
         if target == "system-verilog":
             kwargs["simulator"] = simulator
         tester.compile_and_run(**kwargs)

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -883,7 +883,7 @@ def test_poke_expect_var(target, simulator, T, value):
     tester.expect(circ.O, value)
     tester.expect(circ.O, v)
     with tempfile.TemporaryDirectory(dir=".") as _dir:
-        kwargs = {"target": target, "directory": "build"}
+        kwargs = {"target": target, "directory": _dir}
         if target == "system-verilog":
             kwargs["simulator"] = simulator
         tester.compile_and_run(**kwargs)


### PR DESCRIPTION
It turns out fault converts signed values in poke/expect to unsigned
values (see process_signed_values).  This is because verilator uses
unsigned C types for the ports (even though in magma it may be an SInt).

I also updated the var test's interface to be more consistent by using
BitVector and SIntVector instead of m.Bits (since this is testing I
think it makes sense to use the hwtypes versus magma types).  I had to
make a small change to make_value to support that (no conversion is
necessary since we're already using an appropriate BitVector type).

I remove the signed specific cdoe for the var poke since it's not needed
(since the poke value will be converted to unsigned by
process_signed_value, we should store it as unsigned, the same way that
verilator does it).

This is similar to how the system verilog test bench works (magma/coreir
does not generate the signed prefix for m.SInt types, so they are
treated as unsigned in the design and test benches, so we convert signed
python values to unsigned when generating code).