### PR TITLE
Add support for call statements

### DIFF
--- a/fault/actions.py
+++ b/fault/actions.py
@@ -296,6 +296,17 @@ class Call(Action):
         return Call(self.func.func_call)
 
 
+class CallStmt(Action):
+    def __init__(self, call_expr):
+        self.call_expr = call_expr
+
+    def __str__(self):
+        return f"CallStmt({self.call_expr})"
+
+    def retarget(self, new_circuit, clock):
+        return CallStmt(self.call_expr.retarget(new_circuit, clock))
+
+
 class FileOpen(Action):
     def __init__(self, file):
         """

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -358,7 +358,7 @@ class SystemVerilogTarget(VerilogTarget):
             new_value = f"{value.file.name_without_ext}_in"
             value = new_value
         elif isinstance(value, expression.Expression):
-            value = f"({self.compile_expression(value)})"
+            value = f"{self.compile_expression(value)}"
         return value
 
     def compile_expression(self, value):
@@ -372,11 +372,11 @@ class SystemVerilogTarget(VerilogTarget):
             elif op == "!=":
                 # Use strict neq
                 op = "!=="
-            return f"({left}) {op} ({right})"
+            return f"({left} {op} {right})"
         elif isinstance(value, expression.UnaryOp):
             operand = self.compile_expression(value.operand)
             op = value.op_str
-            return f"{op} ({operand})"
+            return f"({op} {operand})"
         elif isinstance(value, PortWrapper):
             path = value.select_path.system_verilog_path(self.disable_ndarray)
             return f"dut.{path}"

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -357,10 +357,6 @@ class SystemVerilogTarget(VerilogTarget):
         elif isinstance(value, actions.FileRead):
             new_value = f"{value.file.name_without_ext}_in"
             value = new_value
-        elif isinstance(value, expression.CallExpression):
-            def arg_to_str(v):
-                return self.process_value(port, v)
-            value = value.str(True, arg_to_str)
         elif isinstance(value, expression.Expression):
             value = f"({self.compile_expression(value)})"
         return value
@@ -397,6 +393,8 @@ class SystemVerilogTarget(VerilogTarget):
             return f"{func_str}({args})"
         elif isinstance(value, int):
             return str(value)
+        elif isinstance(value, expression.CallExpression):
+            return value.str(True, self.compile_expression, use_ptr=True)
         return value
 
     def make_poke(self, i, action):
@@ -536,9 +534,6 @@ class SystemVerilogTarget(VerilogTarget):
     def make_call(self, i, action: actions.Call):
         self.imports.add("pysv")
         return super().make_call(i, action)
-
-    def make_call_stmt(self, i, action: actions.CallStmt):
-        return [action.call_expr.str(True, self.compile_expression) + ";"]
 
     def make_expect(self, i, action):
         # don't do anything if any value is OK

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -394,7 +394,7 @@ class SystemVerilogTarget(VerilogTarget):
         elif isinstance(value, int):
             return str(value)
         elif isinstance(value, expression.CallExpression):
-            return value.str(True, self.compile_expression, use_ptr=True)
+            return value.str(True, self.compile_expression)
         return value
 
     def make_poke(self, i, action):

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -537,6 +537,9 @@ class SystemVerilogTarget(VerilogTarget):
         self.imports.add("pysv")
         return super().make_call(i, action)
 
+    def make_call_stmt(self, i, action: actions.CallStmt):
+        return [action.call_expr.str(True, self.compile_expression) + ";"]
+
     def make_expect(self, i, action):
         # don't do anything if any value is OK
         if value_utils.is_any(action.value):

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -360,7 +360,7 @@ class Tester(TesterBase):
     def join_none(self, *args):
         return self.join(*args, join_type=actions.JoinType.None_)
 
-    def make_call(self, func, *args, **kwargs):
+    def _make_call_expr(self, func, *args, **kwargs):
         if type(func) == type:
             func_def = func.__init__
         else:
@@ -370,6 +370,13 @@ class Tester(TesterBase):
             self.pysv_funcs.append(func)
         self.actions.append(actions.Call(func))
         return expression.CallExpression(func_def, *args, **kwargs)
+
+    def make_call_expr(self, func, *args, **kwargs):
+        return self._make_call_expr(func, *args, **kwargs)
+
+    def make_call_stmt(self, func, *args, **kwargs):
+        call_expr = self._make_call_expr(func, *args, **kwargs)
+        self.actions.append(actions.CallStmt(call_expr))
 
     def file_open(self, file_name, mode="r", chunk_size=1, endianness="little"):
         """

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -249,11 +249,7 @@ if (!({cond})) {{
         return value_str
 
     def process_value(self, port, value):
-        if isinstance(value, expression.CallExpression):
-            def arg_to_str(v):
-                return self.process_value(port, v)
-            return value.str(False, arg_to_str, use_ptr=True)
-        elif isinstance(value, expression.Expression):
+        if isinstance(value, expression.Expression):
             return self.compile_expression(value)
         if isinstance(value, Bit):
             return int(value)
@@ -314,6 +310,8 @@ if (!({cond})) {{
             return f"{func_str}({args})"
         elif isinstance(value, int):
             return str(value)
+        elif isinstance(value, expression.CallExpression):
+            return value.str(False, self.compile_expression, use_ptr=True)
         return value
 
     def process_bitwise_assign(self, port, name, value):
@@ -648,6 +646,11 @@ if (!({expr_str})) {{
     exit(1);
 }}
     """.splitlines()
+
+    def make_call_stmt(self, i, action: actions.CallStmt):
+        def arg_to_str(v):
+            return self.process_value(None, v)
+        return [action.call_expr.str(False, arg_to_str, use_ptr=True) + ";"]
 
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -647,11 +647,6 @@ if (!({expr_str})) {{
 }}
     """.splitlines()
 
-    def make_call_stmt(self, i, action: actions.CallStmt):
-        def arg_to_str(v):
-            return self.process_value(None, v)
-        return [action.call_expr.str(False, arg_to_str, use_ptr=True) + ";"]
-
     def generate_code(self, actions, verilator_includes, num_tests, circuit):
         if verilator_includes:
             # Include the top circuit by default

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -7,7 +7,6 @@ import fault.actions as actions
 from fault.util import flatten
 import os
 from fault.select_path import SelectPath
-import fault.expression as expression
 
 
 class VerilogTarget(Target):
@@ -227,7 +226,7 @@ class VerilogTarget(Target):
         return []
 
     @abstractmethod
-    def make_call_stmt(self, i, action: expression.CallExpression):
+    def make_call_stmt(self, i, action: actions.CallStmt):
         pass
 
     @abstractmethod

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -7,6 +7,7 @@ import fault.actions as actions
 from fault.util import flatten
 import os
 from fault.select_path import SelectPath
+import fault.expression as expression
 
 
 class VerilogTarget(Target):
@@ -146,6 +147,8 @@ class VerilogTarget(Target):
             return self.make_join(i, action)
         elif isinstance(action, actions.Call):
             return self.make_call(i, action)
+        elif isinstance(action, actions.CallStmt):
+            return self.make_call_stmt(i, action)
         elif isinstance(action, actions.FileOpen):
             return self.make_file_open(i, action)
         elif isinstance(action, actions.FileWrite):
@@ -222,6 +225,10 @@ class VerilogTarget(Target):
         if func not in self.pysv_funcs:
             self.pysv_funcs.append(func)
         return []
+
+    @abstractmethod
+    def make_call_stmt(self, i, action: expression.CallExpression):
+        pass
 
     @abstractmethod
     def make_file_open(self, i, action):

--- a/fault/verilog_target.py
+++ b/fault/verilog_target.py
@@ -225,9 +225,8 @@ class VerilogTarget(Target):
             self.pysv_funcs.append(func)
         return []
 
-    @abstractmethod
     def make_call_stmt(self, i, action: actions.CallStmt):
-        pass
+        return [self.compile_expression(action.call_expr) + ";"]
 
     @abstractmethod
     def make_file_open(self, i, action):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -37,7 +37,7 @@ class MWrapper(m.MagmaProtocol, metaclass=MWrapperMeta):
 WrappedBits8 = MWrapper[m.UInt[8]]
 
 
-@m.syntax.sequential.sequential
+@m.sequential2()
 class Foo:
     def __call__(self, val: WrappedBits8) -> m.UInt[8]:
         return val.apply(lambda x: x + 1)


### PR DESCRIPTION
Separates make_call into two functions: one for an expression and one
for a statement.

Reworks the backend call logic to treat it as an expression rather than
a value (also adds a test that uses it in an expression).

Call statements are useful for making calls to a model that don't
return a value (e.g. just manipulates the state)