### PR TITLE
ReadyValidTester improvements

### DIFF
--- a/fault/__init__.py
+++ b/fault/__init__.py
@@ -22,4 +22,4 @@ from fault.sva import sva
 from fault.assert_immediate import assert_immediate, assert_final, assert_initial
 from fault.expression import abs, min, max, signed, integer
 from fault.pysv import PysvMonitor, python_monitor
-from fault.ready_valid import run_ready_valid_test
+from fault.ready_valid import run_ready_valid_test, ReadyValidTester

--- a/fault/ready_valid.py
+++ b/fault/ready_valid.py
@@ -15,7 +15,8 @@ def wrap_with_sequence(ckt, sequences):
         normal_lifted = []
         monitors = []
         for key, value in ckt.interface.items():
-            assert key != "_fault_rv_tester_done_", "Reserved port name"
+            if key == "_fault_rv_tester_done_":
+                raise RuntimeError("Reserved port name used")
 
             if key not in sequences:
                 io += m.IO(**{key: value})
@@ -25,7 +26,7 @@ def wrap_with_sequence(ckt, sequences):
                 monitors.append(key)
 
         for key in normal_lifted:
-            m.wire(getattr(io, key), getattr(inst, key))
+            m.wire(io[key], getattr(inst, key))
 
         done = m.Bit(1)
         for key, value in sequences.items():
@@ -65,7 +66,7 @@ def wrap_with_sequence(ckt, sequences):
 
         for key in monitors:
             value = getattr(inst, key)
-            port = getattr(io, key)
+            port = io[key]
             if m.is_producer(value):
                 port.ready @= value.ready.value()
                 port.valid @= value.valid

--- a/fault/ready_valid.py
+++ b/fault/ready_valid.py
@@ -93,7 +93,8 @@ def run_ready_valid_test(ckt: m.DefineCircuitKind, sequences: Mapping,
                          target, synthesizable: bool = True,
                          compile_and_run_args=[], compile_and_run_kwargs={}):
     if target == "verilator":
-        compile_and_run_kwargs = _add_verilator_flags(compile_and_run_kwargs)
+        compile_and_run_kwargs = \
+            _add_verilator_assert_flag(compile_and_run_kwargs)
     if synthesizable:
         wrapped = wrap_with_sequence(ckt, sequences)
         tester = SynchronousTester(wrapped)
@@ -119,5 +120,5 @@ class ReadyValidTester(SynchronousTester):
 
     def compile_and_run(self, target, *args, **kwargs):
         if target == "verilator":
-            kwargs = _add_verilator_flags(kwargs)
+            kwargs = _add_verilator_assert_flag(kwargs)
         super().compile_and_run(*args, **kwargs)

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -488,10 +488,18 @@ class Tester(TesterBase):
             loop.assign(timeout_var, timeout_var + 1)
 
     def wait_until_low(self, signal, timeout=None):
-        self.wait_on(self.peek(signal) != 0, timeout)
+        if isinstance(signal, m.Type):
+            # TODO: Deprecate and require peek so it's consistent with other
+            # interfaces?
+            signal = self.peek(signal)
+        self.wait_on(signal != 0, timeout)
 
     def wait_until_high(self, signal, timeout=None):
-        self.wait_on(self.peek(signal) == 0, timeout)
+        if isinstance(signal, m.Type):
+            # TODO: Deprecate and require peek so it's consistent with other
+            # interfaces?
+            signal = self.peek(signal)
+        self.wait_on(signal == 0, timeout)
 
     def wait_until_negedge(self, signal, timeout=None):
         self.wait_until_high(signal, timeout)

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -489,15 +489,15 @@ class Tester(TesterBase):
 
     def wait_until_low(self, signal, timeout=None):
         if isinstance(signal, m.Type):
-            # TODO(leonardt): Deprecate and require peek so it's consistent with other
-            # interfaces?
+            # TODO(leonardt): Deprecate and require peek so it's consistent
+            # with other interfaces?
             signal = self.peek(signal)
         self.wait_on(signal != 0, timeout)
 
     def wait_until_high(self, signal, timeout=None):
         if isinstance(signal, m.Type):
-            # TODO(leonardt): Deprecate and require peek so it's consistent with other
-            # interfaces?
+            # TODO(leonardt): Deprecate and require peek so it's consistent
+            # with other interfaces?
             signal = self.peek(signal)
         self.wait_on(signal == 0, timeout)
 

--- a/fault/tester/staged_tester.py
+++ b/fault/tester/staged_tester.py
@@ -512,4 +512,5 @@ class Tester(TesterBase):
     def finish(self):
         self.actions.append(actions.Finish())
 
+
 StagedTester = Tester

--- a/tests/test_ready_valid.py
+++ b/tests/test_ready_valid.py
@@ -30,5 +30,64 @@ def test_basic_ready_valid_sequence_fail():
         pytest.skip("Untested with earlier verilator versions")
     I = [BitVector.random(8) for _ in range(8)] + [0]
     O = [0] + [i - 1 for i in I[:-1]]
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(AssertionError):
         f.run_ready_valid_test(Main, {"I": I, "O": O}, "verilator")
