### PR TITLE
Add support for monitor with product type arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vnc_logs
 coverage.xml
 parser.out
 parsetab.py
+.ast_tools

--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -21,4 +21,4 @@ from fault.property import (assert_, implies, delay, posedge, repeat, goto,
 from fault.sva import sva
 from fault.assert_immediate import assert_immediate, assert_final
 from fault.expression import abs, min, max, signed, integer
-from fault.pysv import PysvMonitor
+from fault.pysv import PysvMonitor, python_monitor

--- a/fault/pysv.py
+++ b/fault/pysv.py
@@ -1,7 +1,96 @@
 from abc import abstractmethod, ABC, ABCMeta
+import inspect
+from pysv import sv
+
+from ast_tools.stack import SymbolTable
+from ast_tools.passes import Pass, PASS_ARGS_T, apply_passes
+from ast_tools.common import to_module
+import typing as tp
+
+import libcst as cst
+import libcst.matchers as match
+
+import magma as m
+
+
+def _gen_product_args(base_name, T):
+    if not issubclass(T, m.Product):
+        return [base_name], base_name
+    flat_args = []
+    nested_args = []
+    for elem, value in T.field_dict.items():
+        _flat_args, _nested_arg = _gen_product_args(
+            base_name + "_" + elem, value
+        )
+        flat_args += _flat_args
+        nested_args.append(f"'{elem}': {_nested_arg}")
+    return flat_args, f"{{{', '.join(nested_args)}}}"
 
 
 class PysvMonitor(ABC, metaclass=ABCMeta):
     @abstractmethod
     def observe(self, *args, **kwargs):
         pass
+
+
+class MonitorTransformer(cst.CSTTransformer):
+    def __init__(self, env, metadata):
+        self.env = env
+        self.metadata = metadata
+
+    def leave_FunctionDef(self, original_node, updated_node):
+        if match.matches(updated_node.name,
+                         match.Name("observe")):
+            params = updated_node.params.params
+            assert match.matches(params[0], match.Param(match.Name("self")))
+            self.metadata["_orig_observe_args_"] = [param.name.value
+                                                    for param in params]
+            new_params = [params[0]]
+            prelude = []
+            for param in params[1:]:
+                if param.annotation is None:
+                    new_params.append(param)
+                else:
+                    T = eval(to_module(param.annotation.annotation).code, dict(self.env))
+                    if not issubclass(T, m.Product):
+                        raise NotImplementedError()
+                    flat_args, nested_args = _gen_product_args(param.name.value, T)
+                    new_params.extend(cst.Param(cst.Name(arg)) for arg in flat_args)
+                    prelude.append(cst.parse_statement(f"{param.name.value} = {nested_args}"))
+            return updated_node.with_changes(
+                params=updated_node.params.with_changes(params=new_params),
+                body=updated_node.body.with_changes(
+                    body=tuple(prelude) + updated_node.body.body)
+            )
+        return updated_node
+
+
+class MonitorPass(Pass):
+    def rewrite(self,
+                tree: cst.CSTNode,
+                env: SymbolTable,
+                metadata: tp.MutableMapping) -> PASS_ARGS_T:
+        tree = tree.visit(MonitorTransformer(env, metadata))
+        return tree, env, metadata
+
+
+class python_monitor(apply_passes):
+    def __init__(self, pre_passes=[], post_passes=[],
+                 debug: bool = False,
+                 env: tp.Optional[SymbolTable] = None,
+                 path: tp.Optional[str] = None,
+                 file_name: tp.Optional[str] = None
+                 ):
+        passes = pre_passes + [MonitorPass()] + post_passes
+        super().__init__(passes=passes, env=env, debug=debug, path=path,
+                         file_name=file_name)
+
+    def exec(self,
+            etree: tp.Union[cst.ClassDef, cst.FunctionDef],
+            stree: tp.Union[cst.ClassDef, cst.FunctionDef],
+            env: SymbolTable,
+            metadata: tp.MutableMapping):
+        result = super().exec(etree, stree, env, metadata)
+        result.observe._orig_args_ = metadata["_orig_observe_args_"]
+        result._source_code_ = to_module(stree).code
+        return result

--- a/fault/pysv.py
+++ b/fault/pysv.py
@@ -51,12 +51,17 @@ class MonitorTransformer(cst.CSTTransformer):
                 if param.annotation is None:
                     new_params.append(param)
                 else:
-                    T = eval(to_module(param.annotation.annotation).code, dict(self.env))
+                    T = eval(to_module(param.annotation.annotation).code,
+                             dict(self.env))
                     if not issubclass(T, m.Product):
                         raise NotImplementedError()
-                    flat_args, nested_args = _gen_product_args(param.name.value, T)
-                    new_params.extend(cst.Param(cst.Name(arg)) for arg in flat_args)
-                    prelude.append(cst.parse_statement(f"{param.name.value} = {nested_args}"))
+                    flat_args, nested_args = _gen_product_args(
+                        param.name.value, T)
+                    new_params.extend(
+                        cst.Param(cst.Name(arg)) for arg in flat_args)
+                    prelude.append(
+                        cst.parse_statement(
+                            f"{param.name.value} = {nested_args}"))
             return updated_node.with_changes(
                 params=updated_node.params.with_changes(params=new_params),
                 body=updated_node.body.with_changes(
@@ -86,10 +91,10 @@ class python_monitor(apply_passes):
                          file_name=file_name)
 
     def exec(self,
-            etree: tp.Union[cst.ClassDef, cst.FunctionDef],
-            stree: tp.Union[cst.ClassDef, cst.FunctionDef],
-            env: SymbolTable,
-            metadata: tp.MutableMapping):
+             etree: tp.Union[cst.ClassDef, cst.FunctionDef],
+             stree: tp.Union[cst.ClassDef, cst.FunctionDef],
+             env: SymbolTable,
+             metadata: tp.MutableMapping):
         result = super().exec(etree, stree, env, metadata)
         result.observe._orig_args_ = metadata["_orig_observe_args_"]
         result._source_code_ = to_module(stree).code

--- a/fault/pysv.py
+++ b/fault/pysv.py
@@ -23,8 +23,8 @@ def _gen_product_args(base_name, T):
             base_name + "_" + elem, value
         )
         flat_args += _flat_args
