### PR TITLE
Simplify assert immediate to use initial block

### DIFF
--- a/doc/assert_immediate.md
+++ b/doc/assert_immediate.md
@@ -13,8 +13,6 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
                             wrapped in quotes, integers are passed without
                             quotes (for $fatal))
     severity (optional): "error", "fatal", or "warning"
-    on (optional): If None, uses always @(*) sensitivity, otherwise something
-                   like f.posedge(io.CLK)
     name (optional): Adds `{name}: ` prefix to assertion
     """
 ```

--- a/doc/assert_immediate.md
+++ b/doc/assert_immediate.md
@@ -1,6 +1,11 @@
-# assert_immediate
+# assert_immediate and assert_final
 
-`fault` provides the ability to define immediate assertions using the `assert_immediate` function.
+`fault` provides the ability to define immediate assertions using the
+`assert_immediate` function.  These assertions are expected to hold true
+throughout the entire simulation.  There is also an `assert_final` function
+that provides the same interface for assertions that are expected to hold true
+at the end of a simulation.
+
 
 Here is the interface:
 ```python
@@ -14,6 +19,9 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
                             quotes (for $fatal))
     severity (optional): "error", "fatal", or "warning"
     name (optional): Adds `{name}: ` prefix to assertion
+    compile_guard (optional): a string or list of strings corresponding to
+                              macro variables used to guard the assertion with
+                              verilog `ifdef statements
     """
 ```
 

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -19,5 +19,5 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
                             throughout, until, until_with, inside, cover,
                             assume)
 from fault.sva import sva
-from fault.assert_immediate import assert_immediate
+from fault.assert_immediate import assert_immediate, assert_final
 from fault.expression import abs, min, max, signed, integer

--- a/fault/assert_immediate.py
+++ b/fault/assert_immediate.py
@@ -3,7 +3,7 @@ from fault.property import Posedge
 
 
 def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
-                     on=None, name=None):
+                     name=None):
     """
     cond: m.Bit
     success_msg (optional): passed to $display on success
@@ -13,8 +13,6 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
                             form  `("<display message>", *display_args)` to
                             display debug information upon failure
     severity (optional): "error", "fatal", or "warning"
-    on (optional): If None, uses always @(*) sensitivity, otherwise something
-                   like f.posedge(io.CLK)
     name (optional): Adds `{name}: ` prefix to assertion
     """
     success_msg_str = ""
@@ -37,14 +35,8 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
             raise TypeError(
                 f"Unexpected type for failure_msg={type(failure_msg)}")
         failure_msg_str = f" else ${severity}({failure_msg});"
-    if on is None:
-        on = "@(*)"
-    elif isinstance(on, Posedge):
-        on = on.compile(format_args)
-    else:
-        raise TypeError(f"Unexpected type for on={type(on)}")
     name_str = "" if name is None else f"{name}: "
     m.inline_verilog(
-        "always {on} {name_str}assert ({cond})"
+        "initial {name_str}assert ({cond})"
         "{success_msg_str}{failure_msg_str};",
         **format_args)

--- a/fault/assert_immediate.py
+++ b/fault/assert_immediate.py
@@ -1,20 +1,10 @@
 import magma as m
 from fault.property import Posedge
+from fault.assert_utils import add_compile_guards
 
 
-def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
-                     name=None):
-    """
-    cond: m.Bit
-    success_msg (optional): passed to $display on success
-    failure_msg (optional): passed to else $<severity> on failure (strings are
-                            wrapped in quotes, integers are passed without
-                            quotes (for $fatal)), can also pass a tuple of the
-                            form  `("<display message>", *display_args)` to
-                            display debug information upon failure
-    severity (optional): "error", "fatal", or "warning"
-    name (optional): Adds `{name}: ` prefix to assertion
-    """
+def _make_assert(type_, cond, success_msg=None, failure_msg=None,
+                 severity="error", name=None, compile_guard=None):
     success_msg_str = ""
     if success_msg is not None:
         success_msg_str = f" $display(\"{success_msg}\");"
@@ -36,7 +26,50 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
                 f"Unexpected type for failure_msg={type(failure_msg)}")
         failure_msg_str = f" else ${severity}({failure_msg});"
     name_str = "" if name is None else f"{name}: "
+    assert_str = """\
+{type_} {name_str}assert ({cond}){success_msg_str}{failure_msg_str};\
+"""
+    assert_str = add_compile_guards(compile_guard, assert_str)
     m.inline_verilog(
-        "initial {name_str}assert ({cond})"
-        "{success_msg_str}{failure_msg_str};",
-        **format_args)
+        assert_str,
+        **format_args, type_=type_)
+
+
+def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
+                     name=None, compile_guard=None):
+    """
+    cond: m.Bit
+    success_msg (optional): passed to $display on success
+    failure_msg (optional): passed to else $<severity> on failure (strings are
+                            wrapped in quotes, integers are passed without
+                            quotes (for $fatal)), can also pass a tuple of the
+                            form  `("<display message>", *display_args)` to
+                            display debug information upon failure
+    severity (optional): "error", "fatal", or "warning"
+    name (optional): Adds `{name}: ` prefix to assertion
+    compile_guard (optional): a string or list of strings corresponding to
+                              macro variables used to guard the assertion with
+                              verilog `ifdef statements
+    """
+    _make_assert("initial", cond, success_msg, failure_msg, severity, name,
+                 compile_guard)
+
+
+def assert_final(cond, success_msg=None, failure_msg=None, severity="error",
+                 name=None, compile_guard=None):
+    """
+    cond: m.Bit
+    success_msg (optional): passed to $display on success
+    failure_msg (optional): passed to else $<severity> on failure (strings are
+                            wrapped in quotes, integers are passed without
+                            quotes (for $fatal)), can also pass a tuple of the
+                            form  `("<display message>", *display_args)` to
+                            display debug information upon failure
+    severity (optional): "error", "fatal", or "warning"
+    name (optional): Adds `{name}: ` prefix to assertion
+    compile_guard (optional): a string or list of strings corresponding to
+                              macro variables used to guard the assertion with
+                              verilog `ifdef statements
+    """
+    _make_assert("final", cond, success_msg, failure_msg, severity, name,
+                 compile_guard)

--- a/fault/assert_utils.py
+++ b/fault/assert_utils.py
@@ -1,0 +1,16 @@
+def add_compile_guards(compile_guard, verilog_str):
+    if compile_guard is None:
+        return verilog_str
+    if not isinstance(compile_guard, (str, list)):
+        raise TypeError("Expected string or list for compile_guard")
+    if isinstance(compile_guard, str):
+        compile_guard = [compile_guard]
+    for guard in reversed(compile_guard):
+        # Add tabs to line for indent
+        nested_verilog_str = "\n    ".join(verilog_str.splitlines())
+        verilog_str = f"""\
+`ifdef {guard}
+    {nested_verilog_str}
+`endif
+"""
+    return verilog_str

--- a/fault/property.py
+++ b/fault/property.py
@@ -3,6 +3,7 @@ import magma as m
 from fault.sva import SVAProperty
 from fault.expression import Expression, UnaryOp, BinaryOp
 from fault.infix import Infix
+from fault.assert_utils import add_compile_guards
 
 
 class Property:
@@ -258,19 +259,7 @@ def _make_statement(statement, prop, on, disable_iff, compile_guard, name,
         if not isinstance(name, str):
             raise TypeError("Expected string for name")
         prop_str = f"{name}: {prop_str}"
-    if compile_guard is not None:
-        if not isinstance(compile_guard, (str, list)):
-            raise TypeError("Expected string or list for compile_guard")
-        if isinstance(compile_guard, str):
-            compile_guard = [compile_guard]
-        for guard in reversed(compile_guard):
-            # Add tabs to line for indent
-            nested_prop_str = "\n    ".join(prop_str.splitlines())
-            prop_str = f"""\
-`ifdef {guard}
-    {nested_prop_str}
-`endif
-"""
+    prop_str = add_compile_guards(compile_guard, prop_str)
     m.inline_verilog(prop_str, inline_wire_prefix=inline_wire_prefix,
                      **format_args)
 

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -77,6 +77,7 @@ int main(int argc, char **argv) {{
 #ifdef _VERILATED_COV_H_
     write_coverage();
 #endif
+  top->final();
 
 }}
 """  # nopep8

--- a/tests/test_assert_immediate.py
+++ b/tests/test_assert_immediate.py
@@ -9,9 +9,8 @@ from fault.verilator_utils import verilator_version
 @pytest.mark.parametrize('success_msg', [None, "OK"])
 @pytest.mark.parametrize('failure_msg', [None, "FAILED"])
 @pytest.mark.parametrize('severity', ["error", "fatal", "warning"])
-@pytest.mark.parametrize('on', [None, f.posedge])
 @pytest.mark.parametrize('name', [None, "my_assert"])
-def test_immediate_assert(capsys, failure_msg, success_msg, severity, on,
+def test_immediate_assert(capsys, failure_msg, success_msg, severity,
                           name):
     if verilator_version() < 4.0:
         pytest.skip("Untested with earlier verilator versions")
@@ -29,7 +28,6 @@ def test_immediate_assert(capsys, failure_msg, success_msg, severity, on,
                            success_msg=success_msg,
                            failure_msg=failure_msg,
                            severity=severity,
-                           on=on if on is None else on(io.CLK),
                            name=name)
 
     tester = f.Tester(Foo, Foo.CLK)

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -711,6 +711,7 @@ def test_not_onehot(use_sva):
                                            "terminate_unused": True})
 
 
+@requires_ncsim
 @pytest.mark.parametrize('use_sva', [True, False])
 @pytest.mark.parametrize('should_pass', [True, False])
 def test_advanced_property_example_1(use_sva, should_pass):

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -711,7 +711,6 @@ def test_not_onehot(use_sva):
                                            "terminate_unused": True})
 
 
-@requires_ncsim
 @pytest.mark.parametrize('use_sva', [True, False])
 @pytest.mark.parametrize('should_pass', [True, False])
 def test_advanced_property_example_1(use_sva, should_pass):
@@ -744,7 +743,7 @@ def test_advanced_property_example_1(use_sva, should_pass):
                 # Note parens matter!
                 (f.not_(f.onehot(io.a)) & io.b.reduce_or() & io.x[0].value())
                 | f.implies | f.delay[1] |
-                (io.y != f.past(io.y.value(), 2)),
+                (io.y.value() != f.past(io.y.value(), 2)),
                 name="name_A",
                 on=f.posedge(io.CLK),
                 disable_iff=f.not_(io.RESETN)


### PR DESCRIPTION
In verilog, assertions are "behavioral" statements so they need to be
contained within a block such as always or initial (compared to
structural statements such as module instancing or assignment).  Before,
we used always @(*), however initial is preferred for some tool
compatability an the effect should be the same (since it's an immediate
assertion, it doesn't really make sense to have it sensitive to anything
other than *, so we can remove the code related to other events).