+
+
+class Main2(m.Circuit):
+    io = m.IO(I=m.Consumer(m.ReadyValid[m.UInt[8]]),
+              O=m.Producer(m.ReadyValid[m.UInt[8]]),
+              inc=m.In(m.UInt[8]),
+              ) + m.ClockIO()
+    count = m.Register(m.UInt[2])()
+    count.I @= count.O + 1
+    enable = io.I.valid & (count.O == 3) & io.O.ready
+    io.I.ready @= enable
+    io.O.data @= m.Register(m.UInt[8], has_enable=True)()(io.I.data + io.inc,
+                                                          CE=enable)
+    io.O.valid @= enable
+
+
+def test_lifted_ready_valid_sequence_simple():
+    if verilator_version() < 4.0:
+        pytest.skip("Untested with earlier verilator versions")
+    I = [BitVector.random(8) for _ in range(8)] + [0]
+    O = [0] + [i + 2 for i in I[:-1]]
+    tester = f.ReadyValidTester(Main2, {"I": I, "O": O})
+    tester.circuit.inc = 2
+    tester.finish_sequences()
+    tester.compile_and_run("verilator", disp_type="realtime")
+
+
+def test_lifted_ready_valid_sequence_simple_fail():
+    if verilator_version() < 4.0:
+        pytest.skip("Untested with earlier verilator versions")
+    I = [BitVector.random(8) for _ in range(8)] + [0]
+    O = [0] + [i + 2 for i in I[:-1]]
+    tester = f.ReadyValidTester(Main2, {"I": I, "O": O})
+    tester.circuit.inc = 2
+    # Should work for a few cycles
+    for i in range(9):
+        tester.advance_cycle()
+    # Bad inc should fail
+    tester.circuit.inc = 3
+    tester.finish_sequences()
+    with pytest.raises(AssertionError):
+        tester.compile_and_run("verilator", disp_type="realtime")
+
+
+def test_lifted_ready_valid_sequence_changing_inc():
+    if verilator_version() < 4.0:
+        pytest.skip("Untested with earlier verilator versions")
+    I = [BitVector.random(8) for _ in range(8)] + [0]
+    O = [0] + [I[i] + ((i + 1) % 2) for i in range(8)]
+    tester = f.ReadyValidTester(Main2, {"I": I, "O": O})
+    # Sequence expects inc to change over time
+    for i in range(8):
+        tester.circuit.inc = i % 2
+        tester.advance_cycle()
+        tester.wait_until_high(tester.circuit.O.ready & tester.circuit.O.valid)
+    # Advance one cycle to finish last handshake
+    tester.advance_cycle()
+    tester.expect_sequences_finished()
+    tester.compile_and_run("verilator", disp_type="realtime")

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -183,7 +183,7 @@ def test_packed_arrays(use_packed_arrays, stimulator):
 
     # skip_run = not shutil.which("vcs")
     # TODO: Enable run when MLIR is merged
-    skip_run = False
+    skip_run = True
     tester = fault.Tester(_Foo)
     stimulator(tester, _Foo)
     tester.compile_and_run(

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -181,12 +181,15 @@ def test_packed_arrays(use_packed_arrays, stimulator):
         io = m.IO(I=m.In(T), O=m.Out(T))
         io.O @= io.I
 
-    skip_run = not shutil.which("vcs")
+    # skip_run = not shutil.which("vcs")
+    # TODO: Enable run when MLIR is merged
+    skip_run = False
     tester = fault.Tester(_Foo)
     stimulator(tester, _Foo)
     tester.compile_and_run(
         target="system-verilog",
         simulator="vcs",
+        skip_compile=True,
         skip_run=skip_run,
         use_packed_arrays=use_packed_arrays,
     )

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -187,7 +187,7 @@ def test_packed_arrays(use_packed_arrays, stimulator):
     tester.compile_and_run(
         target="system-verilog",
         simulator="vcs",
-        skip_compile=True,
+        skip_compile=False,
         skip_run=skip_run,
         use_packed_arrays=use_packed_arrays,
     )

--- a/tests/test_system_verilog_target.py
+++ b/tests/test_system_verilog_target.py
@@ -187,7 +187,6 @@ def test_packed_arrays(use_packed_arrays, stimulator):
     tester.compile_and_run(
         target="system-verilog",
         simulator="vcs",
-        skip_compile=False,
         skip_run=skip_run,
         use_packed_arrays=use_packed_arrays,
     )


### PR DESCRIPTION
* Automatically lift signals that are not covered by sequences, this
  allows the user to control them from the test bench (e.g. tie to a
  constant, change over time)
* Provide a Tester abstraction for the more general use case of test
  bench controlling signals while sequences are being processed
  * Adds some convenience/abstraction APIs:
    * `finish_sequences` will run the test bench until the done signal
      is high (all sequences are processed)
    * `expect_sequences_finished` will check that the done signal is
      high (important if the user is manually controlling the test
      clock, otherwise some sequences may be left unfinished/unchecked)