-        nested_args.append(f"'{elem}': {_nested_arg}")
-    return flat_args, f"{{{', '.join(nested_args)}}}"
+        nested_args.append(f"{elem}={_nested_arg}")
+    return flat_args, f"SimpleNamespace({', '.join(nested_args)})"
 
 
 class PysvMonitor(ABC, metaclass=ABCMeta):
@@ -46,7 +46,9 @@ class MonitorTransformer(cst.CSTTransformer):
             self.metadata["_orig_observe_args_"] = [param.name.value
                                                     for param in params]
             new_params = [params[0]]
-            prelude = []
+            prelude = [
+                cst.parse_statement("from types import SimpleNamespace")
+            ]
             for param in params[1:]:
                 if param.annotation is None:
                     new_params.append(param)

--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -319,7 +319,7 @@ class SystemVerilogTarget(VerilogTarget):
                 self.disable_ndarray
             )
             return f"dut.{path}"
-        return f"{value.port.name}"
+        return f"{verilog_name(value.port.name, self.disable_ndarray)}"
 
     def make_var(self, i, action):
         if isinstance(action._type, AbstractBitVectorMeta):

--- a/tests/test_pysv.py
+++ b/tests/test_pysv.py
@@ -164,7 +164,7 @@ def test_monitor_product(target, simulator):
         def observe(self, I: T, O):
             if self.value is not None:
                 assert O == self.value, f"{O} != {self.value}"
-            self.value = BitVector[4](I["A"]) + BitVector[4](I["B"])
+            self.value = BitVector[4](I.A) + BitVector[4](I.B)
             print(f"next value {self.value}")
 
     tester = fault.SynchronousTester(DelayedDUTProduct)


### PR DESCRIPTION
In the verilog simulation, product types are flattened into leaf ports.  This adds logic to the monitor code that allows the user to provide a type annotation on an argument that is a product.  When encountering product arguments, the observe function will be rewritten to accept the flattened arguments, and a small snippet of code is inserted into the function to reconstruct the original product argument from the flattened arguments.  For now, we use SimpleNamespace to provide dot notation on the product fields.  In the future, we should figure out a way to pass the magma type converted to hwtypes to the pysv class and use that to reconstruct the original argument.

Support for nested array arguments will be added next.