### PR TITLE
Add basic support for pysv monitor

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -21,3 +21,4 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
 from fault.sva import sva
 from fault.assert_immediate import assert_immediate, assert_final
 from fault.expression import abs, min, max, signed, integer
+from fault.pysv import PysvMonitor

--- a/fault/actions.py
+++ b/fault/actions.py
@@ -420,7 +420,7 @@ class Var(Action, expression.Expression):
         return Var(self.name, self._type)
 
     def __getattr__(self, name):
-        if type(self._type) == type:
+        if isinstance(self._type, type):
             func = getattr(self._type, name)
             assert isinstance(func, pysv.function.DPIFunctionCall),\
                 "Only pysv class object can be used to get class methods"

--- a/fault/pysv.py
+++ b/fault/pysv.py
@@ -1,0 +1,7 @@
+from abc import abstractmethod, ABC, ABCMeta
+
+
+class PysvMonitor(ABC, metaclass=ABCMeta):
+    @abstractmethod
+    def observe(self, *args, **kwargs):
+        pass

--- a/fault/tester/control.py
+++ b/fault/tester/control.py
@@ -30,29 +30,30 @@ def add_control_structures(tester_class):
     class LoopTester(NoClockInit, tester_class):
         __unique_index_id = -1
 
-        def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
-            super().__init__(circuit, clock)
+        def __init__(self, circuit: m.Circuit, clock: m.Clock, monitors):
+            super().__init__(circuit, clock, monitors=monitors)
             LoopTester.__unique_index_id += 1
             self.index = LoopIndex(
                 f"__fault_loop_var_action_{LoopTester.__unique_index_id}")
 
     class ElseTester(NoClockInit, tester_class):
         def __init__(self, else_actions: List, circuit: m.Circuit,
-                     clock: m.Clock = None):
-            super().__init__(circuit, clock)
+                     clock: m.Clock, monitors):
+            super().__init__(circuit, clock, monitors=monitors)
             self.actions = else_actions
 
     class IfTester(NoClockInit, tester_class):
-        def __init__(self, circuit: m.Circuit, clock: m.Clock = None):
-            super().__init__(circuit, clock)
+        def __init__(self, circuit: m.Circuit, clock: m.Clock, monitors):
+            super().__init__(circuit, clock, monitors=monitors)
             self.else_actions = []
 
         def _else(self):
-            return ElseTester(self.else_actions, self._circuit, self.clock)
+            return ElseTester(self.else_actions, self._circuit, self.clock,
+                              self.monitors)
 
     class ForkTester(NoClockInit, tester_class):
-        def __init__(self, name, circuit: m.Circuit, clock: m.Clock = None):
-            super().__init__(circuit, clock)
+        def __init__(self, name, circuit: m.Circuit, clock: m.Clock, monitors):
+            super().__init__(circuit, clock, monitors=monitors)
             self.name = name
 
     tester_class.LoopTester = LoopTester

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -366,7 +366,7 @@ class Tester(TesterBase):
         return self.join(*args, join_type=actions.JoinType.None_)
 
     def _make_call_expr(self, func, *args, **kwargs):
-        if type(func) == type:
+        if isinstance(func, type):
             func_def = func.__init__
         else:
             func_def = func

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -69,7 +69,7 @@ class Tester(TesterBase):
 
     def __init__(self, circuit: m.Circuit, clock: m.Clock = None,
                  reset: m.Reset = None, poke_delay_default=None,
-                 expect_strict_default=True):
+                 expect_strict_default=True, monitors=None):
         """
         `circuit`: the device under test (a magma circuit)
         `clock`: optional, a port from `circuit` corresponding to the clock
@@ -86,6 +86,10 @@ class Tester(TesterBase):
         # For public verilator modules
         self.verilator_includes = []
         self.pysv_funcs = []
+        if monitors is None:
+            self.monitors = []
+        else:
+            self.monitors = monitors
 
     def init_clock(self):
         if self.clock is not None:
@@ -333,7 +337,7 @@ class Tester(TesterBase):
         loop action object maintains a references to the return Tester's
         `actions` list.
         """
-        loop_tester = self.LoopTester(self._circuit, self.clock)
+        loop_tester = self.LoopTester(self._circuit, self.clock, self.monitors)
         self.actions.append(Loop(n_iter, loop_tester.index,
                                  loop_tester.actions))
         return loop_tester
@@ -342,7 +346,8 @@ class Tester(TesterBase):
         """
         Returns a fork process to record actions inside the fork
         """
