### PR TITLE
Add error message for implicit peek of magma value

### DIFF
--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -1012,7 +1012,7 @@ def test_wait_until_timeout(target, simulator, capsys):
         with pytest.raises(AssertionError):
             tester.compile_and_run(**kwargs)
         out = capsys.readouterr()[0]
-        assert "(_fault_timeout_var_1 < 3) failed" in out
+        assert "(_fault_timeout_var_0 < 3) failed" in out
 
 
 def test_implicit_peek_error(target, simulator):

--- a/tests/test_tester/test_core.py
+++ b/tests/test_tester/test_core.py
@@ -1014,4 +1014,13 @@ def test_wait_until_timeout(target, simulator, capsys):
         with pytest.raises(AssertionError):
             tester.compile_and_run(**kwargs)
         out = capsys.readouterr()[0]
-        assert "(_fault_timeout_var_0 < 3) failed" in out
+        assert "(_fault_timeout_var_1 < 3) failed" in out
+
+
+def test_implicit_peek_error(target, simulator):
+    circ = TestArrayCircuit
+    tester = fault.Tester(circ)
+    with pytest.raises(TypeError):
+        tester._if(circ.O)
+    with pytest.raises(TypeError):
+        tester._while(circ.O)

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -43,7 +43,7 @@ def test_while_loop(target, simulator, n_cyc=3, n_bits=8):
 
     # wait for the loop to complete
     tester.poke(dut.rst, 0)
-    loop = tester._while(dut.n_done)
+    loop = tester._while(tester.peek(dut.n_done))
     debug_print(loop, dut)
     loop.step()
     loop.step()


### PR DESCRIPTION
If you try to call if/while with a magma value, raise a helpful error
asking you to use peek, rather than emitting bad code downstream.  We
need the user to call `peek` in general so you can do things like
expressions (e.g. ~magma_value) which are then code generated in the
test bench.  We could implicitly covert a plain magma value, but then
this would be confusing because ~magma_value wouldn't work since this
would try to instance circuits outside of a circuit definition, so for
consistency this enforces that all values referred to in the test bench
are passed through the peek logic.