### PR TITLE
Add support for compiling UnknownValue

### DIFF
--- a/fault/system_verilog_target.py
+++ b/fault/system_verilog_target.py
@@ -15,6 +15,7 @@ from fault.wrapper import PortWrapper
 from fault.subprocess_run import subprocess_run
 import fault
 import fault.expression as expression
+from fault.value import Value
 from fault.ms_types import RealType
 import os
 import pysv
@@ -395,6 +396,10 @@ class SystemVerilogTarget(VerilogTarget):
             return str(value)
         elif isinstance(value, expression.CallExpression):
             return value.str(True, self.compile_expression)
+        elif isinstance(value, Value):
+            if value == Value.Unknown:
+                return "'x";
+            raise NotImplementedError(value)
         return value
 
     def make_poke(self, i, action):

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -91,7 +91,7 @@ def test_unknown_value(target, simulator):
         Stub circuit to generate x
         """
         io = m.IO(O=m.Out(m.Bits[4]))
-        verilog = "assign O = 'x;"
+        verilog = "assign O = 4'dx;"
 
     tester = fault.Tester(X)
     tester.eval()

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -96,6 +96,7 @@ def test_unknown_value(target, simulator):
     tester = fault.Tester(X)
     tester.eval()
     tester.circuit.O.expect(fault.UnknownValue)
+    tester.assert_(tester.peek(X.O) == fault.UnknownValue)
     tester.compile_and_run(target, simulator=simulator)
     with pytest.raises(AssertionError):
         # Expect is strict, so this should fail


### PR DESCRIPTION
This allows checking that a value is X, which could be useful for
verifying initialization behavior.