-        fork_tester = self.ForkTester(name, self._circuit, self.clock)
+        fork_tester = self.ForkTester(name, self._circuit, self.clock,
+                                      self.monitors)
         return fork_tester
 
     def join(self, *args, join_type=actions.JoinType.Default):
@@ -404,12 +409,13 @@ class Tester(TesterBase):
         loop action object maintains a references to the return Tester's
         `actions` list.
         """
-        while_tester = self.LoopTester(self._circuit, self.clock)
+        while_tester = self.LoopTester(self._circuit, self.clock,
+                                       self.monitors)
         self.actions.append(While(cond, while_tester.actions))
         return while_tester
 
     def _if(self, cond):
-        if_tester = self.IfTester(self._circuit, self.clock)
+        if_tester = self.IfTester(self._circuit, self.clock, self.monitors)
         self.actions.append(If(cond, if_tester.actions,
                                if_tester.else_actions))
         return if_tester

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -1,8 +1,11 @@
+import inspect
+
 from .staged_tester import StagedTester
 from ..system_verilog_target import SynchronousSystemVerilogTarget
 from ..verilator_target import SynchronousVerilatorTarget
 
 from fault.tester.control import add_control_structures
+from fault.pysv import PysvMonitor
 
 
 @add_control_structures
@@ -16,6 +19,18 @@ class SynchronousTester(StagedTester):
         raise TypeError("Cannot eval with synchronous tester")
 
     def advance_cycle(self):
+        for monitor in self.monitors:
+            argspec = inspect.getfullargspec(monitor.observe.func_def.func)
+            assert argspec.args[0] == "self", "Expected self as first arg"
+            args = [self.peek(getattr(self._circuit, arg))
+                    for arg in argspec.args[1:]]
+            assert argspec.varargs is None, "Unsupported"
+            assert argspec.varkw is None, "Unsupported"
+            assert argspec.kwonlyargs == [], "Unsupported"
+            assert argspec.kwonlydefaults is None, "Unsupported"
+            assert argspec.annotations  == {}, "Unsupported"
+            assert argspec.defaults is None, "Unsupported"
+            self.make_call_stmt(monitor.observe, *args)
         self.step(2)
 
     def make_target(self, target, **kwargs):
@@ -26,3 +41,9 @@ class SynchronousTester(StagedTester):
             return SynchronousVerilatorTarget(self._circuit, clock=self.clock,
                                               **kwargs)
         return super().make_target(target, **kwargs)
+
+    def attach_monitor(self, monitor: PysvMonitor):
+        # TODO: See tests/test_pysv.py:111, pysv preventing inheritance
+        # if not isinstance(monitor, PysvMonitor):
+        #     raise TypeError("Expected PysvMonitor")
+        self.monitors.append(monitor)

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -6,6 +6,7 @@ from ..verilator_target import SynchronousVerilatorTarget
 
 from fault.tester.control import add_control_structures
 from fault.pysv import PysvMonitor
+import fault.actions as actions
 
 
 @add_control_structures
@@ -43,8 +44,8 @@ class SynchronousTester(StagedTester):
                                               **kwargs)
         return super().make_target(target, **kwargs)
 
-    def attach_monitor(self, monitor: PysvMonitor):
-        # TODO: See tests/test_pysv.py:111, pysv preventing inheritance
-        # if not isinstance(monitor, PysvMonitor):
-        #     raise TypeError("Expected PysvMonitor")
+    def attach_monitor(self, monitor: actions.Var):
+        if (not isinstance(monitor, actions.Var) and
+                not isinstance(monitor._type, PysvMonitor)):
+            raise TypeError("Expected PysvMonitor variable")
         self.monitors.append(monitor)

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -19,6 +19,7 @@ class SynchronousTester(StagedTester):
         raise TypeError("Cannot eval with synchronous tester")
 
     def advance_cycle(self):
+        self.step(1)
         for monitor in self.monitors:
             argspec = inspect.getfullargspec(monitor.observe.func_def.func)
             assert argspec.args[0] == "self", "Expected self as first arg"
@@ -31,7 +32,7 @@ class SynchronousTester(StagedTester):
             assert argspec.annotations == {}, "Unsupported"
             assert argspec.defaults is None, "Unsupported"
             self.make_call_stmt(monitor.observe, *args)
-        self.step(2)
+        self.step(1)
 
     def make_target(self, target, **kwargs):
         if target == "system-verilog":

--- a/fault/tester/synchronous.py
+++ b/fault/tester/synchronous.py
@@ -28,7 +28,7 @@ class SynchronousTester(StagedTester):
             assert argspec.varkw is None, "Unsupported"
             assert argspec.kwonlyargs == [], "Unsupported"
             assert argspec.kwonlydefaults is None, "Unsupported"
-            assert argspec.annotations  == {}, "Unsupported"
+            assert argspec.annotations == {}, "Unsupported"
             assert argspec.defaults is None, "Unsupported"
             self.make_call_stmt(monitor.observe, *args)
         self.step(2)

--- a/fault/verilator_target.py
+++ b/fault/verilator_target.py
@@ -615,7 +615,7 @@ if (!({cond})) {{
             for s, t in size_map:
                 if size_key <= s:
                     return [f"{t} {action.name};"]
-        elif type(action._type) == type:
+        elif isinstance(action._type, type):
             return [f"{action._type.__name__} *{action.name};"]
 
         raise NotImplementedError(action._type)

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -132,6 +132,8 @@ def test_monitor(target, simulator):
     def test(circuit, enable):
         tester = fault.SynchronousTester(circuit)
         monitor = tester.Var("monitor", Monitor)
+        # TODO: Need clock to start at 1 for proper semantics
+        tester.poke(circuit.CLK, 1)
         tester.poke(monitor, tester.make_call_expr(Monitor))
         tester.attach_monitor(monitor)
         tester.poke(circuit.CE, enable)

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -118,7 +118,7 @@ def test_monitor(target, simulator):
 
         @sv()
         def observe(self, A, B, O):
-            print(A, B, self.value)
+            print(A, B, O, self.value)
             if self.value is not None:
                 assert O == self.value, f"{O} != {self.value}"
             # TODO: Referencing bitvector here doesn't work, so just manually

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -106,9 +106,7 @@ def test_monitor(target, simulator):
         io.O @= m.Register(m.Bits[4], has_enable=True)()(dut()(io.A, io.B),
                                                          CE=io.CE)
 
-    # TODO: Using a subclass breaks pysv
-    # class Monitor(fault.PysvMonitor):
-    class Monitor:
+    class Monitor(fault.PysvMonitor):
         @sv()
         def __init__(self):
             self.value = None

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -24,6 +24,7 @@ def run_tester(tester, target, simulator):
         "target": target,
         # "disp_type": "realtime",
         "simulator": simulator,
+        "magma_opts": {"sv": True},
         "tmp_dir": False
     }
 

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -125,6 +125,7 @@ def test_monitor(target, simulator):
             # mask for now
             # self.value = BitVector[4](A) + BitVector[4](B)
             self.value = (A + B) & ((1 << 4) - 1)
+            print(f"next value {self.value}")
 
     clear_imports(Monitor)
 

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -1,6 +1,5 @@
 import pytest
 from pysv import sv, DataType
-from pysv.util import clear_imports
 import fault
 import magma as m
 from hwtypes import BitVector
@@ -48,7 +47,6 @@ def test_function(target, simulator):
     def gold_func(a, b):
         return a + b
 
-    clear_imports(gold_func)
     tester = fault.Tester(dut)
     tester.poke(tester.circuit.A, 1)
     tester.poke(tester.circuit.B, 1)
@@ -80,7 +78,6 @@ def test_class(target, simulator):
         def incr(self, amount):
             self.b += amount
 
-    clear_imports(Model)
     a_value = 1
     tester = fault.Tester(dut)
     tester.poke(tester.circuit.A, a_value)
@@ -121,13 +118,8 @@ def test_monitor(target, simulator):
             print(A, B, O, self.value)
             if self.value is not None:
                 assert O == self.value, f"{O} != {self.value}"
-            # TODO: Referencing bitvector here doesn't work, so just manually
-            # mask for now
-            # self.value = BitVector[4](A) + BitVector[4](B)
-            self.value = (A + B) & ((1 << 4) - 1)
+            self.value = BitVector[4](A) + BitVector[4](B)
             print(f"next value {self.value}")
-
-    clear_imports(Monitor)
 
     def test(circuit, enable):
         tester = fault.SynchronousTester(circuit)


### PR DESCRIPTION
A monitor is a pysv class that defines an `observe` function that is
invoked every time advance_cycle is called.

The arguments to the observe functions refer to circuit ports by name
(in the future we could add support for internal signals).