### PR TITLE
Add support for assert final

### DIFF
--- a/doc/assert_immediate.md
+++ b/doc/assert_immediate.md
@@ -1,6 +1,11 @@
-# assert_immediate
+# assert_immediate and assert_final
 
-`fault` provides the ability to define immediate assertions using the `assert_immediate` function.
+`fault` provides the ability to define immediate assertions using the
+`assert_immediate` function.  These assertions are expected to hold true
+throughout the entire simulation.  There is also an `assert_final` function
+that provides the same interface for assertions that are expected to hold true
+at the end of a simulation.
+
 
 Here is the interface:
 ```python

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -19,5 +19,5 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
                             throughout, until, until_with, inside, cover,
                             assume)
 from fault.sva import sva
-from fault.assert_immediate import assert_immediate
+from fault.assert_immediate import assert_immediate, assert_final
 from fault.expression import abs, min, max, signed, integer

--- a/fault/assert_immediate.py
+++ b/fault/assert_immediate.py
@@ -3,22 +3,8 @@ from fault.property import Posedge
 from fault.assert_utils import add_compile_guards
 
 
-def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
-                     name=None, compile_guard=None):
-    """
-    cond: m.Bit
-    success_msg (optional): passed to $display on success
-    failure_msg (optional): passed to else $<severity> on failure (strings are
-                            wrapped in quotes, integers are passed without
-                            quotes (for $fatal)), can also pass a tuple of the
-                            form  `("<display message>", *display_args)` to
-                            display debug information upon failure
-    severity (optional): "error", "fatal", or "warning"
-    name (optional): Adds `{name}: ` prefix to assertion
-    compile_guard (optional): a string or list of strings corresponding to
-                              macro variables used to guard the assertion with
-                              verilog `ifdef statements
-    """
+def _make_assert(type_, cond, success_msg=None, failure_msg=None,
+                 severity="error", name=None, compile_guard=None):
     success_msg_str = ""
     if success_msg is not None:
         success_msg_str = f" $display(\"{success_msg}\");"
@@ -41,9 +27,49 @@ def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
         failure_msg_str = f" else ${severity}({failure_msg});"
     name_str = "" if name is None else f"{name}: "
     assert_str = """\
-initial {name_str}assert ({cond}){success_msg_str}{failure_msg_str};\
+{type_} {name_str}assert ({cond}){success_msg_str}{failure_msg_str};\
 """
     assert_str = add_compile_guards(compile_guard, assert_str)
     m.inline_verilog(
         assert_str,
-        **format_args)
+        **format_args, type_=type_)
+
+
+def assert_immediate(cond, success_msg=None, failure_msg=None, severity="error",
+                     name=None, compile_guard=None):
+    """
+    cond: m.Bit
+    success_msg (optional): passed to $display on success
+    failure_msg (optional): passed to else $<severity> on failure (strings are
+                            wrapped in quotes, integers are passed without
+                            quotes (for $fatal)), can also pass a tuple of the
+                            form  `("<display message>", *display_args)` to
+                            display debug information upon failure
+    severity (optional): "error", "fatal", or "warning"
+    name (optional): Adds `{name}: ` prefix to assertion
+    compile_guard (optional): a string or list of strings corresponding to
+                              macro variables used to guard the assertion with
+                              verilog `ifdef statements
+    """
+    _make_assert("initial", cond, success_msg, failure_msg, severity, name,
+                 compile_guard)
+
+
+def assert_final(cond, success_msg=None, failure_msg=None, severity="error",
+                 name=None, compile_guard=None):
+    """
+    cond: m.Bit
+    success_msg (optional): passed to $display on success
+    failure_msg (optional): passed to else $<severity> on failure (strings are
+                            wrapped in quotes, integers are passed without
+                            quotes (for $fatal)), can also pass a tuple of the
+                            form  `("<display message>", *display_args)` to
+                            display debug information upon failure
+    severity (optional): "error", "fatal", or "warning"
+    name (optional): Adds `{name}: ` prefix to assertion
+    compile_guard (optional): a string or list of strings corresponding to
+                              macro variables used to guard the assertion with
+                              verilog `ifdef statements
+    """
+    _make_assert("final", cond, success_msg, failure_msg, severity, name,
+                 compile_guard)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -77,6 +77,7 @@ int main(int argc, char **argv) {{
 #ifdef _VERILATED_COV_H_
     write_coverage();
 #endif
+  top->final();
 
 }}
 """  # nopep8

--- a/tests/test_assert_immediate.py
+++ b/tests/test_assert_immediate.py
@@ -129,3 +129,29 @@ def test_immediate_assert_compile_guard():
             tester.compile_and_run("verilator", magma_opts={"inline": True},
                                    flags=['--assert', '-DASSERT_ON=1',
                                    '-Wno-UNUSED'], directory=dir_)
+
+
+def test_assert_final():
+    class Foo(m.Circuit):
+        io = m.IO(
+            O=m.Out(m.UInt[2]),
+        ) + m.ClockIO()
+        count = m.Register(m.UInt[2])()
+        count.I @= count.O + 1
+        io.O @= count.O
+        f.assert_final(count.O == 3)
+
+    tester = f.Tester(Foo, Foo.CLK)
+    for i in range(2):
+        tester.step(2)
+    # Should fail since count is 2
+    with pytest.raises(AssertionError):
+        with tempfile.TemporaryDirectory() as dir_:
+            dir_ = "build"
+            tester.compile_and_run("verilator", magma_opts={"inline": True},
+                                   flags=['--assert'], directory=dir_)
+    tester.step(2)
+    # Should pass since count is 3
+    with tempfile.TemporaryDirectory() as dir_:
+        tester.compile_and_run("verilator", magma_opts={"inline": True},
+                               flags=['--assert'], directory=dir_)


### PR DESCRIPTION
This is like assert immediate, except it's only run at the end of
simulation.

Also needed to update the verilator test bench to call `top->final();`
which is required to mark the end of simulation (and thus trigger the
evaluation of final blocks such as these assertions).